### PR TITLE
Archive YOLO26 TRT optimization scripts

### DIFF
--- a/development/yolo26_trt/README.md
+++ b/development/yolo26_trt/README.md
@@ -1,0 +1,52 @@
+# YOLO26 TensorRT optimization
+
+Scripts and session notes from a prior optimization pass on the YOLO26 TRT
+inference path (`inference_models/models/yolo26/*_trt.py`). This work
+**predates the SAM3 TRT work in `development/sam3_tensorrt/`** and is
+preserved here rather than left in the untracked `.codeflash/` scratch
+directory.
+
+> **Provenance note.** This cluster of scripts was produced in an earlier
+> autonomous session (commit history / timestamps predate the SAM3 work).
+> It is checked in as an archival record, not as a promise of
+> reproducibility — the scripts reference `~/.cache/roboflow/...` engine
+> paths and assume the prior session's L4 state. They will need rebuilt
+> engines to run again.
+
+## Files
+
+- [SESSION_STATUS.md](SESSION_STATUS.md) — original progress log with
+  objective, phases, environment, and open questions.
+- [session_prompt.md](session_prompt.md) — the autonomous-mode prompt
+  the session started from.
+
+### `scripts/`
+
+- `build_yolo26_engines.py` — builds TRT engines (FP16, max batch 8,
+  8 GB workspace) from the three YOLO26 variants' ONNX files.
+- `bench_yolo26_comprehensive.py` — first benchmark attempt (failed due
+  to ONNX packaging mismatch).
+- `bench_yolo26_all_variants.py` — second attempt using prebuilt TRT
+  packages (failed because engines were built for a different GPU
+  compute capability).
+- `bench_yolo26_final.py` — the working benchmark against locally-built
+  engines across all three variants (object detection, instance
+  segmentation, keypoints).
+- `profile_yolo26.py` — torch.profiler-based stage breakdown for
+  identifying YOLO26-specific hotspots.
+- `compare_yolo26_vs_yolov8.py` — differential profile vs YOLOv8n to
+  find YOLO26-only slowdowns.
+
+## Shared infrastructure context
+
+YOLO26 sits on shared preprocessing / postprocessing helpers that were
+optimized in prior sessions (YOLOv8n, YOLOv8n-seg, RF-DETR). See
+`SESSION_STATUS.md` § "Shared Infrastructure Already Optimized" for the
+specific commits. The scripts here were intended to determine whether
+YOLO26 has additional YOLO26-specific wins beyond those shared gains.
+
+## Status at hand-off
+
+Phase 2 (engine build) was in progress when the session wrapped; Phases
+3 (baseline), 4 (profile), and 5 (optimization loop) are planned but not
+executed in this directory. `SESSION_STATUS.md` has the full plan.

--- a/development/yolo26_trt/SESSION_STATUS.md
+++ b/development/yolo26_trt/SESSION_STATUS.md
@@ -1,0 +1,124 @@
+# YOLO26 TRT Optimization Session - Status Report
+
+**Session Start:** 2026-04-21 22:50 UTC  
+**Status:** In Progress - Engine Build Phase
+
+## Objective
+
+End-to-end optimization of `.infer()` method for YOLO26 TRT models (object detection, instance segmentation, keypoints detection) on L4 GPU.
+
+## Progress
+
+### Phase 1: Setup and Discovery ✓
+
+1. **Identified YOLO26 TRT backends** (3 variants):
+   - `yolo26_object_detection_trt.py`
+   - `yolo26_instance_segmentation_trt.py`
+   - `yolo26_key_points_detection_trt.py`
+
+2. **Found test model packages**:
+   - Object Detection: yolo26-coin-counting
+   - Instance Segmentation: yolo26-seg-asl
+   - Keypoints: yolo26n-pose
+
+3. **Identified GPU incompatibility issue**:
+   - Pre-built TRT engines from test packages were built for different GPU architecture
+   - TRT engines are not portable across compute capabilities
+   - Need to rebuild engines for current GPU (L4, compute 8.9)
+
+### Phase 2: TRT Engine Build (In Progress)
+
+**Current Action:** Building TRT engines from ONNX models for all three YOLO26 variants
+
+**Script:** `.codeflash/build_yolo26_engines.py`
+
+Building engines with:
+- FP16 precision enabled
+- Max batch size: 8
+- Workspace: 8GB
+- Target: L4 GPU (compute 8.9)
+
+**Output locations:**
+- Object Detection: `~/.cache/roboflow/yolo26_trt_engines/yolo26-det/`
+- Instance Segmentation: `~/.cache/roboflow/yolo26_trt_engines/yolo26-seg/`
+- Keypoints: `~/.cache/roboflow/yolo26_trt_engines/yolo26-pose/`
+
+### Phase 3: Baseline Benchmarking (Planned)
+
+Once engines are built:
+1. Benchmark all three variants (single-image + batch=8)
+2. Identify heaviest model as primary optimization target
+3. Establish baseline metrics (mean, median, stdev)
+
+### Phase 4: Profiling (Planned)
+
+Using torch.profiler:
+1. Profile preprocess, forward, postprocess stages
+2. Identify YOLO26-specific hotspots
+3. Compare against YOLOv8n to find differential slowdowns
+
+### Phase 5: Optimization Loop (Planned)
+
+Focus areas based on prior sessions:
+- Check if YOLO26 benefits from existing shared optimizations (pinned memory, cached tensors, etc.)
+- Identify YOLO26-specific opportunities (unique postprocessing, different decode logic)
+- Run experiments with correctness verification
+
+## Technical Context
+
+### Shared Infrastructure Already Optimized
+
+YOLO26 likely benefits from these prior optimizations to shared code:
+1. **Pinned staging buffer cache** (6c45a8265) - in `pre_process_network_input`
+2. **Strided scalar rescale** (66724c1da) - in `rescale_image_detections`
+3. **Single nonzero + packed gather in NMS** (97b52ad26, 6f42f447d) - in `run_nms_*`
+4. **Cached normalize constants** (bd4599538) - in preprocessing
+5. **Cached arange indices** (3c710460b) - in `crop_masks_to_boxes`
+
+### YOLO26-Specific Code Paths
+
+Need to profile to determine if YOLO26 has:
+- Different preprocessing pipeline (different resize modes, normalization)
+- Different postprocessing (NMS-fused vs separate, different decode logic)
+- Additional per-model overhead not covered by shared optimizations
+
+### Architecture Notes
+
+YOLO26 TRT implementation structure:
+- Uses `post_process_nms_fused_model_output` (confidence threshold filtering only)
+- Uses `rescale_detections` / `rescale_image_detections` (already optimized)
+- Instance segmentation uses `crop_masks_to_boxes` (already optimized)
+- Keypoints use `rescale_key_points_detections` (already optimized)
+- All use shared `pre_process_network_input` (already optimized)
+
+**Key Question:** Are there YOLO26-specific wins beyond shared infrastructure?
+
+## Environment
+
+- GPU: NVIDIA L4 (compute 8.9)
+- PyTorch: 2.10.0+cu128
+- TensorRT: 10.12.0.36
+- Python: 3.12.3
+- Branch: `codeflash/optimize`
+
+## Files Created This Session
+
+- `.codeflash/bench_yolo26_comprehensive.py` - Initial benchmark attempt (failed due to ONNX packages)
+- `.codeflash/bench_yolo26_all_variants.py` - Second attempt with TRT packages (failed due to GPU mismatch)
+- `.codeflash/build_yolo26_engines.py` - Engine builder from ONNX (in progress)
+- `.codeflash/YOLO26_SESSION_STATUS.md` - This status report
+
+## Next Steps
+
+1. ✓ Wait for engine build to complete (~5-10 minutes per model)
+2. Verify engines load correctly
+3. Run comprehensive benchmark
+4. Profile and identify optimization targets
+5. Begin experiment loop
+
+## Notes
+
+- This session is autonomous - making all decisions without user input
+- Following same methodology as prior YOLOv8/RF-DETR sessions
+- Will stop at genuine plateau (5 consecutive failed experiments)
+- All experiments will include correctness verification (IoU >= 0.95, class-match >= 99%, score drift <= 1%)

--- a/development/yolo26_trt/scripts/.gitignore
+++ b/development/yolo26_trt/scripts/.gitignore
@@ -1,0 +1,5 @@
+*.onnx
+*.engine
+*.plan
+*.pyc
+__pycache__/

--- a/development/yolo26_trt/scripts/bench_yolo26_all_variants.py
+++ b/development/yolo26_trt/scripts/bench_yolo26_all_variants.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Comprehensive YOLO26 TRT benchmark using actual TRT engine packages.
+Establishes baselines for object detection, instance segmentation, and keypoints.
+"""
+
+import os
+import sys
+import time
+import json
+import shutil
+import statistics
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import torch
+
+# Add inference_models to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "inference_models"))
+
+from inference_models.models.yolo26.yolo26_object_detection_trt import (
+    YOLO26ForObjectDetectionTRT,
+)
+from inference_models.models.yolo26.yolo26_instance_segmentation_trt import (
+    YOLO26ForInstanceSegmentationTRT,
+)
+from inference_models.models.yolo26.yolo26_key_points_detection_trt import (
+    YOLO26ForKeyPointsDetectionTRT,
+)
+
+
+def download_and_extract(url: str, package_name: str) -> str:
+    """Download and extract a model package, return path to extracted directory."""
+    import requests
+    import zipfile
+
+    cache_dir = Path.home() / ".cache" / "roboflow" / "trt_packages" / package_name
+    if cache_dir.exists():
+        print(f"  Using cached package at {cache_dir}")
+        return str(cache_dir)
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"  Downloading {url}...")
+    response = requests.get(url, stream=True, timeout=120)
+    response.raise_for_status()
+
+    zip_path = cache_dir.parent / f"{package_name}.zip"
+    with open(zip_path, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+    print(f"  Extracting to {cache_dir}...")
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall(cache_dir)
+
+    zip_path.unlink()
+    return str(cache_dir)
+
+
+def benchmark_model(
+    model,
+    model_name: str,
+    num_iters: int = 200,
+    warmup: int = 50,
+    batch_size: int = 1,
+) -> Dict:
+    """Benchmark a YOLO26 TRT model and return statistics."""
+    # Generate random input images
+    if batch_size == 1:
+        img = np.random.randint(0, 256, (640, 640, 3), dtype=np.uint8)
+    else:
+        img = [
+            np.random.randint(0, 256, (640, 640, 3), dtype=np.uint8)
+            for _ in range(batch_size)
+        ]
+
+    print(f"\n{'='*60}")
+    print(f"Benchmarking: {model_name} (batch={batch_size})")
+    print(f"{'='*60}")
+
+    # Warmup
+    print(f"Warmup: {warmup} iterations...")
+    for _ in range(warmup):
+        _ = model.infer(img)
+    torch.cuda.synchronize()
+
+    # Benchmark
+    print(f"Measuring: {num_iters} iterations...")
+    times = []
+    for i in range(num_iters):
+        t0 = time.perf_counter()
+        _ = model.infer(img)
+        torch.cuda.synchronize()
+        elapsed = (time.perf_counter() - t0) * 1000
+        times.append(elapsed)
+
+        if (i + 1) % 50 == 0:
+            print(f"  Progress: {i+1}/{num_iters}")
+
+    # Statistics
+    mean = statistics.mean(times)
+    median = statistics.median(times)
+    stdev = statistics.stdev(times)
+    p95 = np.percentile(times, 95)
+    min_time = min(times)
+    max_time = max(times)
+
+    print(f"\nResults:")
+    print(f"  Mean:   {mean:.3f}ms ± {stdev:.3f}ms")
+    print(f"  Median: {median:.3f}ms")
+    print(f"  P95:    {p95:.3f}ms")
+    print(f"  Min:    {min_time:.3f}ms")
+    print(f"  Max:    {max_time:.3f}ms")
+
+    return {
+        "model": model_name,
+        "batch_size": batch_size,
+        "num_iters": num_iters,
+        "mean_ms": mean,
+        "median_ms": median,
+        "stdev_ms": stdev,
+        "p95_ms": p95,
+        "min_ms": min_time,
+        "max_ms": max_time,
+        "times": times,
+    }
+
+
+def main():
+    print("YOLO26 TRT Comprehensive Benchmark")
+    print("="*60)
+
+    device = torch.device("cuda:0")
+
+    # Model configurations with actual TRT package URLs
+    models_config = [
+        {
+            "name": "yolo26-det",
+            "class": YOLO26ForObjectDetectionTRT,
+            "url": "https://storage.googleapis.com/roboflow-tests-assets/rf-platform-models/yolo26-coin-counting-trt-t4-package.zip",
+            "package_name": "yolo26-coin-counting-trt",
+        },
+        {
+            "name": "yolo26-seg",
+            "class": YOLO26ForInstanceSegmentationTRT,
+            "url": "https://storage.googleapis.com/roboflow-tests-assets/rf-platform-models/yolo26-seg-asl-trt-t4-package.zip",
+            "package_name": "yolo26-seg-asl-trt",
+        },
+        {
+            "name": "yolo26-pose",
+            "class": YOLO26ForKeyPointsDetectionTRT,
+            "url": "https://storage.googleapis.com/roboflow-tests-assets/rf-platform-models/yolov26n-pose-trt-t4-package.zip",
+            "package_name": "yolo26-pose-trt",
+        },
+    ]
+
+    all_results = []
+
+    for config in models_config:
+        print(f"\n{'#'*60}")
+        print(f"# {config['name'].upper()}")
+        print(f"{'#'*60}")
+
+        try:
+            # Download/cache model package
+            model_dir = download_and_extract(config["url"], config["package_name"])
+
+            # Load model
+            print(f"\nLoading model from {model_dir}...")
+            model = config["class"].from_pretrained(
+                model_name_or_path=model_dir,
+                device=device,
+                engine_host_code_allowed=True,
+            )
+            print("Model loaded successfully!")
+
+            # Benchmark single image
+            result_single = benchmark_model(
+                model=model,
+                model_name=config["name"],
+                num_iters=200,
+                warmup=50,
+                batch_size=1,
+            )
+            all_results.append(result_single)
+
+            # Benchmark batch=8
+            result_batch = benchmark_model(
+                model=model,
+                model_name=config["name"],
+                num_iters=100,
+                warmup=20,
+                batch_size=8,
+            )
+            all_results.append(result_batch)
+
+        except Exception as e:
+            print(f"\nERROR benchmarking {config['name']}: {e}")
+            import traceback
+            traceback.print_exc()
+            continue
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print(f"{'='*60}\n")
+
+    print(f"{'Model':<20} {'Batch':<8} {'Mean (ms)':<12} {'Median (ms)':<12} {'Stdev (ms)':<12}")
+    print("-" * 64)
+    for result in all_results:
+        print(
+            f"{result['model']:<20} "
+            f"{result['batch_size']:<8} "
+            f"{result['mean_ms']:>10.3f}  "
+            f"{result['median_ms']:>10.3f}  "
+            f"{result['stdev_ms']:>10.3f}"
+        )
+
+    # Identify heaviest model
+    single_results = [r for r in all_results if r["batch_size"] == 1]
+    if single_results:
+        heaviest = max(single_results, key=lambda r: r["mean_ms"])
+        print(f"\nHeaviest model (single-image): {heaviest['model']} ({heaviest['mean_ms']:.3f}ms)")
+        print(f"This will be the primary optimization target.")
+
+    # Save results
+    output_file = Path(__file__).parent / "yolo26_baseline_results.json"
+    with open(output_file, 'w') as f:
+        json.dump(all_results, f, indent=2)
+    print(f"\nDetailed results saved to: {output_file}")
+
+    # Update results.tsv with baselines
+    tsv_file = Path(__file__).parent / "results.tsv"
+    with open(tsv_file, 'a') as f:
+        for result in single_results:
+            f.write(
+                f"baseline-{result['model']}\tbaseline\t-\t"
+                f"{result['model']}.infer()\t"
+                f"{result['mean_ms']:.3f}ms±{result['stdev_ms']:.3f}ms\t-\t-\t"
+                f"2026-04-21T23:00:00\t-\n"
+            )
+    print(f"Baselines appended to: {tsv_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/development/yolo26_trt/scripts/bench_yolo26_comprehensive.py
+++ b/development/yolo26_trt/scripts/bench_yolo26_comprehensive.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Comprehensive YOLO26 TRT benchmark to establish baselines for all three variants
+(object detection, instance segmentation, keypoints) and identify the heaviest one.
+"""
+
+import os
+import sys
+import time
+import json
+import shutil
+import tempfile
+import statistics
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import torch
+
+# Add inference_models to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "inference_models"))
+
+from inference_models.models.yolo26.yolo26_object_detection_trt import (
+    YOLO26ForObjectDetectionTRT,
+)
+from inference_models.models.yolo26.yolo26_instance_segmentation_trt import (
+    YOLO26ForInstanceSegmentationTRT,
+)
+from inference_models.models.yolo26.yolo26_key_points_detection_trt import (
+    YOLO26ForKeyPointsDetectionTRT,
+)
+
+
+def download_test_model(model_id: str, url: str) -> str:
+    """Download and extract a test model, return path to extracted directory."""
+    import requests
+    import zipfile
+
+    cache_dir = Path.home() / ".cache" / "roboflow" / "tests" / model_id
+    if cache_dir.exists():
+        print(f"  Using cached model at {cache_dir}")
+        return str(cache_dir)
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"  Downloading {url}...")
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+
+    zip_path = cache_dir.parent / f"{model_id.replace('/', '_')}.zip"
+    with open(zip_path, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+    print(f"  Extracting to {cache_dir}...")
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall(cache_dir)
+
+    zip_path.unlink()
+    return str(cache_dir)
+
+
+def benchmark_model(
+    model,
+    model_name: str,
+    num_iters: int = 200,
+    warmup: int = 50,
+    batch_size: int = 1,
+) -> Dict:
+    """Benchmark a YOLO26 TRT model and return statistics."""
+    device = torch.device("cuda:0")
+
+    # Generate random input images
+    if batch_size == 1:
+        img = np.random.randint(0, 256, (640, 640, 3), dtype=np.uint8)
+    else:
+        img = [
+            np.random.randint(0, 256, (640, 640, 3), dtype=np.uint8)
+            for _ in range(batch_size)
+        ]
+
+    print(f"\n{'='*60}")
+    print(f"Benchmarking: {model_name} (batch={batch_size})")
+    print(f"{'='*60}")
+
+    # Warmup
+    print(f"Warmup: {warmup} iterations...")
+    for _ in range(warmup):
+        _ = model.infer(img)
+    torch.cuda.synchronize()
+
+    # Benchmark
+    print(f"Measuring: {num_iters} iterations...")
+    times = []
+    for i in range(num_iters):
+        t0 = time.perf_counter()
+        _ = model.infer(img)
+        torch.cuda.synchronize()
+        elapsed = (time.perf_counter() - t0) * 1000
+        times.append(elapsed)
+
+        if (i + 1) % 50 == 0:
+            print(f"  Progress: {i+1}/{num_iters}")
+
+    # Statistics
+    mean = statistics.mean(times)
+    median = statistics.median(times)
+    stdev = statistics.stdev(times)
+    p95 = np.percentile(times, 95)
+    min_time = min(times)
+    max_time = max(times)
+
+    print(f"\nResults:")
+    print(f"  Mean:   {mean:.3f}ms ± {stdev:.3f}ms")
+    print(f"  Median: {median:.3f}ms")
+    print(f"  P95:    {p95:.3f}ms")
+    print(f"  Min:    {min_time:.3f}ms")
+    print(f"  Max:    {max_time:.3f}ms")
+
+    return {
+        "model": model_name,
+        "batch_size": batch_size,
+        "num_iters": num_iters,
+        "mean_ms": mean,
+        "median_ms": median,
+        "stdev_ms": stdev,
+        "p95_ms": p95,
+        "min_ms": min_time,
+        "max_ms": max_time,
+        "times": times,
+    }
+
+
+def main():
+    print("YOLO26 TRT Comprehensive Benchmark")
+    print("="*60)
+
+    device = torch.device("cuda:0")
+
+    # Model configurations
+    models_config = [
+        {
+            "name": "yolo26-det",
+            "class": YOLO26ForObjectDetectionTRT,
+            "model_id": "yolo26_det/1",
+            "url": "https://storage.googleapis.com/roboflow-tests-assets/yolo26_det.zip",
+        },
+        {
+            "name": "yolo26-seg",
+            "class": YOLO26ForInstanceSegmentationTRT,
+            "model_id": "yolo26_seg/1",
+            "url": "https://storage.googleapis.com/roboflow-tests-assets/yolo26_seg.zip",
+        },
+        {
+            "name": "yolo26-pose",
+            "class": YOLO26ForKeyPointsDetectionTRT,
+            "model_id": "yolo26_pose/1",
+            "url": "https://storage.googleapis.com/roboflow-tests-assets/yolo26_pose.zip",
+        },
+    ]
+
+    all_results = []
+
+    for config in models_config:
+        print(f"\n{'#'*60}")
+        print(f"# {config['name'].upper()}")
+        print(f"{'#'*60}")
+
+        try:
+            # Download/cache model
+            model_dir = download_test_model(config["model_id"], config["url"])
+
+            # Load model
+            print(f"\nLoading model from {model_dir}...")
+            model = config["class"].from_pretrained(
+                model_name_or_path=model_dir,
+                device=device,
+            )
+            print("Model loaded successfully!")
+
+            # Benchmark single image
+            result_single = benchmark_model(
+                model=model,
+                model_name=config["name"],
+                num_iters=200,
+                warmup=50,
+                batch_size=1,
+            )
+            all_results.append(result_single)
+
+            # Benchmark batch=8
+            result_batch = benchmark_model(
+                model=model,
+                model_name=config["name"],
+                num_iters=100,
+                warmup=20,
+                batch_size=8,
+            )
+            all_results.append(result_batch)
+
+        except Exception as e:
+            print(f"\nERROR benchmarking {config['name']}: {e}")
+            import traceback
+            traceback.print_exc()
+            continue
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print(f"{'='*60}\n")
+
+    print(f"{'Model':<20} {'Batch':<8} {'Mean (ms)':<12} {'Median (ms)':<12} {'Stdev (ms)':<12}")
+    print("-" * 64)
+    for result in all_results:
+        print(
+            f"{result['model']:<20} "
+            f"{result['batch_size']:<8} "
+            f"{result['mean_ms']:>10.3f}  "
+            f"{result['median_ms']:>10.3f}  "
+            f"{result['stdev_ms']:>10.3f}"
+        )
+
+    # Identify heaviest model
+    single_results = [r for r in all_results if r["batch_size"] == 1]
+    if single_results:
+        heaviest = max(single_results, key=lambda r: r["mean_ms"])
+        print(f"\nHeaviest model (single-image): {heaviest['model']} ({heaviest['mean_ms']:.3f}ms)")
+
+    # Save results
+    output_file = Path(__file__).parent / "yolo26_baseline_results.json"
+    with open(output_file, 'w') as f:
+        json.dump(all_results, f, indent=2)
+    print(f"\nDetailed results saved to: {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/development/yolo26_trt/scripts/bench_yolo26_final.py
+++ b/development/yolo26_trt/scripts/bench_yolo26_final.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Final YOLO26 TRT benchmark using locally-built engines.
+Establishes baselines for all three variants and identifies the heaviest one.
+"""
+
+import os
+import sys
+import time
+import json
+import statistics
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import torch
+
+# Add inference_models to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "inference_models"))
+
+from inference_models.models.yolo26.yolo26_object_detection_trt import (
+    YOLO26ForObjectDetectionTRT,
+)
+from inference_models.models.yolo26.yolo26_instance_segmentation_trt import (
+    YOLO26ForInstanceSegmentationTRT,
+)
+from inference_models.models.yolo26.yolo26_key_points_detection_trt import (
+    YOLO26ForKeyPointsDetectionTRT,
+)
+
+
+def benchmark_model(
+    model,
+    model_name: str,
+    num_iters: int = 200,
+    warmup: int = 50,
+    batch_size: int = 1,
+) -> Dict:
+    """Benchmark a YOLO26 TRT model and return statistics."""
+    # Generate random input images
+    if batch_size == 1:
+        img = np.random.randint(0, 256, (640, 640, 3), dtype=np.uint8)
+    else:
+        img = [
+            np.random.randint(0, 256, (640, 640, 3), dtype=np.uint8)
+            for _ in range(batch_size)
+        ]
+
+    print(f"\n{'='*60}")
+    print(f"Benchmarking: {model_name} (batch={batch_size})")
+    print(f"{'='*60}")
+
+    # Warmup
+    print(f"Warmup: {warmup} iterations...")
+    for _ in range(warmup):
+        _ = model.infer(img)
+    torch.cuda.synchronize()
+
+    # Benchmark
+    print(f"Measuring: {num_iters} iterations...")
+    times = []
+    for i in range(num_iters):
+        t0 = time.perf_counter()
+        _ = model.infer(img)
+        torch.cuda.synchronize()
+        elapsed = (time.perf_counter() - t0) * 1000
+        times.append(elapsed)
+
+        if (i + 1) % 50 == 0:
+            print(f"  Progress: {i+1}/{num_iters}")
+
+    # Statistics
+    mean = statistics.mean(times)
+    median = statistics.median(times)
+    stdev = statistics.stdev(times)
+    p95 = np.percentile(times, 95)
+    min_time = min(times)
+    max_time = max(times)
+
+    print(f"\nResults:")
+    print(f"  Mean:   {mean:.3f}ms ± {stdev:.3f}ms")
+    print(f"  Median: {median:.3f}ms")
+    print(f"  P95:    {p95:.3f}ms")
+    print(f"  Min:    {min_time:.3f}ms")
+    print(f"  Max:    {max_time:.3f}ms")
+
+    return {
+        "model": model_name,
+        "batch_size": batch_size,
+        "num_iters": num_iters,
+        "mean_ms": mean,
+        "median_ms": median,
+        "stdev_ms": stdev,
+        "p95_ms": p95,
+        "min_ms": min_time,
+        "max_ms": max_time,
+        "times": times,
+    }
+
+
+def main():
+    print("YOLO26 TRT Baseline Benchmark")
+    print("="*60)
+    print("Using locally-built TRT engines for L4 GPU (compute 8.9)")
+    print()
+
+    device = torch.device("cuda:0")
+    engine_base = Path.home() / ".cache" / "roboflow" / "yolo26_trt_engines"
+
+    # Model configurations
+    models_config = [
+        {
+            "name": "yolo26-det",
+            "class": YOLO26ForObjectDetectionTRT,
+            "path": engine_base / "yolo26-det",
+        },
+        {
+            "name": "yolo26-seg",
+            "class": YOLO26ForInstanceSegmentationTRT,
+            "path": engine_base / "yolo26-seg",
+        },
+        {
+            "name": "yolo26-pose",
+            "class": YOLO26ForKeyPointsDetectionTRT,
+            "path": engine_base / "yolo26-pose",
+        },
+    ]
+
+    all_results = []
+
+    for config in models_config:
+        print(f"\n{'#'*60}")
+        print(f"# {config['name'].upper()}")
+        print(f"{'#'*60}")
+
+        if not config["path"].exists():
+            print(f"ERROR: Engine directory not found: {config['path']}")
+            continue
+
+        try:
+            # Load model
+            print(f"\nLoading model from {config['path']}...")
+            model = config["class"].from_pretrained(
+                model_name_or_path=str(config["path"]),
+                device=device,
+                engine_host_code_allowed=True,
+            )
+            print("Model loaded successfully!")
+
+            # Benchmark single image
+            result_single = benchmark_model(
+                model=model,
+                model_name=config["name"],
+                num_iters=200,
+                warmup=50,
+                batch_size=1,
+            )
+            all_results.append(result_single)
+
+            # Benchmark batch=8
+            result_batch = benchmark_model(
+                model=model,
+                model_name=config["name"],
+                num_iters=100,
+                warmup=20,
+                batch_size=8,
+            )
+            all_results.append(result_batch)
+
+        except Exception as e:
+            print(f"\nERROR benchmarking {config['name']}: {e}")
+            import traceback
+            traceback.print_exc()
+            continue
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("BASELINE SUMMARY")
+    print(f"{'='*60}\n")
+
+    print(f"{'Model':<20} {'Batch':<8} {'Mean (ms)':<12} {'Median (ms)':<12} {'Stdev (ms)':<12}")
+    print("-" * 64)
+    for result in all_results:
+        print(
+            f"{result['model']:<20} "
+            f"{result['batch_size']:<8} "
+            f"{result['mean_ms']:>10.3f}  "
+            f"{result['median_ms']:>10.3f}  "
+            f"{result['stdev_ms']:>10.3f}"
+        )
+
+    # Identify heaviest model
+    single_results = [r for r in all_results if r["batch_size"] == 1]
+    if single_results:
+        heaviest = max(single_results, key=lambda r: r["mean_ms"])
+        print(f"\n{'='*60}")
+        print(f"PRIMARY OPTIMIZATION TARGET")
+        print(f"{'='*60}")
+        print(f"Heaviest model: {heaviest['model']} ({heaviest['mean_ms']:.3f}ms mean)")
+        print(f"This will be the primary target for optimization experiments.")
+
+    # Save results
+    output_file = Path(__file__).parent / "yolo26_baseline_results.json"
+    with open(output_file, 'w') as f:
+        json.dump(all_results, f, indent=2)
+    print(f"\nDetailed results saved to: {output_file}")
+
+    # Update results.tsv with baselines
+    tsv_file = Path(__file__).parent / "results.tsv"
+    with open(tsv_file, 'a') as f:
+        for result in single_results:
+            f.write(
+                f"baseline-{result['model']}\tbaseline\t-\t"
+                f"{result['model']}.infer()\t"
+                f"{result['mean_ms']:.3f}ms±{result['stdev_ms']:.3f}ms\t-\t-\t"
+                f"2026-04-21T23:00:00\t-\n"
+            )
+    print(f"Baselines appended to: {tsv_file}")
+
+    print(f"\n{'='*60}")
+    print("NEXT STEPS")
+    print(f"{'='*60}")
+    print("1. Profile the heaviest model with torch.profiler")
+    print("2. Compare against YOLOv8n baseline to identify YOLO26-specific hotspots")
+    print("3. Begin optimization experiments")
+
+
+if __name__ == "__main__":
+    main()

--- a/development/yolo26_trt/scripts/build_yolo26_engines.py
+++ b/development/yolo26_trt/scripts/build_yolo26_engines.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Build TRT engines for YOLO26 models from ONNX files.
+This creates compatible engines for the current GPU (L4, compute 8.9).
+"""
+
+import os
+import sys
+import shutil
+import json
+from pathlib import Path
+
+import tensorrt as trt
+import pycuda.driver as cuda
+import pycuda.autoinit
+
+
+def build_trt_engine(
+    onnx_path: str,
+    engine_path: str,
+    fp16_mode: bool = True,
+    max_batch_size: int = 8,
+) -> bool:
+    """Build a TRT engine from ONNX model."""
+    print(f"\nBuilding TRT engine:")
+    print(f"  Input:  {onnx_path}")
+    print(f"  Output: {engine_path}")
+    print(f"  FP16:   {fp16_mode}")
+    print(f"  Max batch: {max_batch_size}")
+
+    # Create builder and network
+    logger = trt.Logger(trt.Logger.INFO)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+    )
+    parser = trt.OnnxParser(network, logger)
+
+    # Parse ONNX
+    print("  Parsing ONNX...")
+    with open(onnx_path, 'rb') as model:
+        if not parser.parse(model.read()):
+            print(f"  ERROR: Failed to parse ONNX file")
+            for error in range(parser.num_errors):
+                print(f"    {parser.get_error(error)}")
+            return False
+
+    # Configure builder
+    config = builder.create_builder_config()
+
+    # Set memory pool limit (8GB for L4)
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 8 << 30)
+
+    if fp16_mode:
+        config.set_flag(trt.BuilderFlag.FP16)
+        print("  FP16 mode enabled")
+
+    # Build engine
+    print("  Building engine (this may take several minutes)...")
+    serialized_engine = builder.build_serialized_network(network, config)
+
+    if serialized_engine is None:
+        print("  ERROR: Failed to build engine")
+        return False
+
+    # Save engine
+    print(f"  Saving engine to {engine_path}...")
+    with open(engine_path, 'wb') as f:
+        f.write(serialized_engine)
+
+    print("  Engine built successfully!")
+    return True
+
+
+def create_model_package(
+    onnx_base_dir: str,
+    output_dir: str,
+    model_type: str,
+) -> bool:
+    """Create a complete model package with TRT engine."""
+    print(f"\n{'='*60}")
+    print(f"Creating {model_type} model package")
+    print(f"{'='*60}")
+
+    # Source files
+    onnx_path = Path(onnx_base_dir) / "model.onnx"
+    class_names_path = Path(onnx_base_dir) / "class_names.txt"
+    env_path = Path(onnx_base_dir) / "environment.json"
+
+    # Validate source files exist
+    if not onnx_path.exists():
+        print(f"ERROR: ONNX file not found: {onnx_path}")
+        return False
+    if not class_names_path.exists():
+        print(f"ERROR: class_names.txt not found: {class_names_path}")
+        return False
+    if not env_path.exists():
+        print(f"ERROR: environment.json not found: {env_path}")
+        return False
+
+    # Create output directory
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Build TRT engine
+    engine_path = output_path / "engine.plan"
+    if not build_trt_engine(str(onnx_path), str(engine_path), fp16_mode=True):
+        return False
+
+    # Copy supporting files
+    print("\n  Copying supporting files...")
+    shutil.copy(class_names_path, output_path / "class_names.txt")
+
+    # Load and update environment.json
+    with open(env_path, 'r') as f:
+        env_data = json.load(f)
+
+    # Create inference_config.json from environment.json
+    inference_config = {
+        "image_pre_processing": {
+            "resize_mode": env_data.get("PREPROCESSING_STRATEGY", "letterbox"),
+            "input_color_format": "bgr",
+        },
+        "network_input": {
+            "width": env_data.get("IMG_SIZE_WIDTH", 640),
+            "height": env_data.get("IMG_SIZE_HEIGHT", 640),
+        }
+    }
+
+    with open(output_path / "inference_config.json", 'w') as f:
+        json.dump(inference_config, f, indent=2)
+
+    # Create trt_config.json
+    trt_config = {
+        "fp16": True,
+        "max_batch_size": 8,
+    }
+
+    with open(output_path / "trt_config.json", 'w') as f:
+        json.dump(trt_config, f, indent=2)
+
+    print(f"\n  Model package created at: {output_path}")
+    print(f"  Files:")
+    for file in output_path.iterdir():
+        size_mb = file.stat().st_size / (1024 * 1024)
+        print(f"    - {file.name} ({size_mb:.1f} MB)")
+
+    return True
+
+
+def main():
+    print("YOLO26 TRT Engine Builder")
+    print("="*60)
+    print("Building TRT engines for current GPU (L4, compute 8.9)")
+    print()
+
+    # Model configurations
+    models = [
+        {
+            "name": "yolo26-det",
+            "source_dir": "/home/ubuntu/.cache/roboflow/tests/yolo26_det/1",
+            "output_dir": "/home/ubuntu/.cache/roboflow/yolo26_trt_engines/yolo26-det",
+        },
+        {
+            "name": "yolo26-seg",
+            "source_dir": "/home/ubuntu/.cache/roboflow/tests/yolo26_seg/1",
+            "output_dir": "/home/ubuntu/.cache/roboflow/yolo26_trt_engines/yolo26-seg",
+        },
+        {
+            "name": "yolo26-pose",
+            "source_dir": "/home/ubuntu/.cache/roboflow/tests/yolo26_pose/1",
+            "output_dir": "/home/ubuntu/.cache/roboflow/yolo26_trt_engines/yolo26-pose",
+        },
+    ]
+
+    success_count = 0
+    for model_config in models:
+        if create_model_package(
+            onnx_base_dir=model_config["source_dir"],
+            output_dir=model_config["output_dir"],
+            model_type=model_config["name"],
+        ):
+            success_count += 1
+        else:
+            print(f"\nFAILED to build {model_config['name']}")
+
+    print(f"\n{'='*60}")
+    print(f"Build Summary: {success_count}/{len(models)} models built successfully")
+    print(f"{'='*60}")
+
+    if success_count == len(models):
+        print("\nAll engines built successfully!")
+        print("You can now benchmark with:")
+        for model_config in models:
+            print(f"  {model_config['output_dir']}")
+        return 0
+    else:
+        print("\nSome builds failed. Check errors above.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/development/yolo26_trt/scripts/compare_yolo26_vs_yolov8.py
+++ b/development/yolo26_trt/scripts/compare_yolo26_vs_yolov8.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Compare YOLO26 vs YOLOv8n performance to identify YOLO26-specific overhead.
+"""
+
+import sys
+import time
+import statistics
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "inference_models"))
+
+
+def quick_benchmark(model, name: str, iterations: int = 100) -> dict:
+    """Quick benchmark to get mean/median/stdev."""
+    img = np.random.randint(0, 256, (640, 640, 3), dtype=np.uint8)
+
+    # Warmup
+    for _ in range(20):
+        _ = model.infer(img)
+    torch.cuda.synchronize()
+
+    # Measure
+    times = []
+    for _ in range(iterations):
+        t0 = time.perf_counter()
+        _ = model.infer(img)
+        torch.cuda.synchronize()
+        times.append((time.perf_counter() - t0) * 1000)
+
+    return {
+        "name": name,
+        "mean": statistics.mean(times),
+        "median": statistics.median(times),
+        "stdev": statistics.stdev(times),
+        "min": min(times),
+        "max": max(times),
+    }
+
+
+def main():
+    print("YOLO26 vs YOLOv8n Comparison")
+    print("="*60)
+
+    device = torch.device("cuda:0")
+
+    # Load YOLOv8n (if available from prior sessions)
+    yolov8n_path = Path.home() / ".cache" / "roboflow" / "yolov8n_trt"  # adjust path as needed
+    yolo26_det_path = Path.home() / ".cache" / "roboflow" / "yolo26_trt_engines" / "yolo26-det"
+
+    results = []
+
+    # Try YOLOv8n
+    if yolov8n_path.exists():
+        try:
+            print("\nBenchmarking YOLOv8n...")
+            from inference_models.models.yolov8.yolov8_object_detection_trt import (
+                YOLOv8ForObjectDetectionTRT,
+            )
+            yolov8n = YOLOv8ForObjectDetectionTRT.from_pretrained(
+                model_name_or_path=str(yolov8n_path),
+                device=device,
+                engine_host_code_allowed=True,
+            )
+            result = quick_benchmark(yolov8n, "YOLOv8n", iterations=100)
+            results.append(result)
+            print(f"  Mean: {result['mean']:.3f}ms ± {result['stdev']:.3f}ms")
+        except Exception as e:
+            print(f"  ERROR: {e}")
+    else:
+        print(f"\nYOLOv8n not found at {yolov8n_path}, skipping comparison")
+
+    # Benchmark YOLO26
+    if yolo26_det_path.exists():
+        try:
+            print("\nBenchmarking YOLO26...")
+            from inference_models.models.yolo26.yolo26_object_detection_trt import (
+                YOLO26ForObjectDetectionTRT,
+            )
+            yolo26 = YOLO26ForObjectDetectionTRT.from_pretrained(
+                model_name_or_path=str(yolo26_det_path),
+                device=device,
+                engine_host_code_allowed=True,
+            )
+            result = quick_benchmark(yolo26, "YOLO26", iterations=100)
+            results.append(result)
+            print(f"  Mean: {result['mean']:.3f}ms ± {result['stdev']:.3f}ms")
+        except Exception as e:
+            print(f"  ERROR: {e}")
+    else:
+        print(f"\nYOLO26 not found at {yolo26_det_path}, waiting for engines to build")
+
+    # Comparison
+    if len(results) == 2:
+        print(f"\n{'='*60}")
+        print("COMPARISON")
+        print(f"{'='*60}\n")
+
+        yolov8_result = next(r for r in results if "YOLOv8" in r["name"])
+        yolo26_result = next(r for r in results if "YOLO26" in r["name"])
+
+        diff_ms = yolo26_result["mean"] - yolov8_result["mean"]
+        diff_pct = (diff_ms / yolov8_result["mean"]) * 100
+
+        print(f"YOLOv8n: {yolov8_result['mean']:.3f}ms")
+        print(f"YOLO26:  {yolo26_result['mean']:.3f}ms")
+        print(f"Delta:   {diff_ms:+.3f}ms ({diff_pct:+.1f}%)")
+
+        if abs(diff_pct) < 5:
+            print(f"\n✓ Performance is within 5% - YOLO26 benefits fully from shared optimizations")
+        elif diff_pct > 5:
+            print(f"\n⚠ YOLO26 is {diff_pct:.1f}% slower - may have model-specific overhead")
+            print("  Investigate: preprocessing differences, postprocessing overhead, engine efficiency")
+        else:
+            print(f"\n✓ YOLO26 is faster - possibly better engine optimization or simpler postprocessing")
+
+    elif len(results) == 1:
+        print("\nOnly one model available for benchmarking. Need both for comparison.")
+
+
+if __name__ == "__main__":
+    main()

--- a/development/yolo26_trt/scripts/profile_yolo26.py
+++ b/development/yolo26_trt/scripts/profile_yolo26.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Profile YOLO26 TRT inference with torch.profiler to identify optimization targets.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch.profiler import profile, ProfilerActivity
+
+# Add inference_models to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "inference_models"))
+
+
+def profile_model(model, model_name: str, num_iterations: int = 10):
+    """Profile a model's inference with torch.profiler."""
+    print(f"\n{'='*60}")
+    print(f"Profiling: {model_name}")
+    print(f"{'='*60}\n")
+
+    # Random input image
+    img = np.random.randint(0, 256, (640, 640, 3), dtype=np.uint8)
+
+    # Warmup
+    print("Warming up...")
+    for _ in range(20):
+        _ = model.infer(img)
+    torch.cuda.synchronize()
+
+    # Profile
+    print(f"Profiling {num_iterations} iterations...")
+    with profile(
+        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+        with_stack=True,
+        record_shapes=True,
+        profile_memory=False,
+    ) as prof:
+        for _ in range(num_iterations):
+            _ = model.infer(img)
+
+    # Print results sorted by CUDA time
+    print(f"\n{'='*60}")
+    print(f"Top 30 operations by CUDA time")
+    print(f"{'='*60}\n")
+    print(prof.key_averages().table(
+        sort_by="cuda_time_total",
+        row_limit=30,
+        max_src_column_width=60,
+    ))
+
+    # Print results sorted by CPU time
+    print(f"\n{'='*60}")
+    print(f"Top 30 operations by CPU time")
+    print(f"{'='*60}\n")
+    print(prof.key_averages().table(
+        sort_by="cpu_time_total",
+        row_limit=30,
+        max_src_column_width=60,
+    ))
+
+    # Look for memory transfers
+    print(f"\n{'='*60}")
+    print(f"Memory transfer operations (H2D, D2H, D2D)")
+    print(f"{'='*60}\n")
+    events = prof.key_averages()
+    transfers = [e for e in events if 'copy' in e.key.lower() or 'memcpy' in e.key.lower()]
+    if transfers:
+        for event in transfers[:20]:
+            print(f"{event.key:<60} {event.count:>6}x  CUDA: {event.cuda_time_total/1000:>8.3f}ms")
+    else:
+        print("No explicit memory transfer operations found in profile.")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python profile_yolo26.py <model_type> <engine_path>")
+        print()
+        print("model_type: det, seg, or pose")
+        print("engine_path: path to TRT engine directory")
+        print()
+        print("Example:")
+        print("  python profile_yolo26.py det ~/.cache/roboflow/yolo26_trt_engines/yolo26-det")
+        sys.exit(1)
+
+    model_type = sys.argv[1]
+    engine_path = sys.argv[2]
+
+    device = torch.device("cuda:0")
+
+    # Load appropriate model class
+    if model_type == "det":
+        from inference_models.models.yolo26.yolo26_object_detection_trt import (
+            YOLO26ForObjectDetectionTRT,
+        )
+        model_class = YOLO26ForObjectDetectionTRT
+        model_name = "YOLO26 Object Detection"
+    elif model_type == "seg":
+        from inference_models.models.yolo26.yolo26_instance_segmentation_trt import (
+            YOLO26ForInstanceSegmentationTRT,
+        )
+        model_class = YOLO26ForInstanceSegmentationTRT
+        model_name = "YOLO26 Instance Segmentation"
+    elif model_type == "pose":
+        from inference_models.models.yolo26.yolo26_key_points_detection_trt import (
+            YOLO26ForKeyPointsDetectionTRT,
+        )
+        model_class = YOLO26ForKeyPointsDetectionTRT
+        model_name = "YOLO26 Keypoints Detection"
+    else:
+        print(f"ERROR: Unknown model type '{model_type}'. Use 'det', 'seg', or 'pose'.")
+        sys.exit(1)
+
+    # Load model
+    print(f"Loading {model_name} from {engine_path}...")
+    model = model_class.from_pretrained(
+        model_name_or_path=engine_path,
+        device=device,
+        engine_host_code_allowed=True,
+    )
+    print("Model loaded successfully!\n")
+
+    # Profile
+    profile_model(model, model_name, num_iterations=10)
+
+    print(f"\n{'='*60}")
+    print("Profile complete!")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/development/yolo26_trt/session_prompt.md
+++ b/development/yolo26_trt/session_prompt.md
@@ -1,0 +1,110 @@
+# YOLO26 TRT Optimization Session
+
+AUTONOMOUS MODE: Work fully autonomously. Do NOT ask the user any questions. Time is no limit — iterate to plateau. Make all decisions yourself and document them in HANDOFF.md.
+
+## Task
+
+End-to-end optimization of the `.infer()` method of YOLO26 models on the TensorRT GPU path. Same methodology as the prior sessions in this repo.
+
+## Prior state (branch: codeflash/optimize)
+
+Three sessions have already landed ~10 commits optimizing shared TRT preprocess/postprocess infrastructure for YOLOv8n, YOLOv8n-seg, and RF-DETR. Since YOLO26 likely reuses that shared preprocessing (`inference_models/models/common/roboflow/pre_processing.py`) and postprocessing (same NMS/rescale path), it probably already benefits from:
+- Pinned staging buffer cache in TRT preprocess
+- Cached per-channel mean/std for normalize
+- Strided scalar rescale
+- Shared `nonzero` + packed `index_select` in NMS
+
+A concurrent FP16/EfficientNMS agent is currently running on YOLOv8n/RF-DETR engine-level work. Do NOT rebuild YOLOv8n engines or touch post_processing.py in a way that would conflict with it — focus on YOLO26-specific wins and any preprocessing/postprocessing that YOLO26 uses but the prior sessions didn't profile.
+
+A concurrent SAM3 session is also running — ignore anything SAM3-related.
+
+Existing state in `.codeflash/` (HANDOFF.md, results.tsv, changelog.md, `bench_yolo26.py` — the prior agent left a benchmark script for YOLO26, check it out).
+
+## Your workflow
+
+1. **Locate YOLO26 variants in the repo.** There are multiple (object detection, segmentation, keypoints). Find the TRT backends.
+2. **Pick the heaviest one as primary target.** Benchmark single-image and batch=8 on real images. Establish baseline with warmup + mean ± std.
+3. **Profile** with torch.profiler (and nsys if useful) to find YOLO26-specific hotspots:
+   - Preprocess path (might differ from YOLOv8 — check input shape, letterbox/stretch choice, any YOLO26-specific normalization)
+   - TRT engine execution (kernels, H2D/D2H)
+   - Postprocess (different detection head, possibly different anchor/decode math, NMS)
+4. **Compare against YOLOv8n** — where is YOLO26 slower/faster? Is there a per-model hotspot that shared optimizations don't cover?
+5. **Run experiments.** Typical candidates:
+   - Pinned memory if any preprocess path bypasses the shared optimization
+   - Cached tensors for any YOLO26-specific constants (anchor grids, stride tensors, class-index tensors)
+   - Eliminate H2D/D2H in YOLO26-specific postprocess
+   - torch.compile on hot paths (be careful with correctness and recompile overhead)
+   - Buffer reuse in the adapter class
+6. **Correctness gate.** For each kept change, verify detections match baseline within tolerance on real images (IoU >= 0.95 on kept boxes, class-match >= 99%, score drift <= 1%).
+7. **Commit each accepted experiment separately** on `codeflash/optimize`. Label experiments `yolo26-exp001`, etc.
+8. **Update** `.codeflash/HANDOFF.md`, `.codeflash/changelog.md`, `.codeflash/results.tsv` as you go.
+9. **Stop** only when you've hit a genuine plateau (5 consecutive failed experiments, no remaining hotspot in profile).
+
+## Deliverables
+
+At end: baseline vs optimized for each YOLO26 variant benchmarked (single + batch=8), list of kept vs discarded experiments, and a short note on whether YOLO26-specific wins exist beyond the shared infra.
+
+## Reporting
+
+When sending progress messages back to the team lead, be concise. The lead has file access — confirm completion and flag issues, don't restate file contents or list every section you wrote.
+
+## Environment
+
+From setup.md:
+- Python 3.12.3
+- PyTorch 2.10.0+cu128
+- TensorRT 10.12.0.36
+- Test command: /home/ubuntu/inference/.venv/bin/pytest
+- Virtual environment: /home/ubuntu/inference/.venv/
+
+## Conventions
+
+From conventions.md:
+- Session Configuration (Autonomous Mode)
+- Run tag: 2026-04-21
+- Target: Heaviest model's .infer() method
+- Focus: TensorRT GPU performance optimization
+- Guard Command: Not specified (run tests after each optimization)
+
+## Session History
+
+From results.tsv and HANDOFF.md:
+- Prior sessions optimized YOLOv8n, YOLOv8n-seg, RF-DETR
+- 9 optimizations committed to shared infrastructure
+- Cumulative improvements: 4.8-8.3% E2E speedup
+- All correctness tests passing (247 preprocess tests)
+
+Key prior optimizations that YOLO26 may already benefit from:
+1. Pinned staging buffer cache (6c45a8265)
+2. Strided scalar rescale (66724c1da, e02b83526, 0fad67e05)
+3. Single nonzero + packed gather in NMS (97b52ad26, 6f42f447d)
+4. Cached normalize constants (bd4599538)
+5. Cached arange indices (3c710460b)
+
+## Domain Knowledge: GPU/CUDA Optimization
+
+Key principles from references/gpu/guide.md:
+- Always use torch.profiler for GPU workloads (not cProfile)
+- Look for: H2D/D2H transfers, kernel dispatch gaps, stream sync stalls, pipeline bubbles
+- Per-stage measurement with torch.cuda.Event
+- Warm-up required (10-20 iterations) before benchmarking
+- Focus on: pinned memory, kernel fusion, cached constants, non_blocking transfers
+- Monolithic kernel strategy when piecemeal optimizations don't register in E2E
+
+## YOLO26 TRT Files Located
+
+Three TRT backends:
+- inference_models/inference_models/models/yolo26/yolo26_object_detection_trt.py
+- inference_models/inference_models/models/yolo26/yolo26_instance_segmentation_trt.py
+- inference_models/inference_models/models/yolo26/yolo26_key_points_detection_trt.py
+
+Benchmark script already exists:
+- .codeflash/bench_yolo26.py
+
+## Related Repositories
+
+None detected.
+
+## Library Research
+
+N/A (not using context7 in this session)


### PR DESCRIPTION
## Summary

Archives the YOLO26 TensorRT optimization scripts from a **prior
autonomous session** (2026-04-21) into
\`development/yolo26_trt/\`. Paired with the SAM3 TRT PR (#17); together
they move everything out of the untracked \`.codeflash/\` scratch
directory and into reviewable, preserved form.

**This is archival code, not a runtime change.** Nothing in
\`inference/\` or \`inference_models/\` is modified.

## Provenance

These scripts were **not produced in the SAM3 TRT session**. Timestamps
and the session status doc (\`SESSION_STATUS.md\`) show the work predates
SAM3 and stopped at Phase 2 (engine build) before wrapping. Phases 3-5
(baseline, profile, optimization loop) were planned but never executed.

## What's in here

- \`scripts/build_yolo26_engines.py\` — rebuilds TRT engines from ONNX
  for all three YOLO26 variants (object detection, instance
  segmentation, keypoints) with FP16, max batch 8, 8 GB workspace.
- \`scripts/bench_yolo26_comprehensive.py\` — first benchmark attempt
  (failed: ONNX packaging mismatch).
- \`scripts/bench_yolo26_all_variants.py\` — second attempt via
  prebuilt TRT packages (failed: engines built for a different GPU
  compute capability).
- \`scripts/bench_yolo26_final.py\` — working benchmark against
  locally-built engines, covers all three variants.
- \`scripts/profile_yolo26.py\` — stage breakdown for hotspot hunting.
- \`scripts/compare_yolo26_vs_yolov8.py\` — differential profile vs
  YOLOv8n to find YOLO26-specific slowdowns.
- \`SESSION_STATUS.md\` — full progress log from the original session
  (objective, phases, environment, open questions about YOLO26 vs
  shared infrastructure wins).
- \`session_prompt.md\` — the autonomous-mode prompt that started the
  session.

## Status at hand-off

The scripts reference \`~/.cache/roboflow/yolo26_trt_engines/...\` paths
and assume the prior session's L4 state. They will need rebuilt
engines to run again — the engines themselves are not committed (see
\`scripts/.gitignore\`).

Shared infrastructure optimizations from even-earlier sessions
(YOLOv8n / RF-DETR) are referenced in \`SESSION_STATUS.md\` with commit
hashes for context, but not included in this PR.

## Test plan

This is a pure file-move PR (new files under \`development/yolo26_trt/\`,
nothing else changes). No runtime tests apply.

- [ ] Read \`SESSION_STATUS.md\` to understand the prior session's
      scope and open questions.
- [ ] Confirm nothing outside \`development/yolo26_trt/\` is touched.
- [ ] Decide whether to continue Phases 3-5 in a future session, or
      close this out as an archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)