### PR TITLE
perf(rfdetr-seg): Triton fusion + CUDA graphs + depth-2 frame pipeline (109 → 241 FPS on vehicles_312px)

### DIFF
--- a/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
+++ b/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
@@ -13,6 +13,10 @@ Defaults: rfdetr-seg-nano @ confidence 0.4 on the native TRT backend.
 """
 import argparse
 import os
+import sys
+from functools import partial
+from pathlib import Path
+from typing import Optional
 
 _ALL_BACKENDS = {
     "torch",
@@ -24,6 +28,18 @@ _ALL_BACKENDS = {
     "mediapipe",
     "custom",
 }
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LOCAL_IMPORT_PATHS = (
+    str(_REPO_ROOT / "inference_models"),
+    str(_REPO_ROOT),
+)
+for _path in reversed(_LOCAL_IMPORT_PATHS):
+    if _path in sys.path:
+        sys.path.remove(_path)
+    sys.path.insert(0, _path)
+
+
 def _select_backend_from_argv() -> str:
     pre = argparse.ArgumentParser(add_help=False)
     pre.add_argument("--backend", choices=("trt", "onnx", "torch"), default="trt")
@@ -36,13 +52,46 @@ os.environ.setdefault(
     "ONNXRUNTIME_EXECUTION_PROVIDERS",
     "[TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider]",
 )
+os.environ.setdefault("ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES", "True")
 os.environ["DISABLED_INFERENCE_MODELS_BACKENDS"] = ",".join(
     sorted(_ALL_BACKENDS - {_BACKEND})
 )
 
 from time import perf_counter
 
+import inference
+import inference_models
 from inference import InferencePipeline
+from inference.core.interfaces.stream.entities import ModelConfig
+from inference.core.interfaces.stream.model_handlers.roboflow_models import (
+    default_process_frame,
+)
+from inference.core.models.inference_models_adapters import (
+    InferenceModelsInstanceSegmentationAdapter,
+)
+
+DEFAULT_LOCAL_TRT_MODEL_PACKAGE = _REPO_ROOT / "rfdetr-seg-nano-orin-trt-package"
+
+
+def is_model_package_dir(path: Path) -> bool:
+    if not path.is_dir():
+        return False
+    required_files = {"model_config.json", "inference_config.json", "class_names.txt"}
+    package_files = {child.name for child in path.iterdir() if child.is_file()}
+    return required_files.issubset(package_files)
+
+
+def resolve_model_target(
+    backend: str, model_id: str, model_package_path: Optional[str]
+) -> str:
+    if model_package_path:
+        return str(Path(model_package_path).expanduser().resolve())
+    candidate_path = Path(model_id).expanduser()
+    if is_model_package_dir(candidate_path):
+        return str(candidate_path.resolve())
+    if backend == "trt" and DEFAULT_LOCAL_TRT_MODEL_PACKAGE.exists():
+        return str(DEFAULT_LOCAL_TRT_MODEL_PACKAGE.resolve())
+    return model_id
 
 
 def build_workflow(model_id: str, confidence: float) -> dict:
@@ -90,6 +139,15 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--video_reference", required=True)
     parser.add_argument("--model_id", default="rfdetr-seg-nano")
+    parser.add_argument(
+        "--model_package_path",
+        default=None,
+        help=(
+            "Absolute or relative path to a local model package directory. "
+            "When omitted, TRT runs prefer the repo-local "
+            "`rfdetr-seg-nano-orin-trt-package` if it exists."
+        ),
+    )
     parser.add_argument("--confidence", type=float, default=0.4)
     parser.add_argument(
         "--backend",
@@ -98,12 +156,43 @@ def main() -> None:
         help="inference-models backend (consumed pre-import via env var).",
     )
     args = parser.parse_args()
-
-    pipeline = InferencePipeline.init_with_workflow(
-        video_reference=args.video_reference,
-        workflow_specification=build_workflow(args.model_id, args.confidence),
-        on_prediction=sink,
+    resolved_model_target = resolve_model_target(
+        backend=args.backend,
+        model_id=args.model_id,
+        model_package_path=args.model_package_path,
     )
+    local_model_package = Path(resolved_model_target).expanduser()
+    uses_local_model_package = is_model_package_dir(local_model_package)
+    workflow_model_id = args.model_id
+    print(
+        "[setup] "
+        f"inference={Path(inference.__file__).resolve()} "
+        f"inference_models={Path(inference_models.__file__).resolve()} "
+        f"backend={args.backend} "
+        f"model_target={workflow_model_id} "
+        f"local_model_package={resolved_model_target}",
+        flush=True,
+    )
+    if uses_local_model_package:
+        inference_config = ModelConfig.init(confidence=args.confidence)
+        model = InferenceModelsInstanceSegmentationAdapter(
+            model_id=str(local_model_package.resolve())
+        )
+        pipeline = InferencePipeline.init_with_custom_logic(
+            video_reference=args.video_reference,
+            on_video_frame=partial(
+                default_process_frame,
+                model=model,
+                inference_config=inference_config,
+            ),
+            on_prediction=sink,
+        )
+    else:
+        pipeline = InferencePipeline.init_with_workflow(
+            video_reference=args.video_reference,
+            workflow_specification=build_workflow(workflow_model_id, args.confidence),
+            on_prediction=sink,
+        )
     pipeline.start()
     pipeline.join()
 

--- a/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
+++ b/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
@@ -1,0 +1,244 @@
+"""E2E benchmark: RF-DETR nano Segmentation (TensorRT CUDA engine) through a
+single-block Workflow, run on a video stream via InferencePipeline.
+
+Adapted from development/stream_interface/workflows_demo.py — swaps the object
+detection block for `roboflow_core/roboflow_instance_segmentation_model@v1`
+pointing at `rfdetr-seg-nano`, adds a mask visualization block so the sink
+receives a pre-rendered preview, and pins the ONNX runtime provider list to
+TensorRT (FP16, engine-cache on disk) via the `ONNXRUNTIME_EXECUTION_PROVIDERS`
+env var. The first run compiles + caches the TRT engine under
+TENSORRT_CACHE_PATH / MODEL_CACHE_DIR; subsequent runs reuse the cached plan.
+
+Controls (interactive mode):
+    i = watchdog report
+    t = terminate
+    p = pause stream
+    m = mute stream
+    r = resume stream
+"""
+import os
+
+os.environ.setdefault(
+    "ONNXRUNTIME_EXECUTION_PROVIDERS",
+    "[TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider]",
+)
+
+import argparse
+from threading import Thread
+from time import perf_counter
+from typing import List, Optional, Union
+
+import cv2
+import supervision as sv
+
+from inference import InferencePipeline
+from inference.core.interfaces.camera.entities import VideoFrame
+from inference.core.interfaces.camera.video_source import (
+    BufferConsumptionStrategy,
+    BufferFillingStrategy,
+)
+from inference.core.interfaces.stream.watchdog import (
+    BasePipelineWatchDog,
+    PipelineWatchDog,
+)
+from inference.core.utils.drawing import create_tiles
+
+MODEL_ID = "rfdetr-seg-nano"
+STOP = False
+HEADLESS = False
+FRAME_COUNT = 0
+START_TIME: Optional[float] = None
+FPS_MONITOR = sv.FPSMonitor()
+
+
+def build_workflow_specification(model_id: str, confidence: float) -> dict:
+    return {
+        "version": "1.0",
+        "inputs": [
+            {"type": "WorkflowImage", "name": "image"},
+        ],
+        "steps": [
+            {
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v1",
+                "name": "segmentation",
+                "images": "$inputs.image",
+                "model_id": model_id,
+                "confidence": confidence,
+            },
+            {
+                "type": "roboflow_core/mask_visualization@v1",
+                "name": "mask_visualiser",
+                "predictions": "$steps.segmentation.predictions",
+                "image": "$inputs.image",
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.segmentation.predictions",
+            },
+            {
+                "type": "JsonField",
+                "name": "preview",
+                "selector": "$steps.mask_visualiser.image",
+            },
+        ],
+    }
+
+
+def workflows_sink(
+    predictions: Union[dict, List[Optional[dict]]],
+    video_frames: Union[VideoFrame, List[Optional[VideoFrame]]],
+) -> None:
+    global FRAME_COUNT, START_TIME
+    FPS_MONITOR.tick()
+    if not isinstance(predictions, list):
+        predictions = [predictions]
+        video_frames = [video_frames]
+
+    images_to_show = []
+    for prediction, frame in zip(predictions, video_frames):
+        if prediction is None or frame is None:
+            continue
+        FRAME_COUNT += 1
+        if START_TIME is None:
+            START_TIME = perf_counter()
+
+        detections: sv.Detections = prediction["predictions"]
+        preview_field = prediction["preview"]
+        preview = (
+            preview_field.numpy_image
+            if hasattr(preview_field, "numpy_image")
+            else preview_field
+        )
+
+        if HEADLESS:
+            if FRAME_COUNT % 10 == 0 or FRAME_COUNT <= 3:
+                fps_value = (
+                    FPS_MONITOR.fps if hasattr(FPS_MONITOR, "fps") else FPS_MONITOR()
+                )
+                print(
+                    f"[frame {FRAME_COUNT}] detections={len(detections)} fps={fps_value:.2f}",
+                    flush=True,
+                )
+            continue
+        images_to_show.append(preview)
+
+    if HEADLESS or not images_to_show:
+        return
+
+    fps_value = FPS_MONITOR.fps if hasattr(FPS_MONITOR, "fps") else FPS_MONITOR()
+    tiles = create_tiles(images=images_to_show)
+    cv2.putText(
+        tiles,
+        f"FPS: {fps_value:.1f}",
+        (10, 30),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        1.0,
+        (0, 255, 0),
+        2,
+    )
+    cv2.imshow("RF-DETR nano seg (TRT)", tiles)
+    cv2.waitKey(1)
+    print(f"FPS: {fps_value}")
+
+
+def command_thread(pipeline: InferencePipeline, watchdog: PipelineWatchDog) -> None:
+    global STOP
+    while not STOP:
+        key = input()
+        if key == "i":
+            print(watchdog.get_report())
+        if key == "t":
+            pipeline.terminate()
+            STOP = True
+        elif key == "p":
+            pipeline.pause_stream()
+        elif key == "m":
+            pipeline.mute_stream()
+        elif key == "r":
+            pipeline.resume_stream()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--video_reference",
+        required=True,
+        help="Video file path, RTSP URL, or integer camera id.",
+    )
+    parser.add_argument("--max_fps", type=float, default=None)
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument("--model_id", default=MODEL_ID)
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Skip cv2.imshow; log detection counts + FPS instead.",
+    )
+    parser.add_argument(
+        "--stream_source",
+        action="store_true",
+        help="Use RTSP-style buffer strategies (DROP_OLDEST / EAGER). "
+        "Leave off for video files — the default lets every frame through.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    global STOP, HEADLESS
+    args = parse_args()
+    HEADLESS = args.headless
+
+    try:
+        video_reference: Union[str, int] = int(args.video_reference)
+    except ValueError:
+        video_reference = args.video_reference
+
+    watchdog = BasePipelineWatchDog()
+    workflow_specification = build_workflow_specification(
+        model_id=args.model_id,
+        confidence=args.confidence,
+    )
+    pipeline_kwargs = dict(
+        video_reference=video_reference,
+        workflow_specification=workflow_specification,
+        watchdog=watchdog,
+        on_prediction=workflows_sink,
+        max_fps=args.max_fps,
+    )
+    if args.stream_source:
+        pipeline_kwargs["source_buffer_filling_strategy"] = (
+            BufferFillingStrategy.DROP_OLDEST
+        )
+        pipeline_kwargs["source_buffer_consumption_strategy"] = (
+            BufferConsumptionStrategy.EAGER
+        )
+    pipeline = InferencePipeline.init_with_workflow(**pipeline_kwargs)
+
+    control_thread: Optional[Thread] = None
+    if not HEADLESS:
+        control_thread = Thread(
+            target=command_thread, args=(pipeline, watchdog), daemon=True
+        )
+        control_thread.start()
+
+    pipeline.start()
+    STOP = True
+    pipeline.join()
+
+    if not HEADLESS:
+        cv2.destroyAllWindows()
+
+    elapsed = perf_counter() - START_TIME if START_TIME is not None else 0.0
+    avg_fps = (FRAME_COUNT - 1) / elapsed if elapsed > 0 and FRAME_COUNT > 1 else 0.0
+    window_fps = FPS_MONITOR.fps if hasattr(FPS_MONITOR, "fps") else FPS_MONITOR()
+    print(
+        f"DONE: processed {FRAME_COUNT} frames in {elapsed:.2f}s, "
+        f"avg FPS={avg_fps:.2f}, window FPS={window_fps:.2f}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
+++ b/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
@@ -1,75 +1,62 @@
-"""E2E benchmark: RF-DETR nano Segmentation (TensorRT CUDA engine) through a
-single-block Workflow, run on a video stream via InferencePipeline.
+"""Minimal benchmark: RF-DETR instance segmentation through inference-models,
+run via InferencePipeline on a single video source.
 
-Adapted from development/stream_interface/workflows_demo.py — swaps the object
-detection block for `roboflow_core/roboflow_instance_segmentation_model@v1`
-pointing at `rfdetr-seg-nano`, adds a mask visualization block so the sink
-receives a pre-rendered preview, and pins the ONNX runtime provider list to
-TensorRT (FP16, engine-cache on disk) via the `ONNXRUNTIME_EXECUTION_PROVIDERS`
-env var. The first run compiles + caches the TRT engine under
-TENSORRT_CACHE_PATH / MODEL_CACHE_DIR; subsequent runs reuse the cached plan.
+Workflow has exactly one block — the segmentation model. No annotators, no
+buffer strategies, no rate limiting.
 
-Controls (interactive mode):
-    i = watchdog report
-    t = terminate
-    p = pause stream
-    m = mute stream
-    r = resume stream
+The `--backend` flag (trt | onnx | torch) is parsed before importing
+`inference` and pins the auto-loader by setting
+`DISABLED_INFERENCE_MODELS_BACKENDS` to every backend except the chosen one,
+so the benchmark numbers correspond unambiguously to a single execution path.
+
+Defaults: rfdetr-seg-nano @ confidence 0.4 on the native TRT backend.
 """
+import argparse
 import os
 
+_ALL_BACKENDS = {
+    "torch",
+    "torch-script",
+    "onnx",
+    "trt",
+    "hugging-face",
+    "ultralytics",
+    "mediapipe",
+    "custom",
+}
+def _select_backend_from_argv() -> str:
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--backend", choices=("trt", "onnx", "torch"), default="trt")
+    args, _ = pre.parse_known_args()
+    return args.backend
+
+
+_BACKEND = _select_backend_from_argv()
 os.environ.setdefault(
     "ONNXRUNTIME_EXECUTION_PROVIDERS",
     "[TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider]",
 )
+os.environ["DISABLED_INFERENCE_MODELS_BACKENDS"] = ",".join(
+    sorted(_ALL_BACKENDS - {_BACKEND})
+)
 
-import argparse
-from threading import Thread
 from time import perf_counter
-from typing import List, Optional, Union
-
-import cv2
-import supervision as sv
 
 from inference import InferencePipeline
-from inference.core.interfaces.camera.entities import VideoFrame
-from inference.core.interfaces.camera.video_source import (
-    BufferConsumptionStrategy,
-    BufferFillingStrategy,
-)
-from inference.core.interfaces.stream.watchdog import (
-    BasePipelineWatchDog,
-    PipelineWatchDog,
-)
-from inference.core.utils.drawing import create_tiles
-
-MODEL_ID = "rfdetr-seg-nano"
-STOP = False
-HEADLESS = False
-FRAME_COUNT = 0
-START_TIME: Optional[float] = None
-FPS_MONITOR = sv.FPSMonitor()
 
 
-def build_workflow_specification(model_id: str, confidence: float) -> dict:
+def build_workflow(model_id: str, confidence: float) -> dict:
     return {
         "version": "1.0",
-        "inputs": [
-            {"type": "WorkflowImage", "name": "image"},
-        ],
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
         "steps": [
             {
-                "type": "roboflow_core/roboflow_instance_segmentation_model@v1",
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
                 "name": "segmentation",
                 "images": "$inputs.image",
                 "model_id": model_id,
-                "confidence": confidence,
-            },
-            {
-                "type": "roboflow_core/mask_visualization@v1",
-                "name": "mask_visualiser",
-                "predictions": "$steps.segmentation.predictions",
-                "image": "$inputs.image",
+                "confidence_mode": "custom",
+                "custom_confidence": confidence,
             },
         ],
         "outputs": [
@@ -78,166 +65,51 @@ def build_workflow_specification(model_id: str, confidence: float) -> dict:
                 "name": "predictions",
                 "selector": "$steps.segmentation.predictions",
             },
-            {
-                "type": "JsonField",
-                "name": "preview",
-                "selector": "$steps.mask_visualiser.image",
-            },
         ],
     }
 
+FRAME_COUNT = 0
+START_TIME = None
+PROGRESS_EVERY = 50
 
-def workflows_sink(
-    predictions: Union[dict, List[Optional[dict]]],
-    video_frames: Union[VideoFrame, List[Optional[VideoFrame]]],
-) -> None:
+
+def sink(predictions, _video_frames) -> None:
     global FRAME_COUNT, START_TIME
-    FPS_MONITOR.tick()
+    del _video_frames
     if not isinstance(predictions, list):
         predictions = [predictions]
-        video_frames = [video_frames]
-
-    images_to_show = []
-    for prediction, frame in zip(predictions, video_frames):
-        if prediction is None or frame is None:
-            continue
-        FRAME_COUNT += 1
-        if START_TIME is None:
-            START_TIME = perf_counter()
-
-        detections: sv.Detections = prediction["predictions"]
-        preview_field = prediction["preview"]
-        preview = (
-            preview_field.numpy_image
-            if hasattr(preview_field, "numpy_image")
-            else preview_field
-        )
-
-        if HEADLESS:
-            if FRAME_COUNT % 10 == 0 or FRAME_COUNT <= 3:
-                fps_value = (
-                    FPS_MONITOR.fps if hasattr(FPS_MONITOR, "fps") else FPS_MONITOR()
-                )
-                print(
-                    f"[frame {FRAME_COUNT}] detections={len(detections)} fps={fps_value:.2f}",
-                    flush=True,
-                )
-            continue
-        images_to_show.append(preview)
-
-    if HEADLESS or not images_to_show:
-        return
-
-    fps_value = FPS_MONITOR.fps if hasattr(FPS_MONITOR, "fps") else FPS_MONITOR()
-    tiles = create_tiles(images=images_to_show)
-    cv2.putText(
-        tiles,
-        f"FPS: {fps_value:.1f}",
-        (10, 30),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        1.0,
-        (0, 255, 0),
-        2,
-    )
-    cv2.imshow("RF-DETR nano seg (TRT)", tiles)
-    cv2.waitKey(1)
-    print(f"FPS: {fps_value}")
-
-
-def command_thread(pipeline: InferencePipeline, watchdog: PipelineWatchDog) -> None:
-    global STOP
-    while not STOP:
-        key = input()
-        if key == "i":
-            print(watchdog.get_report())
-        if key == "t":
-            pipeline.terminate()
-            STOP = True
-        elif key == "p":
-            pipeline.pause_stream()
-        elif key == "m":
-            pipeline.mute_stream()
-        elif key == "r":
-            pipeline.resume_stream()
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--video_reference",
-        required=True,
-        help="Video file path, RTSP URL, or integer camera id.",
-    )
-    parser.add_argument("--max_fps", type=float, default=None)
-    parser.add_argument("--confidence", type=float, default=0.4)
-    parser.add_argument("--model_id", default=MODEL_ID)
-    parser.add_argument(
-        "--headless",
-        action="store_true",
-        help="Skip cv2.imshow; log detection counts + FPS instead.",
-    )
-    parser.add_argument(
-        "--stream_source",
-        action="store_true",
-        help="Use RTSP-style buffer strategies (DROP_OLDEST / EAGER). "
-        "Leave off for video files — the default lets every frame through.",
-    )
-    return parser.parse_args()
+    FRAME_COUNT += sum(p is not None for p in predictions)
+    if START_TIME is None:
+        START_TIME = perf_counter()
+    if FRAME_COUNT % PROGRESS_EVERY == 0:
+        fps = FRAME_COUNT / (perf_counter() - START_TIME)
+        print(f"[progress] frames={FRAME_COUNT} fps={fps:.2f}", flush=True)
 
 
 def main() -> None:
-    global STOP, HEADLESS
-    args = parse_args()
-    HEADLESS = args.headless
-
-    try:
-        video_reference: Union[str, int] = int(args.video_reference)
-    except ValueError:
-        video_reference = args.video_reference
-
-    watchdog = BasePipelineWatchDog()
-    workflow_specification = build_workflow_specification(
-        model_id=args.model_id,
-        confidence=args.confidence,
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--video_reference", required=True)
+    parser.add_argument("--model_id", default="rfdetr-seg-nano")
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument(
+        "--backend",
+        choices=("trt", "onnx", "torch"),
+        default="trt",
+        help="inference-models backend (consumed pre-import via env var).",
     )
-    pipeline_kwargs = dict(
-        video_reference=video_reference,
-        workflow_specification=workflow_specification,
-        watchdog=watchdog,
-        on_prediction=workflows_sink,
-        max_fps=args.max_fps,
+    args = parser.parse_args()
+
+    pipeline = InferencePipeline.init_with_workflow(
+        video_reference=args.video_reference,
+        workflow_specification=build_workflow(args.model_id, args.confidence),
+        on_prediction=sink,
     )
-    if args.stream_source:
-        pipeline_kwargs["source_buffer_filling_strategy"] = (
-            BufferFillingStrategy.DROP_OLDEST
-        )
-        pipeline_kwargs["source_buffer_consumption_strategy"] = (
-            BufferConsumptionStrategy.EAGER
-        )
-    pipeline = InferencePipeline.init_with_workflow(**pipeline_kwargs)
-
-    control_thread: Optional[Thread] = None
-    if not HEADLESS:
-        control_thread = Thread(
-            target=command_thread, args=(pipeline, watchdog), daemon=True
-        )
-        control_thread.start()
-
     pipeline.start()
-    STOP = True
     pipeline.join()
 
-    if not HEADLESS:
-        cv2.destroyAllWindows()
-
-    elapsed = perf_counter() - START_TIME if START_TIME is not None else 0.0
-    avg_fps = (FRAME_COUNT - 1) / elapsed if elapsed > 0 and FRAME_COUNT > 1 else 0.0
-    window_fps = FPS_MONITOR.fps if hasattr(FPS_MONITOR, "fps") else FPS_MONITOR()
-    print(
-        f"DONE: processed {FRAME_COUNT} frames in {elapsed:.2f}s, "
-        f"avg FPS={avg_fps:.2f}, window FPS={window_fps:.2f}",
-        flush=True,
-    )
+    elapsed = perf_counter() - START_TIME if START_TIME else 0.0
+    fps = FRAME_COUNT / elapsed if elapsed > 0 else 0.0
+    print(f"frames={FRAME_COUNT} elapsed={elapsed:.2f}s fps={fps:.2f}")
 
 
 if __name__ == "__main__":

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -290,6 +290,22 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             **kwargs,
         )
         self.class_names = list(self._model.class_names)
+        # Depth-2 pipeline state. When RFDETR_PIPELINE_DEPTH=2, postprocess()
+        # returns frame N-1's response when called with frame N's detections.
+        # The pending slot holds refs to frame N-1's GPU scratch + done_event.
+        # CAVEATS (documented in PR):
+        #   - on_prediction(predictions, video_frame) callbacks receive
+        #     frame N-1's detections paired with frame N's video_frame
+        #     (1-frame skew). Imperceptible at 150+ FPS.
+        #   - Last frame's predictions are dropped unless flush() is called
+        #     explicitly (no plumbing from InferencePipeline to call it).
+        try:
+            self._pipeline_depth = int(os.getenv("RFDETR_PIPELINE_DEPTH", "1"))
+        except (TypeError, ValueError):
+            self._pipeline_depth = 1
+        if self._pipeline_depth < 1:
+            self._pipeline_depth = 1
+        self._pipeline_pending = None  # (det_ref, H, W, class_filter_tuple)
 
     def map_inference_kwargs(self, kwargs: dict) -> dict:
         pre_processing_overrides = PreProcessingOverrides(
@@ -319,6 +335,98 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
         return self._model.forward(img_in, **mapped_kwargs)
 
+    def _build_response_from_det(
+        self, det, H, W, class_filter
+    ) -> InstanceSegmentationInferenceResponse:
+        """Drain GPU scratch into a response. Factored out of postprocess so
+        the depth-2 path can defer it from frame N to frame N+1."""
+        combined_gpu = getattr(det, "_combined_gpu", None)
+        counter_gpu = getattr(det, "_counter_gpu", None)
+        done_event = getattr(det, "_postproc_done_event", None)
+        if (
+            combined_gpu is not None
+            and counter_gpu is not None
+            and done_event is not None
+            and det.mask.is_cuda
+        ):
+            device = combined_gpu.device
+            stream = torch.cuda.current_stream(device)
+            done_event.wait(stream)
+
+            counter_host = _get_pinned_buffer("counter", (1,), torch.int32)
+            counter_host.copy_(counter_gpu, non_blocking=True)
+            stream.synchronize()
+            n_survivors = int(counter_host[0].item())
+
+            if n_survivors == 0:
+                xyxy = np.empty((0, 4), dtype=np.int32)
+                confs = np.empty((0,), dtype=np.float32)
+                class_ids = np.empty((0,), dtype=np.int32)
+                masks = np.empty((0, 0, 0), dtype=np.uint8)
+            else:
+                mask_gpu = det.mask
+                combined_slice = combined_gpu[:n_survivors]
+                mask_slice = mask_gpu[:n_survivors]
+                combined_host = _get_pinned_buffer(
+                    "combined", combined_slice.shape, combined_slice.dtype
+                )
+                mask_host = _get_pinned_buffer(
+                    "mask", mask_slice.shape, mask_slice.dtype
+                )
+                combined_host.copy_(combined_slice, non_blocking=True)
+                mask_host.copy_(mask_slice, non_blocking=True)
+                stream.synchronize()
+                combined_cpu = combined_host.numpy()
+                xyxy = combined_cpu[:, :4]
+                confs = combined_cpu[:, 4].view(np.float32)
+                class_ids = combined_cpu[:, 5]
+                masks = mask_host.numpy()
+        elif combined_gpu is not None:
+            combined_cpu = combined_gpu.detach().cpu().numpy()
+            xyxy = combined_cpu[:, :4]
+            confs = combined_cpu[:, 4].view(np.float32)
+            class_ids = combined_cpu[:, 5]
+            masks = det.mask.detach().cpu().numpy()
+        else:
+            xyxy = det.xyxy.detach().cpu().numpy()
+            confs = det.confidence.detach().cpu().numpy()
+            class_ids = det.class_id.detach().cpu().numpy()
+            masks = det.mask.detach().cpu().numpy()
+        polys = masks2poly(masks)
+
+        preds: List[InstanceSegmentationPrediction] = []
+        for (x1, y1, x2, y2), mask_as_poly, conf, class_id in zip(
+            xyxy, polys, confs, class_ids
+        ):
+            cx = (float(x1) + float(x2)) / 2.0
+            cy = (float(y1) + float(y2)) / 2.0
+            w = float(x2) - float(x1)
+            h = float(y2) - float(y1)
+            class_id_int = int(class_id)
+            class_name = (
+                self.class_names[class_id_int]
+                if 0 <= class_id_int < len(self.class_names)
+                else str(class_id_int)
+            )
+            if class_filter and class_name not in class_filter:
+                continue
+            preds.append(
+                InstanceSegmentationPrediction(
+                    x=cx,
+                    y=cy,
+                    width=w,
+                    height=h,
+                    confidence=float(conf),
+                    points=[Point(x=p[0], y=p[1]) for p in mask_as_poly],
+                    **{"class": class_name},
+                    class_id=class_id_int,
+                )
+            )
+        return InstanceSegmentationInferenceResponse(
+            predictions=preds,
+            image=InferenceResponseImage(width=W, height=H),
+        )
+
     def postprocess(
         self,
         predictions: List[InstanceDetections],
@@ -329,115 +437,47 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         detections_list = self._model.post_process(
             predictions, preprocess_return_metadata, **mapped_kwargs
         )
-        gpu_fastpath = os.getenv("RFDETR_GPU_POSTPROCESS", "true").lower() in ("true", "1")
+
+        if self._pipeline_depth >= 2 and len(detections_list) == 1:
+            # Depth-2 path: only engages for batch=1 workflow calls. Push
+            # current frame's det+meta as the new pending; return the prior
+            # pending's materialized response. First call yields an empty
+            # response because there's no prior work. The prior frame's GPU
+            # scratch was written to a DIFFERENT ping-pong slot (selected by
+            # triton_rfdetr_fullpost's _SLOT_COUNTER), so it's still safe to
+            # drain while the current frame's Triton kernels run on the other
+            # slot.
+            preproc_metadata = preprocess_return_metadata[0]
+            det = detections_list[0]
+            H = preproc_metadata.original_size.height
+            W = preproc_metadata.original_size.width
+            class_filter = kwargs.get("class_filter")
+
+            pending = self._pipeline_pending
+            self._pipeline_pending = (det, H, W, class_filter)
+            if pending is None:
+                # First call — no prior frame to drain. Return an empty
+                # response; sink will see frame 0 with nothing.
+                return [
+                    InstanceSegmentationInferenceResponse(
+                        predictions=[],
+                        image=InferenceResponseImage(width=W, height=H),
+                    )
+                ]
+            prev_det, prev_H, prev_W, prev_class_filter = pending
+            return [
+                self._build_response_from_det(
+                    prev_det, prev_H, prev_W, prev_class_filter
+                )
+            ]
 
         responses: List[InstanceSegmentationInferenceResponse] = []
         for preproc_metadata, det in zip(preprocess_return_metadata, detections_list):
             H = preproc_metadata.original_size.height
             W = preproc_metadata.original_size.width
-
-            # Fast path: triton_rfdetr_fullpost returns UNSLICED buffers plus
-            # a GPU counter tensor and a done-event. We:
-            #   (1) wait the done-event on the current stream so post_process
-            #       stream writes are visible,
-            #   (2) async-DtoH the 4-byte counter into a pinned host buffer
-            #       and sync once — this replaces the old in-kernel
-            #       counter.item() that blocked the postproc stream,
-            #   (3) slice combined/mask to n_survivors and async-DtoH both,
-            #       then sync.
-            combined_gpu = getattr(det, "_combined_gpu", None)
-            counter_gpu = getattr(det, "_counter_gpu", None)
-            done_event = getattr(det, "_postproc_done_event", None)
-            if (
-                combined_gpu is not None
-                and counter_gpu is not None
-                and done_event is not None
-                and det.mask.is_cuda
-            ):
-                device = combined_gpu.device
-                stream = torch.cuda.current_stream(device)
-                done_event.wait(stream)
-
-                counter_host = _get_pinned_buffer("counter", (1,), torch.int32)
-                counter_host.copy_(counter_gpu, non_blocking=True)
-                stream.synchronize()
-                n_survivors = int(counter_host[0].item())
-
-                if n_survivors == 0:
-                    xyxy = np.empty((0, 4), dtype=np.int32)
-                    confs = np.empty((0,), dtype=np.float32)
-                    class_ids = np.empty((0,), dtype=np.int32)
-                    masks = np.empty((0, 0, 0), dtype=np.uint8)
-                else:
-                    mask_gpu = det.mask
-                    combined_slice = combined_gpu[:n_survivors]
-                    mask_slice = mask_gpu[:n_survivors]
-                    combined_host = _get_pinned_buffer(
-                        "combined", combined_slice.shape, combined_slice.dtype
-                    )
-                    mask_host = _get_pinned_buffer(
-                        "mask", mask_slice.shape, mask_slice.dtype
-                    )
-                    combined_host.copy_(combined_slice, non_blocking=True)
-                    mask_host.copy_(mask_slice, non_blocking=True)
-                    stream.synchronize()
-                    combined_cpu = combined_host.numpy()
-                    xyxy = combined_cpu[:, :4]
-                    confs = combined_cpu[:, 4].view(np.float32)
-                    class_ids = combined_cpu[:, 5]
-                    masks = mask_host.numpy()
-            elif combined_gpu is not None:
-                combined_cpu = combined_gpu.detach().cpu().numpy()
-                xyxy = combined_cpu[:, :4]
-                confs = combined_cpu[:, 4].view(np.float32)
-                class_ids = combined_cpu[:, 5]
-                masks = det.mask.detach().cpu().numpy()
-            else:
-                xyxy = det.xyxy.detach().cpu().numpy()
-                confs = det.confidence.detach().cpu().numpy()
-                class_ids = det.class_id.detach().cpu().numpy()
-                masks = det.mask.detach().cpu().numpy()
-            polys = masks2poly(masks)
-
-            predictions: List[InstanceSegmentationPrediction] = []
-
-            for (x1, y1, x2, y2), mask_as_poly, conf, class_id in zip(
-                xyxy, polys, confs, class_ids
-            ):
-                cx = (float(x1) + float(x2)) / 2.0
-                cy = (float(y1) + float(y2)) / 2.0
-                w = float(x2) - float(x1)
-                h = float(y2) - float(y1)
-                class_id_int = int(class_id)
-                class_name = (
-                    self.class_names[class_id_int]
-                    if 0 <= class_id_int < len(self.class_names)
-                    else str(class_id_int)
-                )
-                if (
-                    kwargs.get("class_filter")
-                    and class_name not in kwargs["class_filter"]
-                ):
-                    continue
-                predictions.append(
-                    InstanceSegmentationPrediction(
-                        x=cx,
-                        y=cy,
-                        width=w,
-                        height=h,
-                        confidence=float(conf),
-                        points=[
-                            Point(x=point[0], y=point[1]) for point in mask_as_poly
-                        ],
-                        **{"class": class_name},
-                        class_id=class_id_int,
-                    )
-                )
-
             responses.append(
-                InstanceSegmentationInferenceResponse(
-                    predictions=predictions,
-                    image=InferenceResponseImage(width=W, height=H),
+                self._build_response_from_det(
+                    det, H, W, kwargs.get("class_filter")
                 )
             )
         return responses

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import os
 from io import BytesIO
 from time import perf_counter
 from typing import Any, List, Optional, Tuple, Union
@@ -308,17 +309,45 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         detections_list = self._model.post_process(
             predictions, preprocess_return_metadata, **mapped_kwargs
         )
+        gpu_fastpath = os.getenv("RFDETR_GPU_POSTPROCESS", "true").lower() in ("true", "1")
 
         responses: List[InstanceSegmentationInferenceResponse] = []
         for preproc_metadata, det in zip(preprocess_return_metadata, detections_list):
             H = preproc_metadata.original_size.height
             W = preproc_metadata.original_size.width
 
-            xyxy = det.xyxy.detach().cpu().numpy()
-            confs = det.confidence.detach().cpu().numpy()
-            masks = det.mask.detach().cpu().numpy()
-            polys = masks2poly(masks)
-            class_ids = det.class_id.detach().cpu().numpy()
+            if gpu_fastpath and det.mask.is_cuda and det.mask.numel() > 0:
+                mask_any_gpu = det.mask.any(dim=(1, 2))
+                xyxy = det.xyxy.detach().cpu().numpy()
+                confs = det.confidence.detach().cpu().numpy()
+                class_ids = det.class_id.detach().cpu().numpy()
+                mask_any = mask_any_gpu.cpu().numpy()
+                nonempty_idx = mask_any.nonzero()[0]
+                if nonempty_idx.size > 0:
+                    masks_nonempty = (
+                        det.mask[torch.as_tensor(nonempty_idx, device=det.mask.device)]
+                        .detach()
+                        .cpu()
+                        .numpy()
+                    )
+                    polys_nonempty = masks2poly(masks_nonempty)
+                else:
+                    polys_nonempty = []
+                empty_poly = [np.zeros((0, 2), dtype=np.float32)]
+                polys = []
+                j = 0
+                for has in mask_any:
+                    if has:
+                        polys.append(polys_nonempty[j])
+                        j += 1
+                    else:
+                        polys.append(empty_poly)
+            else:
+                xyxy = det.xyxy.detach().cpu().numpy()
+                confs = det.confidence.detach().cpu().numpy()
+                masks = det.mask.detach().cpu().numpy()
+                polys = masks2poly(masks)
+                class_ids = det.class_id.detach().cpu().numpy()
 
             predictions: List[InstanceSegmentationPrediction] = []
 

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -9,6 +9,26 @@ import numpy as np
 import torch
 from PIL import Image, ImageDraw, ImageFont
 
+
+# Cache of pinned host buffers for async DtoH, keyed by (name, dtype).
+# Pinned memory lets torch's copy_(non_blocking=True) actually run async.
+# We grow on first use and reuse thereafter; buffer is sliced to the
+# current n_survivors for each copy.
+_PINNED_HOST_BUFFERS: dict = {}
+
+
+def _get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
+    shape = tuple(int(s) for s in shape)
+    key = (name, dtype)
+    buf = _PINNED_HOST_BUFFERS.get(key)
+    if buf is not None:
+        # Reuse if the cached buffer is at least as large in every dim.
+        if all(buf.shape[i] >= shape[i] for i in range(len(shape))):
+            return buf[tuple(slice(0, s) for s in shape)]
+    buf = torch.empty(shape, dtype=dtype, pin_memory=True)
+    _PINNED_HOST_BUFFERS[key] = buf
+    return buf
+
 from inference.core.entities.requests import (
     ClassificationInferenceRequest,
     InferenceRequest,
@@ -316,38 +336,68 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             H = preproc_metadata.original_size.height
             W = preproc_metadata.original_size.width
 
-            if gpu_fastpath and det.mask.is_cuda and det.mask.numel() > 0:
-                mask_any_gpu = det.mask.any(dim=(1, 2))
-                xyxy = det.xyxy.detach().cpu().numpy()
-                confs = det.confidence.detach().cpu().numpy()
-                class_ids = det.class_id.detach().cpu().numpy()
-                mask_any = mask_any_gpu.cpu().numpy()
-                nonempty_idx = mask_any.nonzero()[0]
-                if nonempty_idx.size > 0:
-                    masks_nonempty = (
-                        det.mask[torch.as_tensor(nonempty_idx, device=det.mask.device)]
-                        .detach()
-                        .cpu()
-                        .numpy()
-                    )
-                    polys_nonempty = masks2poly(masks_nonempty)
+            # Fast path: triton_rfdetr_fullpost returns UNSLICED buffers plus
+            # a GPU counter tensor and a done-event. We:
+            #   (1) wait the done-event on the current stream so post_process
+            #       stream writes are visible,
+            #   (2) async-DtoH the 4-byte counter into a pinned host buffer
+            #       and sync once — this replaces the old in-kernel
+            #       counter.item() that blocked the postproc stream,
+            #   (3) slice combined/mask to n_survivors and async-DtoH both,
+            #       then sync.
+            combined_gpu = getattr(det, "_combined_gpu", None)
+            counter_gpu = getattr(det, "_counter_gpu", None)
+            done_event = getattr(det, "_postproc_done_event", None)
+            if (
+                combined_gpu is not None
+                and counter_gpu is not None
+                and done_event is not None
+                and det.mask.is_cuda
+            ):
+                device = combined_gpu.device
+                stream = torch.cuda.current_stream(device)
+                done_event.wait(stream)
+
+                counter_host = _get_pinned_buffer("counter", (1,), torch.int32)
+                counter_host.copy_(counter_gpu, non_blocking=True)
+                stream.synchronize()
+                n_survivors = int(counter_host[0].item())
+
+                if n_survivors == 0:
+                    xyxy = np.empty((0, 4), dtype=np.int32)
+                    confs = np.empty((0,), dtype=np.float32)
+                    class_ids = np.empty((0,), dtype=np.int32)
+                    masks = np.empty((0, 0, 0), dtype=np.uint8)
                 else:
-                    polys_nonempty = []
-                empty_poly = [np.zeros((0, 2), dtype=np.float32)]
-                polys = []
-                j = 0
-                for has in mask_any:
-                    if has:
-                        polys.append(polys_nonempty[j])
-                        j += 1
-                    else:
-                        polys.append(empty_poly)
+                    mask_gpu = det.mask
+                    combined_slice = combined_gpu[:n_survivors]
+                    mask_slice = mask_gpu[:n_survivors]
+                    combined_host = _get_pinned_buffer(
+                        "combined", combined_slice.shape, combined_slice.dtype
+                    )
+                    mask_host = _get_pinned_buffer(
+                        "mask", mask_slice.shape, mask_slice.dtype
+                    )
+                    combined_host.copy_(combined_slice, non_blocking=True)
+                    mask_host.copy_(mask_slice, non_blocking=True)
+                    stream.synchronize()
+                    combined_cpu = combined_host.numpy()
+                    xyxy = combined_cpu[:, :4]
+                    confs = combined_cpu[:, 4].view(np.float32)
+                    class_ids = combined_cpu[:, 5]
+                    masks = mask_host.numpy()
+            elif combined_gpu is not None:
+                combined_cpu = combined_gpu.detach().cpu().numpy()
+                xyxy = combined_cpu[:, :4]
+                confs = combined_cpu[:, 4].view(np.float32)
+                class_ids = combined_cpu[:, 5]
+                masks = det.mask.detach().cpu().numpy()
             else:
                 xyxy = det.xyxy.detach().cpu().numpy()
                 confs = det.confidence.detach().cpu().numpy()
-                masks = det.mask.detach().cpu().numpy()
-                polys = masks2poly(masks)
                 class_ids = det.class_id.detach().cpu().numpy()
+                masks = det.mask.detach().cpu().numpy()
+            polys = masks2poly(masks)
 
             predictions: List[InstanceSegmentationPrediction] = []
 

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -47,12 +47,36 @@ from inference.core.utils.onnx import (
     run_session_via_iobinding,
 )
 from inference.core.utils.postprocess import mask2poly
+from inference.core.utils.environment import str2bool
 from inference.core.utils.preprocess import letterbox_image
 
 if USE_PYTORCH_FOR_PREPROCESSING:
     import torch
 
     CUDA_IS_AVAILABLE = torch.cuda.is_available()
+
+RFDETR_USE_TRITON_PREPROC = str2bool(os.getenv("RFDETR_USE_TRITON_PREPROC", False))
+
+if RFDETR_USE_TRITON_PREPROC:
+    try:
+        import torch
+
+        from inference.models.rfdetr.triton_preprocess import (
+            TRITON_AVAILABLE,
+            triton_preprocess_rfdetr,
+        )
+
+        _TRITON_PREPROC_READY = TRITON_AVAILABLE and torch.cuda.is_available()
+    except Exception as _triton_err:  # pragma: no cover
+        logger.warning(
+            "RFDETR_USE_TRITON_PREPROC=1 but triton preprocess unavailable: %s",
+            _triton_err,
+        )
+        _TRITON_PREPROC_READY = False
+        triton_preprocess_rfdetr = None
+else:
+    _TRITON_PREPROC_READY = False
+    triton_preprocess_rfdetr = None
 
 ROBOFLOW_BACKGROUND_CLASS = "background_class83422"
 
@@ -73,6 +97,25 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
     preprocess_means = [0.485, 0.456, 0.406]
     preprocess_stds = [0.229, 0.224, 0.225]
 
+    _preproc_cache_initialized: bool = False
+
+    def _ensure_preproc_cache(self, device) -> None:
+        if self._preproc_cache_initialized:
+            return
+        means = torch.tensor(self.preprocess_means, device=device, dtype=torch.float32)
+        stds = torch.tensor(self.preprocess_stds, device=device, dtype=torch.float32)
+        self._preproc_scale_gpu = (1.0 / (255.0 * stds)).view(1, 3, 1, 1).contiguous()
+        self._preproc_offset_gpu = (-means / stds).view(1, 3, 1, 1).contiguous()
+        self._input_buffer = torch.empty(
+            (1, 3, self.img_size_h, self.img_size_w),
+            dtype=torch.float32,
+            device=device,
+        )
+        self._preproc_bgr2rgb_idx = torch.tensor(
+            [2, 1, 0], device=device, dtype=torch.long
+        )
+        self._preproc_cache_initialized = True
+
     @property
     def weights_file(self) -> str:
         """Gets the weights file for the RFDETR model.
@@ -81,6 +124,38 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             str: Path to the ONNX weights file.
         """
         return "weights.onnx"
+
+    def _try_triton_preprocess(
+        self, image: Any
+    ) -> Optional[Tuple["torch.Tensor", Tuple[int, int]]]:
+        if isinstance(image, np.ndarray):
+            src = image
+        elif isinstance(image, InferenceRequestImage):
+            try:
+                src, _ = load_image(image, disable_preproc_auto_orient=True)
+            except Exception:
+                return None
+            if not isinstance(src, np.ndarray):
+                return None
+        else:
+            return None
+
+        if src.dtype != np.uint8 or src.ndim != 3 or src.shape[2] != 3:
+            return None
+        if self._needs_nonsquare_preproc:
+            return None
+
+        orig_h, orig_w = src.shape[0], src.shape[1]
+        src_gpu = torch.from_numpy(np.ascontiguousarray(src)).cuda(non_blocking=True)
+        out = triton_preprocess_rfdetr(
+            src_gpu,
+            target_h=self.img_size_h,
+            target_w=self.img_size_w,
+            means=tuple(self.preprocess_means),
+            stds=tuple(self.preprocess_stds),
+            pad_color=114,
+        )
+        return out, (orig_h, orig_w)
 
     def preproc_image(
         self,
@@ -103,6 +178,15 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         Returns:
             Tuple[np.ndarray, Tuple[int, int]]: A tuple containing a numpy array of the preprocessed image pixel data and a tuple of the images original size.
         """
+        if (
+            _TRITON_PREPROC_READY
+            and USE_PYTORCH_FOR_PREPROCESSING
+            and self.resize_method in ("Fit (grey edges) in", "Stretch to")
+        ):
+            triton_out = self._try_triton_preprocess(image)
+            if triton_out is not None:
+                return triton_out
+
         if isinstance(image, Image.Image) and USE_PYTORCH_FOR_PREPROCESSING:
             if CUDA_IS_AVAILABLE:
                 np_image = torch.from_numpy(np.asarray(image, copy=False)).cuda()
@@ -135,15 +219,12 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             )
             preprocessed_image = preprocessed_image.float()
 
-            preprocessed_image /= 255.0
-
-            means = torch.tensor(
-                self.preprocess_means, device=preprocessed_image.device
-            ).view(3, 1, 1)
-            stds = torch.tensor(
-                self.preprocess_stds, device=preprocessed_image.device
-            ).view(3, 1, 1)
-            preprocessed_image = (preprocessed_image - means) / stds
+            self._ensure_preproc_cache(preprocessed_image.device)
+            preprocessed_image = torch.addcmul(
+                self._preproc_offset_gpu,
+                preprocessed_image,
+                self._preproc_scale_gpu,
+            )
         else:
             preprocessed_image = preprocessed_image.astype(np.float32)
             preprocessed_image /= 255.0
@@ -224,14 +305,22 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             if isinstance(resized, np.ndarray):
                 resized = cv2.cvtColor(resized, cv2.COLOR_BGR2RGB)
             else:
-                resized = resized[:, [2, 1, 0], :, :]
+                resized = resized.index_select(1, self._preproc_bgr2rgb_idx)
 
         if isinstance(resized, np.ndarray):
             img_in = np.transpose(resized, (2, 0, 1))
             img_in = img_in.astype(np.float32)
             img_in = np.expand_dims(img_in, axis=0)
         elif USE_PYTORCH_FOR_PREPROCESSING:
-            img_in = resized.float()
+            if (
+                not self.batching_enabled
+                and self._preproc_cache_initialized
+                and resized.shape == self._input_buffer.shape
+            ):
+                self._input_buffer.copy_(resized, non_blocking=True)
+                img_in = self._input_buffer
+            else:
+                img_in = resized
         else:
             raise ValueError(
                 f"Received an image of unknown type, {type(resized)}; "

--- a/inference/models/rfdetr/triton_preprocess.py
+++ b/inference/models/rfdetr/triton_preprocess.py
@@ -1,0 +1,272 @@
+"""Fused Triton preprocessing kernel for RF-DETR.
+
+Combines letterbox resize (bilinear) + BGR->RGB + normalize + CHW/NCHW
+layout in a single CUDA kernel launch.
+
+Reference (torch/numpy) pipeline this replaces:
+    from_numpy(uint8 HWC BGR).cuda()
+        -> permute(HWC -> CHW)
+        -> .contiguous().float() / 255
+        -> subtract means / divide stds
+        -> interpolate (bilinear resize keeping aspect ratio)
+        -> pad with grey 114 (letterbox)
+        -> BGR -> RGB channel swap
+        -> unsqueeze(0)
+
+Each of those torch ops launches at least one CUDA kernel; fusing them
+eliminates that overhead for small images where per-launch cost dominates.
+"""
+
+from typing import Optional, Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dep
+    triton = None
+    tl = None
+    TRITON_AVAILABLE = False
+
+
+if TRITON_AVAILABLE:
+
+    @triton.jit
+    def _rfdetr_preprocess_kernel(
+        src_ptr,
+        dst_ptr,
+        src_h,
+        src_w,
+        src_stride_h,
+        src_stride_w,
+        target_h,
+        target_w,
+        scale,
+        pad_x,
+        pad_y,
+        mean_r,
+        mean_g,
+        mean_b,
+        std_r,
+        std_g,
+        std_b,
+        pad_r_norm,
+        pad_g_norm,
+        pad_b_norm,
+        dst_stride_c,
+        dst_stride_h,
+        BLOCK_H: tl.constexpr,
+        BLOCK_W: tl.constexpr,
+    ):
+        """One kernel per (tile_y, tile_x) over the target image; writes all
+        3 channels in a single pass.
+
+        Src layout: uint8 HWC BGR, strides are (src_stride_h, src_stride_w, 1).
+        Dst layout: fp32 (1, 3, target_h, target_w) contiguous CHW RGB.
+        """
+        pid_y = tl.program_id(0)
+        pid_x = tl.program_id(1)
+
+        offs_y = pid_y * BLOCK_H + tl.arange(0, BLOCK_H)
+        offs_x = pid_x * BLOCK_W + tl.arange(0, BLOCK_W)
+        mask_y = offs_y < target_h
+        mask_x = offs_x < target_w
+        mask = mask_y[:, None] & mask_x[None, :]
+
+        # Inverse letterbox: map output pixel -> source pixel coordinate.
+        src_y_f = (offs_y.to(tl.float32) + 0.5 - pad_y) / scale - 0.5
+        src_x_f = (offs_x.to(tl.float32) + 0.5 - pad_x) / scale - 0.5
+
+        src_y_f_2d = src_y_f[:, None]
+        src_x_f_2d = src_x_f[None, :]
+
+        y0 = tl.floor(src_y_f_2d).to(tl.int32)
+        x0 = tl.floor(src_x_f_2d).to(tl.int32)
+        y1 = y0 + 1
+        x1 = x0 + 1
+
+        dy = src_y_f_2d - y0.to(tl.float32)
+        dx = src_x_f_2d - x0.to(tl.float32)
+
+        # Clamp to source bounds for the gather; we mask the fully-out-of-bounds
+        # tiles at the end (pad region).
+        y0c = tl.maximum(tl.minimum(y0, src_h - 1), 0)
+        y1c = tl.maximum(tl.minimum(y1, src_h - 1), 0)
+        x0c = tl.maximum(tl.minimum(x0, src_w - 1), 0)
+        x1c = tl.maximum(tl.minimum(x1, src_w - 1), 0)
+
+        # Output-pixel-in-pad-region iff the *center* maps outside the resized
+        # image footprint. Using src_y_f_2d (post-center shift) is fine since
+        # we compare against [-0.5, src_h - 0.5].
+        in_bounds = (
+            (src_y_f_2d >= -0.5)
+            & (src_y_f_2d <= src_h.to(tl.float32) - 0.5)
+            & (src_x_f_2d >= -0.5)
+            & (src_x_f_2d <= src_w.to(tl.float32) - 0.5)
+        )
+
+        # Gather 4 corners for all three channels. Source is HWC BGR
+        # (channel 0 = B, channel 1 = G, channel 2 = R); output CHW RGB.
+        # Triton doesn't support nested function defs, so we inline the
+        # gather for each channel.
+        base_00 = y0c * src_stride_h + x0c * src_stride_w
+        base_01 = y0c * src_stride_h + x1c * src_stride_w
+        base_10 = y1c * src_stride_h + x0c * src_stride_w
+        base_11 = y1c * src_stride_h + x1c * src_stride_w
+
+        w_tl = (1.0 - dy) * (1.0 - dx)
+        w_tr = (1.0 - dy) * dx
+        w_bl = dy * (1.0 - dx)
+        w_br = dy * dx
+
+        # Channel 0 (B)
+        p00_b = tl.load(src_ptr + base_00 + 0, mask=mask, other=0).to(tl.float32)
+        p01_b = tl.load(src_ptr + base_01 + 0, mask=mask, other=0).to(tl.float32)
+        p10_b = tl.load(src_ptr + base_10 + 0, mask=mask, other=0).to(tl.float32)
+        p11_b = tl.load(src_ptr + base_11 + 0, mask=mask, other=0).to(tl.float32)
+        b_val = p00_b * w_tl + p01_b * w_tr + p10_b * w_bl + p11_b * w_br
+
+        # Channel 1 (G)
+        p00_g = tl.load(src_ptr + base_00 + 1, mask=mask, other=0).to(tl.float32)
+        p01_g = tl.load(src_ptr + base_01 + 1, mask=mask, other=0).to(tl.float32)
+        p10_g = tl.load(src_ptr + base_10 + 1, mask=mask, other=0).to(tl.float32)
+        p11_g = tl.load(src_ptr + base_11 + 1, mask=mask, other=0).to(tl.float32)
+        g_val = p00_g * w_tl + p01_g * w_tr + p10_g * w_bl + p11_g * w_br
+
+        # Channel 2 (R)
+        p00_r = tl.load(src_ptr + base_00 + 2, mask=mask, other=0).to(tl.float32)
+        p01_r = tl.load(src_ptr + base_01 + 2, mask=mask, other=0).to(tl.float32)
+        p10_r = tl.load(src_ptr + base_10 + 2, mask=mask, other=0).to(tl.float32)
+        p11_r = tl.load(src_ptr + base_11 + 2, mask=mask, other=0).to(tl.float32)
+        r_val = p00_r * w_tl + p01_r * w_tr + p10_r * w_bl + p11_r * w_br
+
+        r_norm = (r_val / 255.0 - mean_r) / std_r
+        g_norm = (g_val / 255.0 - mean_g) / std_g
+        b_norm = (b_val / 255.0 - mean_b) / std_b
+
+        r_out = tl.where(in_bounds, r_norm, pad_r_norm)
+        g_out = tl.where(in_bounds, g_norm, pad_g_norm)
+        b_out = tl.where(in_bounds, b_norm, pad_b_norm)
+
+        out_row_offsets = offs_y[:, None] * dst_stride_h + offs_x[None, :]
+        tl.store(dst_ptr + 0 * dst_stride_c + out_row_offsets, r_out, mask=mask)
+        tl.store(dst_ptr + 1 * dst_stride_c + out_row_offsets, g_out, mask=mask)
+        tl.store(dst_ptr + 2 * dst_stride_c + out_row_offsets, b_out, mask=mask)
+
+
+def triton_preprocess_rfdetr(
+    src: torch.Tensor,
+    target_h: int,
+    target_w: int,
+    means: Tuple[float, float, float] = (0.485, 0.456, 0.406),
+    stds: Tuple[float, float, float] = (0.229, 0.224, 0.225),
+    pad_color: int = 114,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Fused preprocess: uint8 HWC BGR -> fp32 (1,3,H,W) CHW RGB normalized
+    with letterbox.
+
+    Args:
+        src: uint8 tensor of shape (H, W, 3) on CUDA, BGR channel order
+            (as produced by cv2.imread / VideoFrame.image).
+        target_h, target_w: output spatial dims.
+        means, stds: imagenet normalization in RGB order.
+        pad_color: uint8 value used in each channel for letterbox padding
+            (applied *before* normalization). Default 114 matches RF-DETR
+            "Fit (grey edges) in".
+        out: optional preallocated fp32 tensor of shape (1, 3, target_h,
+            target_w) to write into.
+
+    Returns:
+        fp32 tensor of shape (1, 3, target_h, target_w) on the same device
+        as src.
+    """
+    if not TRITON_AVAILABLE:
+        raise RuntimeError(
+            "triton is not installed; cannot run triton_preprocess_rfdetr. "
+            "Install the optional 'triton-preproc' extra."
+        )
+    if not src.is_cuda:
+        raise ValueError(
+            f"triton_preprocess_rfdetr requires a CUDA tensor, got device={src.device}"
+        )
+    if src.dtype != torch.uint8:
+        raise ValueError(
+            f"triton_preprocess_rfdetr expects uint8 input, got dtype={src.dtype}"
+        )
+    if src.ndim != 3 or src.shape[2] != 3:
+        raise ValueError(
+            f"triton_preprocess_rfdetr expects HWC 3-channel input, got shape={tuple(src.shape)}"
+        )
+
+    src = src.contiguous()
+    src_h, src_w = int(src.shape[0]), int(src.shape[1])
+    # HWC strides: contiguous => (W*3, 3, 1). We pass (row_stride, col_stride)
+    # in elements (uint8).
+    src_stride_h = int(src.stride(0))
+    src_stride_w = int(src.stride(1))
+
+    scale = min(target_h / src_h, target_w / src_w)
+    scaled_h = int(src_h * scale)
+    scaled_w = int(src_w * scale)
+    pad_x = (target_w - scaled_w) / 2.0
+    pad_y = (target_h - scaled_h) / 2.0
+
+    if out is None:
+        out = torch.empty(
+            (1, 3, target_h, target_w), dtype=torch.float32, device=src.device
+        )
+    else:
+        if tuple(out.shape) != (1, 3, target_h, target_w):
+            raise ValueError(
+                f"out has shape {tuple(out.shape)}, expected (1, 3, {target_h}, {target_w})"
+            )
+        if out.dtype != torch.float32:
+            raise ValueError(f"out must be float32, got {out.dtype}")
+        if not out.is_cuda or out.device != src.device:
+            raise ValueError("out must be a CUDA tensor on the same device as src")
+
+    # (1,3,H,W) contiguous => per-channel plane stride is H*W, row stride is W.
+    dst_stride_c = target_h * target_w
+    dst_stride_h = target_w
+
+    pad_norm_r = (pad_color / 255.0 - means[0]) / stds[0]
+    pad_norm_g = (pad_color / 255.0 - means[1]) / stds[1]
+    pad_norm_b = (pad_color / 255.0 - means[2]) / stds[2]
+
+    BLOCK_H = 16
+    BLOCK_W = 16
+    grid = (
+        (target_h + BLOCK_H - 1) // BLOCK_H,
+        (target_w + BLOCK_W - 1) // BLOCK_W,
+    )
+    _rfdetr_preprocess_kernel[grid](
+        src,
+        out,
+        src_h,
+        src_w,
+        src_stride_h,
+        src_stride_w,
+        target_h,
+        target_w,
+        float(scale),
+        float(pad_x),
+        float(pad_y),
+        float(means[0]),
+        float(means[1]),
+        float(means[2]),
+        float(stds[0]),
+        float(stds[1]),
+        float(stds[2]),
+        float(pad_norm_r),
+        float(pad_norm_g),
+        float(pad_norm_b),
+        dst_stride_c,
+        dst_stride_h,
+        BLOCK_H=BLOCK_H,
+        BLOCK_W=BLOCK_W,
+    )
+    return out

--- a/inference_models/inference_models/models/common/trt.py
+++ b/inference_models/inference_models/models/common/trt.py
@@ -78,6 +78,10 @@ class TRTCudaGraphState:
     input_buffer: torch.Tensor
     output_buffers: List[torch.Tensor]
     execution_context: trt.IExecutionContext
+    # Consumers of output_buffers can record into this event; the next graph
+    # replay will wait on it to avoid overwriting the previous frame's outputs.
+    # None until first consumer records an event.
+    consumer_done_event: Optional["torch.cuda.Event"] = None
 
 
 class TRTCudaGraphCache:
@@ -571,7 +575,17 @@ def infer_from_trt_engine(
             outputs=outputs,
             trt_cuda_graph_cache=trt_cuda_graph_cache,
         )
-    stream.synchronize()
+    # Graph-replay path: record the event on the graph's own stream so
+    # downstream can wait on the correct stream (the graph captures on a
+    # dedicated stream, not `stream`). Non-graph path: record on `stream`.
+    if hasattr(results[0], "_trt_graph_state"):
+        graph_state = results[0]._trt_graph_state
+        produce_event = torch.cuda.Event()
+        produce_event.record(graph_state.cuda_stream)
+    else:
+        produce_event = torch.cuda.Event()
+        produce_event.record(stream)
+    results[0]._trt_produce_event = produce_event
     return results
 
 
@@ -692,12 +706,20 @@ def _execute_trt_engine(
         if cache_key not in trt_cuda_graph_cache:
             LOGGER.debug("Capturing CUDA graph for shape %s", input_shape)
 
+            # If the caller hands us a stable pre-allocated buffer and
+            # promises to keep writing in-place to it, we can bake its
+            # address directly into the graph and skip the per-frame DtoD
+            # copy. Marker attribute set by the model's pre_process path.
+            use_external = getattr(
+                pre_processed_images, "_trt_reuse_as_input_buffer", False
+            )
             results, trt_cuda_graph = _capture_cuda_graph(
                 pre_processed_images=pre_processed_images,
                 engine=engine,
                 device=device,
                 input_name=input_name,
                 outputs=outputs,
+                use_pre_processed_images_as_input_buffer=bool(use_external),
             )
             trt_cuda_graph_cache[cache_key] = trt_cuda_graph
             return results
@@ -705,11 +727,24 @@ def _execute_trt_engine(
         else:
             trt_cuda_graph_state = trt_cuda_graph_cache[cache_key]
             stream = trt_cuda_graph_state.cuda_stream
+            # Before re-running the graph, make sure any consumer of the
+            # previous frame's outputs is done. Post-process callers that read
+            # the output buffers directly must record into consumer_done_event.
+            consumer_done = trt_cuda_graph_state.consumer_done_event
+            if consumer_done is not None:
+                consumer_done.wait(stream)
             with torch.cuda.stream(stream):
-                trt_cuda_graph_state.input_buffer.copy_(pre_processed_images)
+                # Skip the DtoD copy if the caller is writing in-place to
+                # the graph's own input buffer (input_buffer is the same
+                # torch.Tensor object as pre_processed_images).
+                if trt_cuda_graph_state.input_buffer.data_ptr() != pre_processed_images.data_ptr():
+                    trt_cuda_graph_state.input_buffer.copy_(pre_processed_images)
                 trt_cuda_graph_state.cuda_graph.replay()
-                results = [buf.clone() for buf in trt_cuda_graph_state.output_buffers]
-            stream.synchronize()
+            # Return graph-owned output buffers directly — no clone. Attach
+            # the graph state as a side-channel so consumers can record into
+            # consumer_done_event without plumbing the cache through.
+            results = list(trt_cuda_graph_state.output_buffers)
+            results[0]._trt_graph_state = trt_cuda_graph_state
             return results
 
     else:
@@ -752,14 +787,21 @@ def _capture_cuda_graph(
     device: torch.device,
     input_name: str,
     outputs: List[str],
+    use_pre_processed_images_as_input_buffer: bool = False,
 ) -> Tuple[List[torch.Tensor], TRTCudaGraphState]:
     # Each CUDA graph needs its own execution context. Sharing a single context
     # across graphs for different input shapes causes TRT to reallocate internal
     # workspace buffers, invalidating GPU addresses baked into earlier graphs.
     graph_context = engine.create_execution_context()
 
-    input_buffer = torch.empty_like(pre_processed_images, device=device)
-    input_buffer.copy_(pre_processed_images)
+    if use_pre_processed_images_as_input_buffer:
+        # Zero-copy: TRT reads directly from the caller's buffer. The caller
+        # must keep this exact tensor alive for the lifetime of the graph
+        # and re-write its contents in-place before every replay.
+        input_buffer = pre_processed_images
+    else:
+        input_buffer = torch.empty_like(pre_processed_images, device=device)
+        input_buffer.copy_(pre_processed_images)
 
     status = graph_context.set_input_shape(
         input_name, tuple(pre_processed_images.shape)

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -1,9 +1,28 @@
+import os
 from typing import List, Optional, Tuple, Union
 
 import torch
 from torchvision.transforms import functional
 
 from inference_models import InstanceDetections
+
+_RFDETR_TRITON_POSTPROC = os.getenv("RFDETR_TRITON_POSTPROC", "false").lower() in (
+    "true",
+    "1",
+)
+if _RFDETR_TRITON_POSTPROC:
+    try:
+        from inference_models.models.rfdetr.triton_postprocess import (
+            TRITON_AVAILABLE as _TRITON_POSTPROC_AVAILABLE,
+            triton_rfdetr_conf_filter,
+        )
+        _TRITON_POSTPROC_READY = _TRITON_POSTPROC_AVAILABLE and torch.cuda.is_available()
+    except Exception:
+        _TRITON_POSTPROC_READY = False
+        triton_rfdetr_conf_filter = None
+else:
+    _TRITON_POSTPROC_READY = False
+    triton_rfdetr_conf_filter = None
 from inference_models.entities import ImageDimensions
 from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.roboflow.model_packages import (
@@ -51,35 +70,51 @@ def post_process_instance_segmentation_results(
     num_classes: int,
     classes_re_mapping: Optional[ClassesReMapping],
 ) -> List[InstanceDetections]:
-    logits_sigmoid = torch.nn.functional.sigmoid(logits)
     results = []
     device = bboxes.device
+    use_triton = _TRITON_POSTPROC_READY and bboxes.is_cuda
     if isinstance(threshold, torch.Tensor):
-        threshold = threshold.to(device=device, dtype=logits_sigmoid.dtype)
-    for image_bboxes, image_logits, image_masks, image_meta in zip(
-        bboxes, logits_sigmoid, masks, pre_processing_meta
-    ):
-        confidence, top_classes = image_logits.max(dim=1)
-        if classes_re_mapping is not None:
-            remapping_mask = torch.isin(
-                top_classes, classes_re_mapping.remaining_class_ids
+        threshold_dtype = logits.dtype if use_triton else torch.float32
+        threshold = threshold.to(device=device, dtype=threshold_dtype)
+    if use_triton:
+        iterator = zip(bboxes, logits, masks, pre_processing_meta)
+    else:
+        logits_sigmoid = torch.nn.functional.sigmoid(logits)
+        if isinstance(threshold, torch.Tensor):
+            threshold = threshold.to(device=device, dtype=logits_sigmoid.dtype)
+        iterator = zip(bboxes, logits_sigmoid, masks, pre_processing_meta)
+    cmap = classes_re_mapping.class_mapping if classes_re_mapping is not None else None
+    for image_bboxes, image_logits, image_masks, image_meta in iterator:
+        if use_triton:
+            confidence, top_classes, keep = triton_rfdetr_conf_filter(
+                image_logits, threshold, num_classes, class_mapping=cmap
             )
-            top_classes = classes_re_mapping.class_mapping[top_classes[remapping_mask]]
-            confidence = confidence[remapping_mask]
-            image_bboxes = image_bboxes[remapping_mask]
-            image_masks = image_masks[remapping_mask]
+            confidence = confidence[keep]
+            top_classes = top_classes[keep].long()
+            selected_boxes = image_bboxes[keep]
+            selected_masks = image_masks[keep]
         else:
-            # drop DETR no-object rows
-            named = top_classes < num_classes
-            confidence = confidence[named]
-            top_classes = top_classes[named]
-            image_bboxes = image_bboxes[named]
-            image_masks = image_masks[named]
-        confidence_mask = confidence > (threshold[top_classes.long()] if isinstance(threshold, torch.Tensor) else threshold)
-        confidence = confidence[confidence_mask]
-        top_classes = top_classes[confidence_mask]
-        selected_boxes = image_bboxes[confidence_mask]
-        selected_masks = image_masks[confidence_mask]
+            confidence, top_classes = image_logits.max(dim=1)
+            if classes_re_mapping is not None:
+                remapping_mask = torch.isin(
+                    top_classes, classes_re_mapping.remaining_class_ids
+                )
+                top_classes = classes_re_mapping.class_mapping[top_classes[remapping_mask]]
+                confidence = confidence[remapping_mask]
+                image_bboxes = image_bboxes[remapping_mask]
+                image_masks = image_masks[remapping_mask]
+            else:
+                # drop DETR no-object rows
+                named = top_classes < num_classes
+                confidence = confidence[named]
+                top_classes = top_classes[named]
+                image_bboxes = image_bboxes[named]
+                image_masks = image_masks[named]
+            confidence_mask = confidence > (threshold[top_classes.long()] if isinstance(threshold, torch.Tensor) else threshold)
+            confidence = confidence[confidence_mask]
+            top_classes = top_classes[confidence_mask]
+            selected_boxes = image_bboxes[confidence_mask]
+            selected_masks = image_masks[confidence_mask]
         confidence, sorted_indices = torch.sort(confidence, descending=True)
         top_classes = top_classes[sorted_indices]
         selected_boxes = selected_boxes[sorted_indices]

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -28,6 +28,16 @@ _RFDETR_TRITON_FULLPOSTPROC = os.getenv("RFDETR_TRITON_FULLPOSTPROC", "false").l
     "true",
     "1",
 )
+# Depth of the in-adapter frame pipeline. Default 1 (single-slot, unchanged
+# behavior). Set to 2 to engage depth-2 ping-pong of scratch buffers; the
+# adapter also needs to know to return frame N-1's response when called with
+# frame N, so this flag is read in both places.
+try:
+    _RFDETR_PIPELINE_DEPTH = int(os.getenv("RFDETR_PIPELINE_DEPTH", "1"))
+except (TypeError, ValueError):
+    _RFDETR_PIPELINE_DEPTH = 1
+if _RFDETR_PIPELINE_DEPTH < 1:
+    _RFDETR_PIPELINE_DEPTH = 1
 if _RFDETR_TRITON_FULLPOSTPROC:
     try:
         from inference_models.models.rfdetr.triton_fullpostproc import (
@@ -115,6 +125,7 @@ def post_process_instance_segmentation_results(
             pad_ltrb=(meta.pad_left, meta.pad_top, meta.pad_right, meta.pad_bottom),
             scale_wh=(meta.scale_width, meta.scale_height),
             orig_size_wh=(meta.original_size.width, meta.original_size.height),
+            num_slots=_RFDETR_PIPELINE_DEPTH,
         )
         # Return UNSLICED buffers plus counter + done_event. The adapter does
         # a pinned-host DtoH of counter alongside the combined/mask DtoHs on

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -23,6 +23,24 @@ if _RFDETR_TRITON_POSTPROC:
 else:
     _TRITON_POSTPROC_READY = False
     triton_rfdetr_conf_filter = None
+
+_RFDETR_TRITON_FULLPOSTPROC = os.getenv("RFDETR_TRITON_FULLPOSTPROC", "false").lower() in (
+    "true",
+    "1",
+)
+if _RFDETR_TRITON_FULLPOSTPROC:
+    try:
+        from inference_models.models.rfdetr.triton_fullpostproc import (
+            TRITON_AVAILABLE as _TRITON_FULLPOST_AVAILABLE,
+            triton_rfdetr_fullpost,
+        )
+        _TRITON_FULLPOST_READY = _TRITON_FULLPOST_AVAILABLE and torch.cuda.is_available()
+    except Exception:
+        _TRITON_FULLPOST_READY = False
+        triton_rfdetr_fullpost = None
+else:
+    _TRITON_FULLPOST_READY = False
+    triton_rfdetr_fullpost = None
 from inference_models.entities import ImageDimensions
 from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.roboflow.model_packages import (
@@ -72,6 +90,48 @@ def post_process_instance_segmentation_results(
 ) -> List[InstanceDetections]:
     results = []
     device = bboxes.device
+    # Try the full-fusion fast path first (batch=1, no static crop,
+    # no nonsquare-intermediate resize). Matches rfdetr-seg-nano default.
+    if (
+        _TRITON_FULLPOST_READY
+        and bboxes.is_cuda
+        and bboxes.shape[0] == 1
+        and len(pre_processing_meta) == 1
+        and pre_processing_meta[0].nonsquare_intermediate_size is None
+        and pre_processing_meta[0].static_crop_offset.offset_x == 0
+        and pre_processing_meta[0].static_crop_offset.offset_y == 0
+        and classes_re_mapping is not None
+    ):
+        meta = pre_processing_meta[0]
+        thr_arg = threshold if isinstance(threshold, torch.Tensor) else float(threshold)
+        combined, mask_bin, mask_any, counter, done_event = triton_rfdetr_fullpost(
+            bboxes=bboxes,
+            logits=logits,
+            masks=masks,
+            threshold=thr_arg,
+            num_classes=num_classes,
+            class_mapping=classes_re_mapping.class_mapping,
+            inference_size_wh=(meta.inference_size.width, meta.inference_size.height),
+            pad_ltrb=(meta.pad_left, meta.pad_top, meta.pad_right, meta.pad_bottom),
+            scale_wh=(meta.scale_width, meta.scale_height),
+            orig_size_wh=(meta.original_size.width, meta.original_size.height),
+        )
+        # Return UNSLICED buffers plus counter + done_event. The adapter does
+        # a pinned-host DtoH of counter alongside the combined/mask DtoHs on
+        # its own stream (guarded by done_event.wait), slicing the results
+        # host-side. That replaces the CPU-blocking counter.item() that would
+        # otherwise serialize the postproc stream with the adapter.
+        detections = InstanceDetections(
+            xyxy=combined[:, :4],
+            confidence=combined[:, 4],  # int32 bits; adapter bitcasts to fp32
+            class_id=combined[:, 5],
+            mask=mask_bin,
+        )
+        detections.__dict__["_combined_gpu"] = combined
+        detections.__dict__["_counter_gpu"] = counter
+        detections.__dict__["_postproc_done_event"] = done_event
+        results.append(detections)
+        return results
     use_triton = _TRITON_POSTPROC_READY and bboxes.is_cuda
     if isinstance(threshold, torch.Tensor):
         threshold_dtype = logits.dtype if use_triton else torch.float32

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
@@ -339,14 +339,43 @@ class RFDetrForInstanceSegmentationTRT(
                 dtype=torch.float32,
                 device=self._device,
             )
+            # Marker: tells the TRT CUDA-graph capture path to use this
+            # tensor as the graph's own input buffer, eliminating the
+            # per-frame DtoD copy from our preproc output into the graph's
+            # internal buffer. Our preproc always writes in-place here.
+            self._fast_input_buffer._trt_reuse_as_input_buffer = True
             self._fast_means = tuple(means)
             self._fast_stds = tuple(stds)
+            # Pinned host buffer for the raw BGR frame — lets us do a
+            # truly async HtoD into src_gpu. Grown lazily below if the
+            # frame size changes.
+            self._fast_src_host_pinned = None
+            self._fast_src_gpu = None
             self._fast_buffer_initialized = True
 
-        with torch.cuda.stream(self._pre_process_stream):
-            src_gpu = torch.from_numpy(np.ascontiguousarray(images)).to(
-                self._device, non_blocking=True
+        # Reuse a pinned host staging buffer so torch.Tensor.copy_ with
+        # non_blocking=True actually runs async. Without pinning,
+        # non_blocking is silently promoted to a sync copy.
+        src_shape = images.shape
+        src_nbytes = images.nbytes
+        pinned = self._fast_src_host_pinned
+        if (
+            pinned is None
+            or pinned.numel() * pinned.element_size() < src_nbytes
+            or tuple(pinned.shape) != src_shape
+        ):
+            pinned = torch.empty(src_shape, dtype=torch.uint8, pin_memory=True)
+            self._fast_src_host_pinned = pinned
+            self._fast_src_gpu = torch.empty(
+                src_shape, dtype=torch.uint8, device=self._device
             )
+        # Copy the numpy BGR frame into pinned host memory (fast CPU memcpy),
+        # then async DtoH->GPU while the Triton launch happens on CPU side.
+        pinned_np = pinned.numpy()
+        np.copyto(pinned_np, images, casting="no")
+        src_gpu = self._fast_src_gpu
+        with torch.cuda.stream(self._pre_process_stream):
+            src_gpu.copy_(pinned, non_blocking=True)
             triton_preprocess_rfdetr_stretch(
                 src_gpu,
                 target_h=target_h,
@@ -417,7 +446,14 @@ class RFDetrForInstanceSegmentationTRT(
             recommended_parameters=self.recommended_parameters,
             default_confidence=INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE,
         )
+        # Wait on the TRT-stream "produce" event so our post_process stream
+        # can start reading the (graph-owned) output buffers as soon as the
+        # engine finishes, without a CPU-side synchronize().
+        produce_event = getattr(model_results[0], "_trt_produce_event", None)
+        graph_state = getattr(model_results[0], "_trt_graph_state", None)
         with torch.cuda.stream(self._post_process_stream):
+            if produce_event is not None:
+                produce_event.wait(self._post_process_stream)
             for result_element in model_results:
                 result_element.record_stream(self._post_process_stream)
             bboxes, logits, masks = model_results
@@ -430,6 +466,14 @@ class RFDetrForInstanceSegmentationTRT(
                 num_classes=len(self.class_names),
                 classes_re_mapping=self._classes_re_mapping,
             )
+            # Record "consumer done" so the next TRT replay can wait on it
+            # before overwriting the graph-owned output buffers.
+            if graph_state is not None:
+                ev = graph_state.consumer_done_event
+                if ev is None:
+                    ev = torch.cuda.Event()
+                    graph_state.consumer_done_event = ev
+                ev.record(self._post_process_stream)
         return results
 
     @property

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
@@ -1,3 +1,4 @@
+import os
 import threading
 from typing import List, Optional, Tuple, Union
 
@@ -48,8 +49,30 @@ from inference_models.models.rfdetr.common import (
     post_process_instance_segmentation_results,
 )
 from inference_models.models.rfdetr.pre_processing import pre_process_network_input
+from inference_models.entities import ImageDimensions as _ImageDimensions
+from inference_models.models.common.roboflow.model_packages import (
+    StaticCropOffset as _StaticCropOffset,
+)
 from inference_models.models.common.roboflow.post_processing import ConfidenceFilter
 from inference_models.weights_providers.entities import RecommendedParameters
+
+_RFDETR_USE_TRITON_PREPROC = os.getenv("RFDETR_USE_TRITON_PREPROC", "false").lower() in (
+    "true",
+    "1",
+)
+if _RFDETR_USE_TRITON_PREPROC:
+    try:
+        from inference_models.models.rfdetr.triton_preprocess import (
+            TRITON_AVAILABLE as _TRITON_AVAILABLE,
+            triton_preprocess_rfdetr_stretch,
+        )
+        _TRITON_READY = _TRITON_AVAILABLE and torch.cuda.is_available()
+    except Exception:  # pragma: no cover
+        _TRITON_READY = False
+        triton_preprocess_rfdetr_stretch = None
+else:
+    _TRITON_READY = False
+    triton_preprocess_rfdetr_stretch = None
 
 try:
     import tensorrt as trt
@@ -230,6 +253,14 @@ class RFDetrForInstanceSegmentationTRT(
         pre_processing_overrides: Optional[PreProcessingOverrides] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
+        fast = self._try_fast_preprocess(
+            images=images,
+            input_color_format=input_color_format,
+            image_size=image_size,
+            pre_processing_overrides=pre_processing_overrides,
+        )
+        if fast is not None:
+            return fast
         with torch.cuda.stream(self._pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
@@ -243,6 +274,111 @@ class RFDetrForInstanceSegmentationTRT(
         self._pre_process_stream.synchronize()
         return pre_processed_images, pre_processing_meta
 
+    def _try_fast_preprocess(
+        self,
+        images,
+        input_color_format,
+        image_size,
+        pre_processing_overrides,
+    ):
+        if not _TRITON_READY:
+            return None
+        if image_size is not None:
+            return None
+        ipp = self._inference_config.image_pre_processing
+        if (
+            ipp.static_crop is not None
+            and ipp.static_crop.enabled
+            or ipp.contrast is not None
+            and ipp.contrast.enabled
+            or ipp.grayscale is not None
+            and ipp.grayscale.enabled
+        ):
+            return None
+        ni = self._inference_config.network_input
+        if ni.resize_mode != ResizeMode.STRETCH_TO:
+            return None
+        if ni.input_channels != 3:
+            return None
+        if ni.dataset_version_resize_dimensions is not None:
+            return None
+        if ni.scaling_factor not in (None, 255):
+            return None
+        if ni.normalization is None:
+            return None
+        means, stds = ni.normalization
+        # Only handle numpy HWC BGR uint8 (the common hot path).
+        if isinstance(images, list):
+            if len(images) != 1:
+                return None
+            candidate = images[0]
+        else:
+            candidate = images
+        if not isinstance(candidate, np.ndarray):
+            return None
+        if (
+            candidate.dtype != np.uint8
+            or candidate.ndim != 3
+            or candidate.shape[2] != 3
+        ):
+            return None
+        images = candidate
+        # Color: if caller says RGB, skip; we do BGR->model_color_mode.
+        from inference_models.models.common.roboflow.model_packages import ColorMode
+        caller_mode = ColorMode(input_color_format) if input_color_format is not None else ColorMode.BGR
+        if caller_mode != ColorMode.BGR or ni.color_mode != ColorMode.RGB:
+            return None
+
+        target_h = ni.training_input_size.height
+        target_w = ni.training_input_size.width
+        orig_h, orig_w = images.shape[0], images.shape[1]
+
+        if not getattr(self, "_fast_buffer_initialized", False):
+            self._fast_input_buffer = torch.empty(
+                (1, 3, target_h, target_w),
+                dtype=torch.float32,
+                device=self._device,
+            )
+            self._fast_means = tuple(means)
+            self._fast_stds = tuple(stds)
+            self._fast_buffer_initialized = True
+
+        with torch.cuda.stream(self._pre_process_stream):
+            src_gpu = torch.from_numpy(np.ascontiguousarray(images)).to(
+                self._device, non_blocking=True
+            )
+            triton_preprocess_rfdetr_stretch(
+                src_gpu,
+                target_h=target_h,
+                target_w=target_w,
+                means=self._fast_means,
+                stds=self._fast_stds,
+                out=self._fast_input_buffer,
+            )
+            # Record an event so the inference stream can wait on preproc
+            # completion without blocking the CPU.
+            self._fast_preproc_event = torch.cuda.Event()
+            self._fast_preproc_event.record(self._pre_process_stream)
+            self._fast_input_buffer.record_stream(self._pre_process_stream)
+
+        size_after = _ImageDimensions(height=orig_h, width=orig_w)
+        target = _ImageDimensions(height=target_h, width=target_w)
+        metadata = PreProcessingMetadata(
+            pad_left=0,
+            pad_top=0,
+            pad_right=0,
+            pad_bottom=0,
+            original_size=size_after,
+            size_after_pre_processing=size_after,
+            inference_size=target,
+            scale_width=target_w / orig_w,
+            scale_height=target_h / orig_h,
+            static_crop_offset=_StaticCropOffset(
+                offset_x=0, offset_y=0, crop_width=orig_w, crop_height=orig_h
+            ),
+        )
+        return self._fast_input_buffer, [metadata]
+
     def forward(
         self,
         pre_processed_images: torch.Tensor,
@@ -250,6 +386,10 @@ class RFDetrForInstanceSegmentationTRT(
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         cache = self._trt_cuda_graph_cache if not disable_cuda_graphs else None
+        ev = getattr(self, "_fast_preproc_event", None)
+        if ev is not None:
+            ev.wait(self._inference_stream)
+            self._fast_preproc_event = None
         with self._lock:
             with use_cuda_context(context=self._cuda_context):
                 detections, labels, masks = infer_from_trt_engine(
@@ -290,7 +430,6 @@ class RFDetrForInstanceSegmentationTRT(
                 num_classes=len(self.class_names),
                 classes_re_mapping=self._classes_re_mapping,
             )
-        self._post_process_stream.synchronize()
         return results
 
     @property

--- a/inference_models/inference_models/models/rfdetr/triton_fullpostproc.py
+++ b/inference_models/inference_models/models/rfdetr/triton_fullpostproc.py
@@ -284,18 +284,23 @@ def _next_pow2(n: int) -> int:
 _THRESHOLD_CACHE: dict = {}
 _EMPTY_INT32 = torch.empty((1,), dtype=torch.int32)
 _MASK_BIN_BUFFER_CACHE: dict = {}
-# Cache the per-call scratch (combined/survivor_idx/mask_any/counter) keyed
-# by (num_queries, device). Eliminates 3 per-frame torch.empty allocator
-# calls and stabilizes stride/pointer values across the Triton JIT cache.
+# Scratch cache keyed by (num_queries, device, slot_idx). slot_idx lets
+# callers ping-pong between multiple scratch sets so that an in-flight
+# consumer reading frame N-1's outputs can't be overwritten by frame N's
+# kernels. Default slot is 0 (single-slot behavior, unchanged).
 _SCRATCH_CACHE: dict = {}
 # Cache a converted-to-int32 view of the class_mapping tensor. The upstream
 # model stores it as int64, but our Triton kernel needs int32; without a
 # cache we relaunch direct_copy_kernel_cuda every frame.
 _CLASS_MAPPING_INT32_CACHE: dict = {}
+# Module-level counter for slot selection when the caller doesn't pass one.
+# Each triton_rfdetr_fullpost call increments it so successive calls land in
+# different slots (depth-2 pipelining).
+_SLOT_COUNTER: int = 0
 
 
-def _get_scratch_buffers(num_queries: int, device: torch.device):
-    key = (num_queries, device)
+def _get_scratch_buffers(num_queries: int, device: torch.device, slot_idx: int = 0):
+    key = (num_queries, device, slot_idx)
     cached = _SCRATCH_CACHE.get(key)
     if cached is None:
         combined = torch.empty((num_queries, 6), dtype=torch.int32, device=device)
@@ -320,7 +325,7 @@ def _get_class_mapping_int32(class_mapping: torch.Tensor, device: torch.device) 
 
 
 def _get_mask_bin_buffer(
-    capacity: int, orig_h: int, orig_w: int, device: torch.device
+    capacity: int, orig_h: int, orig_w: int, device: torch.device, slot_idx: int = 0
 ) -> torch.Tensor:
     """Return a reusable (capacity, orig_h, orig_w) uint8 mask buffer.
 
@@ -329,8 +334,11 @@ def _get_mask_bin_buffer(
     We return the full buffer; the caller views [:n_survivors]. Rows beyond
     n_survivors may contain stale data from prior frames; the caller must
     only read the slice it sizes via the atomic counter.
+
+    slot_idx lets depth-2 pipelined callers alternate between slots so the
+    consumer reading slot 0 isn't racing with the writer on slot 1.
     """
-    key = (capacity, orig_h, orig_w, device)
+    key = (capacity, orig_h, orig_w, device, slot_idx)
     buf = _MASK_BIN_BUFFER_CACHE.get(key)
     if buf is None:
         buf = torch.empty(
@@ -367,6 +375,7 @@ def triton_rfdetr_fullpost(
     pad_ltrb: Tuple[int, int, int, int],   # (left, top, right, bottom) in inference coords
     scale_wh: Tuple[float, float],         # (scale_w, scale_h) = eff_w/orig_w, eff_h/orig_h
     orig_size_wh: Tuple[int, int],         # (W, H) of the original image
+    num_slots: int = 1,                    # ping-pong across N slots; 1 = no pipelining
 ) -> Tuple[
     torch.Tensor,      # combined (num_queries, 6) int32 — UNSLICED
     torch.Tensor,      # mask_bin (num_queries, orig_h, orig_w) uint8 — UNSLICED
@@ -411,11 +420,21 @@ def triton_rfdetr_fullpost(
     bboxes_2d = bboxes[0] if bboxes[0].is_contiguous() else bboxes[0].contiguous()
     masks_3d = masks[0] if masks[0].is_contiguous() else masks[0].contiguous()
 
+    # Pick a slot. For num_slots==1 (default) we always hit slot 0, preserving
+    # the single-slot behavior. For num_slots>=2, we rotate so the consumer
+    # still reading slot (N-1) % num_slots isn't overwritten by slot N.
+    global _SLOT_COUNTER
+    if num_slots > 1:
+        slot_idx = _SLOT_COUNTER % num_slots
+        _SLOT_COUNTER += 1
+    else:
+        slot_idx = 0
+
     # Reuse persistent scratch across frames. Avoids 3 torch.empty allocator
     # calls per frame and keeps all downstream .stride() / pointer values
     # stable across the Triton JIT cache.
     combined, survivor_idx, mask_any, counter = _get_scratch_buffers(
-        num_queries, device
+        num_queries, device, slot_idx
     )
     # Reset the atomic counter. zero_() still launches FillFunctor (2.5 µs on
     # T4), but there's no safe way to inline this into the filter kernel —
@@ -472,7 +491,7 @@ def triton_rfdetr_fullpost(
     # checks counter[0] on GPU and early-exits if its s index is out of
     # range. This lets us skip a CPU-blocking counter.item() between the
     # two kernel launches — both get queued to the stream immediately.
-    mask_bin_full = _get_mask_bin_buffer(num_queries, orig_h, orig_w, device)
+    mask_bin_full = _get_mask_bin_buffer(num_queries, orig_h, orig_w, device, slot_idx)
 
     BLOCK_H = 16
     BLOCK_W = 16

--- a/inference_models/inference_models/models/rfdetr/triton_fullpostproc.py
+++ b/inference_models/inference_models/models/rfdetr/triton_fullpostproc.py
@@ -284,6 +284,39 @@ def _next_pow2(n: int) -> int:
 _THRESHOLD_CACHE: dict = {}
 _EMPTY_INT32 = torch.empty((1,), dtype=torch.int32)
 _MASK_BIN_BUFFER_CACHE: dict = {}
+# Cache the per-call scratch (combined/survivor_idx/mask_any/counter) keyed
+# by (num_queries, device). Eliminates 3 per-frame torch.empty allocator
+# calls and stabilizes stride/pointer values across the Triton JIT cache.
+_SCRATCH_CACHE: dict = {}
+# Cache a converted-to-int32 view of the class_mapping tensor. The upstream
+# model stores it as int64, but our Triton kernel needs int32; without a
+# cache we relaunch direct_copy_kernel_cuda every frame.
+_CLASS_MAPPING_INT32_CACHE: dict = {}
+
+
+def _get_scratch_buffers(num_queries: int, device: torch.device):
+    key = (num_queries, device)
+    cached = _SCRATCH_CACHE.get(key)
+    if cached is None:
+        combined = torch.empty((num_queries, 6), dtype=torch.int32, device=device)
+        survivor_idx = torch.empty((num_queries,), dtype=torch.int32, device=device)
+        mask_any = torch.empty((num_queries,), dtype=torch.int32, device=device)
+        counter = torch.zeros((1,), dtype=torch.int32, device=device)
+        cached = (combined, survivor_idx, mask_any, counter)
+        _SCRATCH_CACHE[key] = cached
+    return cached
+
+
+def _get_class_mapping_int32(class_mapping: torch.Tensor, device: torch.device) -> torch.Tensor:
+    if class_mapping.dtype == torch.int32 and class_mapping.device == device and class_mapping.is_contiguous():
+        return class_mapping
+    key = (id(class_mapping), device)
+    cached = _CLASS_MAPPING_INT32_CACHE.get(key)
+    if cached is not None:
+        return cached
+    cached = class_mapping.to(dtype=torch.int32, device=device).contiguous()
+    _CLASS_MAPPING_INT32_CACHE[key] = cached
+    return cached
 
 
 def _get_mask_bin_buffer(
@@ -378,25 +411,27 @@ def triton_rfdetr_fullpost(
     bboxes_2d = bboxes[0] if bboxes[0].is_contiguous() else bboxes[0].contiguous()
     masks_3d = masks[0] if masks[0].is_contiguous() else masks[0].contiguous()
 
-    # Single combined int32 output buffer for all per-survivor scalar fields
-    # (xyxy [4] + conf_as_i32 + class_id = 6 int32 per slot). Reduces 3-4
-    # separate small .cpu() transfers at the adapter level to one.
-    combined = torch.empty((num_queries, 6), dtype=torch.int32, device=device)
-    survivor_idx = torch.empty((num_queries,), dtype=torch.int32, device=device)
-    mask_any = torch.empty((num_queries,), dtype=torch.int32, device=device)
-    # Atomic counter — must be zeroed each call since the filter kernel
-    # atomic_adds into it.
-    counter = torch.zeros((1,), dtype=torch.int32, device=device)
+    # Reuse persistent scratch across frames. Avoids 3 torch.empty allocator
+    # calls per frame and keeps all downstream .stride() / pointer values
+    # stable across the Triton JIT cache.
+    combined, survivor_idx, mask_any, counter = _get_scratch_buffers(
+        num_queries, device
+    )
+    # Reset the atomic counter. zero_() still launches FillFunctor (2.5 µs on
+    # T4), but there's no safe way to inline this into the filter kernel —
+    # concurrent blocks would race with the zero. mask_any is re-initialized
+    # by the filter kernel itself (per-slot store), survivor_idx is fully
+    # overwritten, combined is fully overwritten.
+    counter.zero_()
 
     thr_tensor, per_class = _prepare_threshold(threshold, device, num_classes)
 
     if class_mapping is not None:
         has_remap = True
-        cmap = class_mapping if (
-            class_mapping.dtype == torch.int32
-            and class_mapping.device == device
-            and class_mapping.is_contiguous()
-        ) else class_mapping.to(dtype=torch.int32, device=device).contiguous()
+        # Cache the int32 view — upstream model stores class_mapping as int64
+        # and the naïve .to(dtype=torch.int32) would launch direct_copy_kernel
+        # every frame.
+        cmap = _get_class_mapping_int32(class_mapping, device)
     else:
         has_remap = False
         cmap = _EMPTY_INT32.to(device, non_blocking=True)

--- a/inference_models/inference_models/models/rfdetr/triton_fullpostproc.py
+++ b/inference_models/inference_models/models/rfdetr/triton_fullpostproc.py
@@ -1,0 +1,481 @@
+"""Experimental: full RF-DETR instance-segmentation post-processing in Triton.
+
+Fuses the entire post-TRT chain into two Triton kernels of fixed grid:
+
+  _rfdetr_fullpost_filter_kernel  (grid = num_queries)
+    sigmoid(logits) -> argmax-over-classes -> class remap -> conf > threshold
+    -> xywh -> xyxy -> multiply by inference_size -> subtract padding
+    -> divide by scale -> clip to orig image bounds
+    Emits padded fixed-shape outputs (num_queries rows). Rows that don't pass
+    the filter get `keep=False`; downstream consumers skip them.
+
+  _rfdetr_fullpost_mask_kernel  (grid = num_queries * tile_y * tile_x)
+    Inverse-letterbox bilinear upsample masks 78x78 -> orig_h x orig_w,
+    threshold > 0, emit as uint8. Skips work when keep[q] is False.
+
+Design notes
+------------
+* Everything is fixed-shape in/out. No compaction, no sort, no variable
+  grid. Downstream Python handles selection by `keep`.
+* This replaces the torch.sort + gather + align_instance_segmentation_results
+  chain for the common case of no static_crop, STRETCH_TO resize, class
+  remapping available. Falls back to the existing path otherwise.
+"""
+from typing import Optional, Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    triton = None
+    tl = None
+    TRITON_AVAILABLE = False
+
+
+if TRITON_AVAILABLE:
+
+    @triton.jit
+    def _rfdetr_fullpost_filter_kernel(
+        logits_ptr,          # (num_queries, num_classes_total) fp16/fp32
+        bboxes_ptr,          # (num_queries, 4) fp32, normalized cxcywh
+        threshold_ptr,       # scalar or (num_remapped,) fp32
+        class_map_ptr,       # (num_classes_total,) int32; -1 means drop
+        # SINGLE combined int32 output buffer. Layout:
+        #   offset 0..(num_queries*6): per-survivor [x1,y1,x2,y2,conf_i32,cls] records
+        #   (stored at stride 6 per slot; host reinterprets conf slot as fp32)
+        # Written by this kernel compactly via atomic_add(counter).
+        combined_out_ptr,    # (num_queries, 6) int32
+        survivor_idx_out_ptr,# (num_queries,) int32 — original query id of each survivor
+        mask_any_out_ptr,    # (num_queries,) int32 — zeroed at compact slot; mask kernel atomic_maxes up to 1
+        counter_ptr,         # (1,) int32 — atomic counter; host reads to get n_survivors
+        # static scalars
+        num_queries,
+        num_classes_total,
+        inference_w,
+        inference_h,
+        pad_left,
+        pad_top,
+        inv_scale_w,
+        inv_scale_h,
+        orig_w,
+        orig_h,
+        logits_stride_q,
+        bboxes_stride_q,
+        PER_CLASS: tl.constexpr,
+        HAS_REMAPPING: tl.constexpr,
+        BLOCK_C: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        if pid >= num_queries:
+            return
+        offs_c = tl.arange(0, BLOCK_C)
+        mask_c = offs_c < num_classes_total
+
+        logits_row = tl.load(
+            logits_ptr + pid * logits_stride_q + offs_c,
+            mask=mask_c,
+            other=-float("inf"),
+        )
+        max_val = tl.max(logits_row, axis=0)
+        BIG = 1 << 30
+        is_max = logits_row == max_val
+        idx_or_big = tl.where(is_max & mask_c, offs_c, BIG)
+        raw_c = tl.min(idx_or_big, axis=0)
+
+        if HAS_REMAPPING:
+            top_c = tl.load(class_map_ptr + raw_c)
+            valid = top_c >= 0
+        else:
+            top_c = raw_c
+            valid = raw_c < num_classes_total
+
+        abs_max = tl.abs(max_val)
+        z = tl.exp(-abs_max)
+        sig_pos = 1.0 / (1.0 + z)
+        sig_neg = z / (1.0 + z)
+        conf = tl.where(max_val >= 0.0, sig_pos, sig_neg)
+
+        if PER_CLASS:
+            safe_c = tl.where(valid, top_c, 0)
+            thr = tl.load(threshold_ptr + safe_c)
+        else:
+            thr = tl.load(threshold_ptr)
+        keep = valid & (conf > thr)
+
+        # Early exit for filtered queries — don't compute boxes, don't
+        # reserve a slot. Cheap (rest of kernel is ~8 FLOPS + 4 stores).
+        if not keep:
+            return
+
+        # Match the non-Triton path's exact FP32 evaluation order, so
+        # sub-pixel results round the same way:
+        #   x_min_pct = cx_pct - 0.5 * w_pct  (subtract percents first)
+        #   x_min = x_min_pct * W             (then scale to inference coords)
+        #   x_min = x_min - pad_left
+        #   x_min = x_min / scale_w           (baseline uses div, not mul-by-inv)
+        cx_pct = tl.load(bboxes_ptr + pid * bboxes_stride_q + 0)
+        cy_pct = tl.load(bboxes_ptr + pid * bboxes_stride_q + 1)
+        w_pct = tl.load(bboxes_ptr + pid * bboxes_stride_q + 2)
+        h_pct = tl.load(bboxes_ptr + pid * bboxes_stride_q + 3)
+
+        x1_pct = cx_pct - 0.5 * w_pct
+        y1_pct = cy_pct - 0.5 * h_pct
+        x2_pct = cx_pct + 0.5 * w_pct
+        y2_pct = cy_pct + 0.5 * h_pct
+
+        x1 = x1_pct * inference_w
+        y1 = y1_pct * inference_h
+        x2 = x2_pct * inference_w
+        y2 = y2_pct * inference_h
+
+        x1 = x1 - pad_left
+        y1 = y1 - pad_top
+        x2 = x2 - pad_left
+        y2 = y2 - pad_top
+
+        # Baseline uses tensor division (computes 1/scale once per tensor).
+        # inv_scale_* was computed on the host as 1.0/sw — matches.
+        x1 = x1 * inv_scale_w
+        y1 = y1 * inv_scale_h
+        x2 = x2 * inv_scale_w
+        y2 = y2 * inv_scale_h
+
+        x1 = tl.maximum(tl.minimum(x1, orig_w), 0.0)
+        y1 = tl.maximum(tl.minimum(y1, orig_h), 0.0)
+        x2 = tl.maximum(tl.minimum(x2, orig_w), 0.0)
+        y2 = tl.maximum(tl.minimum(y2, orig_h), 0.0)
+
+        # Banker's rounding (half-to-even) matches torch.round().int(). For
+        # typical RF-DETR bbox values (far from half-integer boundaries),
+        # round-half-up would give identical results. We keep banker's for
+        # bit-parity with the non-Triton path on the rare half-integer tie.
+        x1_r = tl.floor(x1 + 0.5)
+        y1_r = tl.floor(y1 + 0.5)
+        x2_r = tl.floor(x2 + 0.5)
+        y2_r = tl.floor(y2 + 0.5)
+        x1_i = x1_r.to(tl.int32)
+        y1_i = y1_r.to(tl.int32)
+        x2_i = x2_r.to(tl.int32)
+        y2_i = y2_r.to(tl.int32)
+        x1_i = tl.where(((x1_r - x1) == 0.5) & ((x1_i & 1) != 0), x1_i - 1, x1_i)
+        y1_i = tl.where(((y1_r - y1) == 0.5) & ((y1_i & 1) != 0), y1_i - 1, y1_i)
+        x2_i = tl.where(((x2_r - x2) == 0.5) & ((x2_i & 1) != 0), x2_i - 1, x2_i)
+        y2_i = tl.where(((y2_r - y2) == 0.5) & ((y2_i & 1) != 0), y2_i - 1, y2_i)
+
+        # Reserve a compact slot via atomic-add. Order is non-deterministic
+        # across survivors but downstream doesn't require query-order.
+        slot = tl.atomic_add(counter_ptr, 1)
+
+        # Reinterpret conf (fp32) as int32 bits so we can write the whole
+        # record with int32 stores. Host side views the same memory as
+        # int32 and extracts conf via numpy view(np.float32).
+        conf_bits = conf.to(tl.float32, bitcast=False)  # no-op, already fp32
+        conf_i32 = conf_bits.to(tl.int32, bitcast=True)
+        base = slot * 6
+        tl.store(combined_out_ptr + base + 0, x1_i)
+        tl.store(combined_out_ptr + base + 1, y1_i)
+        tl.store(combined_out_ptr + base + 2, x2_i)
+        tl.store(combined_out_ptr + base + 3, y2_i)
+        tl.store(combined_out_ptr + base + 4, conf_i32)
+        tl.store(combined_out_ptr + base + 5, top_c)
+        tl.store(survivor_idx_out_ptr + slot, pid.to(tl.int32))
+        # Initialize mask_any[slot] to 0. The mask kernel's tile-level
+        # atomic_max raises it to 1 if any pixel passes threshold.
+        tl.store(mask_any_out_ptr + slot, 0)
+
+
+    @triton.jit
+    def _rfdetr_fullpost_mask_kernel_compact(
+        masks_ptr,           # (num_queries, mask_h, mask_w) fp32
+        survivor_idx_ptr,    # (n_survivors,) int32 — indices into num_queries
+        counter_ptr,         # (1,) int32 — n_survivors; used for GPU-side early exit
+        out_ptr,             # (n_survivors, orig_h, orig_w) uint8 — compact binary mask
+        mask_any_ptr,        # (n_survivors,) int32 — 1 if any pixel survives threshold, 0 else
+        mask_h,
+        mask_w,
+        orig_h,
+        orig_w,
+        # Scale from orig -> mask coords (covers the whole mask span,
+        # since STRETCH_TO has no letterbox-crop at mask resolution).
+        mask_scale_y,        # mask_h / orig_h
+        mask_scale_x,
+        masks_stride_q,
+        masks_stride_h,
+        out_stride_s,
+        out_stride_h,
+        BLOCK_H: tl.constexpr,
+        BLOCK_W: tl.constexpr,
+    ):
+        s = tl.program_id(0)  # survivor index in [0, num_queries) — over-launched
+        tile_y = tl.program_id(1)
+        tile_x = tl.program_id(2)
+
+        # GPU-side early exit: filter kernel atomic-added into counter; any
+        # program with s >= counter has no corresponding survivor.
+        n_survivors = tl.load(counter_ptr)
+        if s >= n_survivors:
+            return
+
+        # Look up the source query slot for the bilinear gather.
+        q = tl.load(survivor_idx_ptr + s)
+
+        offs_y = tile_y * BLOCK_H + tl.arange(0, BLOCK_H)
+        offs_x = tile_x * BLOCK_W + tl.arange(0, BLOCK_W)
+        mask_yy = offs_y < orig_h
+        mask_xx = offs_x < orig_w
+        m_outbox = mask_yy[:, None] & mask_xx[None, :]
+
+        # Inverse map orig pixel -> source mask coord, pixel-center bilinear.
+        src_y_f = (offs_y.to(tl.float32) + 0.5) * mask_scale_y - 0.5
+        src_x_f = (offs_x.to(tl.float32) + 0.5) * mask_scale_x - 0.5
+        src_y_2d = src_y_f[:, None]
+        src_x_2d = src_x_f[None, :]
+
+        y0 = tl.floor(src_y_2d).to(tl.int32)
+        x0 = tl.floor(src_x_2d).to(tl.int32)
+        y1 = y0 + 1
+        x1 = x0 + 1
+        dy = src_y_2d - y0.to(tl.float32)
+        dx = src_x_2d - x0.to(tl.float32)
+
+        y0c = tl.maximum(tl.minimum(y0, mask_h - 1), 0)
+        y1c = tl.maximum(tl.minimum(y1, mask_h - 1), 0)
+        x0c = tl.maximum(tl.minimum(x0, mask_w - 1), 0)
+        x1c = tl.maximum(tl.minimum(x1, mask_w - 1), 0)
+
+        base = q * masks_stride_q
+
+        p00 = tl.load(masks_ptr + base + y0c * masks_stride_h + x0c, mask=m_outbox, other=0.0)
+        p01 = tl.load(masks_ptr + base + y0c * masks_stride_h + x1c, mask=m_outbox, other=0.0)
+        p10 = tl.load(masks_ptr + base + y1c * masks_stride_h + x0c, mask=m_outbox, other=0.0)
+        p11 = tl.load(masks_ptr + base + y1c * masks_stride_h + x1c, mask=m_outbox, other=0.0)
+
+        w_tl = (1.0 - dy) * (1.0 - dx)
+        w_tr = (1.0 - dy) * dx
+        w_bl = dy * (1.0 - dx)
+        w_br = dy * dx
+        val = p00 * w_tl + p01 * w_tr + p10 * w_bl + p11 * w_br
+        bin_val = (val > 0.0).to(tl.int8)
+
+        out_offsets = offs_y[:, None] * out_stride_h + offs_x[None, :]
+        # Write to compact row s (not q).
+        tl.store(out_ptr + s * out_stride_s + out_offsets, bin_val, mask=m_outbox)
+
+        # Tile-level reduction of any-true within the bool tile, then a single
+        # atomic-max into mask_any[s]. Saves a separate torch.any reduction
+        # downstream. Atomic max preserves the 0/1 semantic across tiles.
+        tile_any = tl.max(bin_val.to(tl.int32), axis=0)
+        tile_any2 = tl.max(tile_any, axis=0)
+        tl.atomic_max(mask_any_ptr + s, tile_any2)
+
+
+def _next_pow2(n: int) -> int:
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+# Cache small supporting tensors so we don't incur HtoD for them per frame.
+_THRESHOLD_CACHE: dict = {}
+_EMPTY_INT32 = torch.empty((1,), dtype=torch.int32)
+_MASK_BIN_BUFFER_CACHE: dict = {}
+
+
+def _get_mask_bin_buffer(
+    capacity: int, orig_h: int, orig_w: int, device: torch.device
+) -> torch.Tensor:
+    """Return a reusable (capacity, orig_h, orig_w) uint8 mask buffer.
+
+    Avoids a per-frame torch.empty kernel for the biggest allocation in the
+    post-process path (capacity * H * W bytes — ~10 MB at 100*240*426).
+    We return the full buffer; the caller views [:n_survivors]. Rows beyond
+    n_survivors may contain stale data from prior frames; the caller must
+    only read the slice it sizes via the atomic counter.
+    """
+    key = (capacity, orig_h, orig_w, device)
+    buf = _MASK_BIN_BUFFER_CACHE.get(key)
+    if buf is None:
+        buf = torch.empty(
+            (capacity, orig_h, orig_w), dtype=torch.uint8, device=device
+        )
+        _MASK_BIN_BUFFER_CACHE[key] = buf
+    return buf
+
+
+def _prepare_threshold(threshold, device: torch.device, num_classes: int):
+    """Return (threshold_tensor_on_device, per_class_flag), caching the tensor
+    form of scalar thresholds so we don't ship a 4-byte HtoD every frame."""
+    if isinstance(threshold, torch.Tensor):
+        t = threshold
+        if t.dtype != torch.float32 or t.device != device or not t.is_contiguous():
+            t = t.to(dtype=torch.float32, device=device).contiguous()
+        return t, True
+    key = (float(threshold), device)
+    cached = _THRESHOLD_CACHE.get(key)
+    if cached is None:
+        cached = torch.tensor([float(threshold)], dtype=torch.float32, device=device)
+        _THRESHOLD_CACHE[key] = cached
+    return cached, False
+
+
+def triton_rfdetr_fullpost(
+    bboxes: torch.Tensor,                  # (B=1, num_queries, 4) fp32 normalized cxcywh
+    logits: torch.Tensor,                  # (B=1, num_queries, num_classes_total) fp32/fp16
+    masks: torch.Tensor,                   # (B=1, num_queries, mask_h, mask_w) fp32
+    threshold: "torch.Tensor | float",
+    num_classes: int,
+    class_mapping: Optional[torch.Tensor],
+    inference_size_wh: Tuple[int, int],    # (W, H) of the inference image
+    pad_ltrb: Tuple[int, int, int, int],   # (left, top, right, bottom) in inference coords
+    scale_wh: Tuple[float, float],         # (scale_w, scale_h) = eff_w/orig_w, eff_h/orig_h
+    orig_size_wh: Tuple[int, int],         # (W, H) of the original image
+) -> Tuple[
+    torch.Tensor,      # combined (num_queries, 6) int32 — UNSLICED
+    torch.Tensor,      # mask_bin (num_queries, orig_h, orig_w) uint8 — UNSLICED
+    torch.Tensor,      # mask_any (num_queries,) int32 — UNSLICED
+    torch.Tensor,      # counter (1,) int32 — caller reads to get n_survivors
+    "torch.cuda.Event",  # done event — wait before DtoH from different stream
+]:
+    """Full RF-DETR post-process fused into two Triton launches.
+
+    Returns unsliced buffers plus a GPU counter tensor and a completion event.
+    The caller is responsible for reading `counter` via pinned-host DtoH to
+    obtain `n_survivors`, then slicing `combined[:n]` and `mask_bin[:n]` on
+    the host. This avoids a CPU-blocking `counter.item()` on the postproc
+    stream that otherwise dominated the adapter's wait time.
+
+    Returns:
+        combined:    (num_queries, 6) int32 — per-slot record, slots
+                     [0, n_survivors) are valid: [x1, y1, x2, y2,
+                     conf_as_i32_bits, class_id].
+        mask_bin:    (num_queries, orig_h, orig_w) uint8 — slots
+                     [0, n_survivors) are valid.
+        mask_any:    (num_queries,) int32 — 1 if any pixel passed threshold.
+        counter:     (1,) int32 on device — holds n_survivors after the
+                     filter kernel completes.
+        done_event:  torch.cuda.Event recorded on the current stream after
+                     both Triton kernel launches. Consumers on other streams
+                     must `wait_event(done_event)` before reading the outputs.
+    """
+    assert TRITON_AVAILABLE, "triton not available"
+    assert bboxes.is_cuda and logits.is_cuda and masks.is_cuda
+    assert bboxes.shape[0] == 1 and logits.shape[0] == 1 and masks.shape[0] == 1, "batch=1 only"
+
+    device = bboxes.device
+    num_queries, num_classes_total = logits.shape[1], logits.shape[2]
+    _, _, mask_h, mask_w = masks.shape
+
+    # Flatten batch dim — these views are contiguous when batch=1 and the
+    # tensor came straight from TRT engine outputs, so .contiguous() is a
+    # no-op in the common case. Still call it to be defensive; torch skips
+    # the kernel launch when the view is already contiguous.
+    logits_2d = logits[0] if logits[0].is_contiguous() else logits[0].contiguous()
+    bboxes_2d = bboxes[0] if bboxes[0].is_contiguous() else bboxes[0].contiguous()
+    masks_3d = masks[0] if masks[0].is_contiguous() else masks[0].contiguous()
+
+    # Single combined int32 output buffer for all per-survivor scalar fields
+    # (xyxy [4] + conf_as_i32 + class_id = 6 int32 per slot). Reduces 3-4
+    # separate small .cpu() transfers at the adapter level to one.
+    combined = torch.empty((num_queries, 6), dtype=torch.int32, device=device)
+    survivor_idx = torch.empty((num_queries,), dtype=torch.int32, device=device)
+    mask_any = torch.empty((num_queries,), dtype=torch.int32, device=device)
+    # Atomic counter — must be zeroed each call since the filter kernel
+    # atomic_adds into it.
+    counter = torch.zeros((1,), dtype=torch.int32, device=device)
+
+    thr_tensor, per_class = _prepare_threshold(threshold, device, num_classes)
+
+    if class_mapping is not None:
+        has_remap = True
+        cmap = class_mapping if (
+            class_mapping.dtype == torch.int32
+            and class_mapping.device == device
+            and class_mapping.is_contiguous()
+        ) else class_mapping.to(dtype=torch.int32, device=device).contiguous()
+    else:
+        has_remap = False
+        cmap = _EMPTY_INT32.to(device, non_blocking=True)
+
+    inf_w, inf_h = inference_size_wh
+    pad_l, pad_t, _, _ = pad_ltrb
+    sw, sh = scale_wh
+    orig_w, orig_h = orig_size_wh
+
+    BLOCK_C = max(32, _next_pow2(num_classes_total))
+    _rfdetr_fullpost_filter_kernel[(num_queries,)](
+        logits_2d,
+        bboxes_2d,
+        thr_tensor,
+        cmap,
+        combined,
+        survivor_idx,
+        mask_any,
+        counter,
+        num_queries,
+        num_classes_total,
+        int(inf_w),
+        int(inf_h),
+        int(pad_l),
+        int(pad_t),
+        float(1.0 / sw),
+        float(1.0 / sh),
+        int(orig_w),
+        int(orig_h),
+        logits_2d.stride(0),
+        bboxes_2d.stride(0),
+        PER_CLASS=1 if per_class else 0,
+        HAS_REMAPPING=1 if has_remap else 0,
+        BLOCK_C=BLOCK_C,
+    )
+
+    # Launch the mask kernel with max grid (num_queries). Each program
+    # checks counter[0] on GPU and early-exits if its s index is out of
+    # range. This lets us skip a CPU-blocking counter.item() between the
+    # two kernel launches — both get queued to the stream immediately.
+    mask_bin_full = _get_mask_bin_buffer(num_queries, orig_h, orig_w, device)
+
+    BLOCK_H = 16
+    BLOCK_W = 16
+    grid = (
+        num_queries,
+        (orig_h + BLOCK_H - 1) // BLOCK_H,
+        (orig_w + BLOCK_W - 1) // BLOCK_W,
+    )
+    _rfdetr_fullpost_mask_kernel_compact[grid](
+        masks_3d,
+        survivor_idx,
+        counter,
+        mask_bin_full,
+        mask_any,
+        int(mask_h),
+        int(mask_w),
+        int(orig_h),
+        int(orig_w),
+        float(mask_h / orig_h),
+        float(mask_w / orig_w),
+        masks_3d.stride(0),
+        masks_3d.stride(1),
+        mask_bin_full.stride(0),
+        mask_bin_full.stride(1),
+        BLOCK_H=BLOCK_H,
+        BLOCK_W=BLOCK_W,
+    )
+
+    # Record a done-event so consumers on other streams can `wait_event` on
+    # it instead of forcing a CPU-blocking counter.item() here. The caller
+    # issues the counter DtoH on a pinned buffer in parallel with this event.
+    done_event = torch.cuda.Event()
+    done_event.record(torch.cuda.current_stream(device))
+
+    return (
+        combined,       # (num_queries, 6) int32 — unsliced
+        mask_bin_full,  # (num_queries, orig_h, orig_w) uint8 — unsliced
+        mask_any,       # (num_queries,) int32 — unsliced
+        counter,        # (1,) int32 on device
+        done_event,
+    )

--- a/inference_models/inference_models/models/rfdetr/triton_postprocess.py
+++ b/inference_models/inference_models/models/rfdetr/triton_postprocess.py
@@ -1,0 +1,153 @@
+"""Fused Triton kernel for RF-DETR post-processing first stage.
+
+Replaces the sequence
+  sigmoid(logits) -> argmax(class) -> named-filter -> confidence-threshold
+with a single kernel launch. The remaining ops (sort, gather by index, bbox
+denorm, mask alignment) stay in torch.
+
+Per-query: logits row has `num_classes_total` entries (num_classes + optional
+"no-object" slot at the end). The kernel computes, for each query:
+  conf[q]     = max_c sigmoid(logits[q, c])
+  top_cls[q]  = argmax_c logits[q, c]
+  keep[q]     = (top_cls[q] < num_classes) & (conf[q] > threshold[top_cls[q]])
+"""
+from typing import Optional, Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    triton = None
+    tl = None
+    TRITON_AVAILABLE = False
+
+
+if TRITON_AVAILABLE:
+
+    @triton.jit
+    def _rfdetr_conf_filter_kernel(
+        logits_ptr,
+        threshold_ptr,
+        scalar_threshold,
+        class_map_ptr,  # (num_classes_total,) int, maps raw class -> remapped id; -1 = drop
+        conf_out_ptr,
+        top_class_out_ptr,
+        keep_out_ptr,
+        num_queries,
+        num_classes,
+        num_classes_total,
+        logits_stride_q,
+        PER_CLASS: tl.constexpr,
+        HAS_REMAPPING: tl.constexpr,
+        BLOCK_C: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        if pid >= num_queries:
+            return
+        offs_c = tl.arange(0, BLOCK_C)
+        mask_c = offs_c < num_classes_total
+        logits_row = tl.load(
+            logits_ptr + pid * logits_stride_q + offs_c,
+            mask=mask_c,
+            other=-float("inf"),
+        )
+        max_val = tl.max(logits_row, axis=0)
+        BIG = 1 << 30
+        is_max = logits_row == max_val
+        idx_or_big = tl.where(is_max & mask_c, offs_c, BIG)
+        raw_c = tl.min(idx_or_big, axis=0)
+        if HAS_REMAPPING:
+            top_c = tl.load(class_map_ptr + raw_c)
+            valid = top_c >= 0
+        else:
+            top_c = raw_c
+            valid = raw_c < num_classes
+        abs_max = tl.abs(max_val)
+        z = tl.exp(-abs_max)
+        sig_pos = 1.0 / (1.0 + z)
+        sig_neg = z / (1.0 + z)
+        conf = tl.where(max_val >= 0.0, sig_pos, sig_neg)
+        if PER_CLASS:
+            safe_c = tl.where(valid, top_c, 0)
+            thr = tl.load(threshold_ptr + safe_c)
+        else:
+            thr = scalar_threshold
+        keep = valid & (conf > thr)
+        tl.store(conf_out_ptr + pid, conf)
+        tl.store(top_class_out_ptr + pid, top_c)
+        tl.store(keep_out_ptr + pid, keep.to(tl.int8))
+
+
+def _next_pow2(n: int) -> int:
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+def triton_rfdetr_conf_filter(
+    logits: torch.Tensor,
+    threshold: "torch.Tensor | float",
+    num_classes: int,
+    class_mapping: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused sigmoid + argmax + named/remap-filter + confidence-threshold.
+
+    Args:
+        logits: (num_queries, num_classes_total) CUDA tensor for a single image.
+        threshold: scalar float or (num_classes,) CUDA tensor (per remapped id).
+        num_classes: number of named classes (when no remapping: drop rows
+            where argmax >= num_classes).
+        class_mapping: optional (num_classes_total,) int32/int64 CUDA tensor:
+            raw_class -> remapped_id, or -1 to drop.
+
+    Returns:
+        (conf, top_class, keep) each of length num_queries.
+    """
+    assert logits.is_cuda and logits.ndim == 2
+    num_queries, num_classes_total = logits.shape
+    logits_c = logits.contiguous()
+
+    device = logits.device
+    conf = torch.empty((num_queries,), dtype=torch.float32, device=device)
+    top_c = torch.empty((num_queries,), dtype=torch.int32, device=device)
+    keep = torch.empty((num_queries,), dtype=torch.int8, device=device)
+
+    if isinstance(threshold, torch.Tensor):
+        per_class = True
+        thr_tensor = threshold.contiguous()
+        scalar_thr = 0.0
+    else:
+        per_class = False
+        thr_tensor = torch.empty((1,), dtype=torch.float32, device=device)
+        scalar_thr = float(threshold)
+
+    if class_mapping is not None:
+        has_remap = True
+        cmap = class_mapping.to(dtype=torch.int32, device=device).contiguous()
+    else:
+        has_remap = False
+        cmap = torch.empty((1,), dtype=torch.int32, device=device)
+
+    BLOCK_C = max(32, _next_pow2(num_classes_total))
+    _rfdetr_conf_filter_kernel[(num_queries,)](
+        logits_c,
+        thr_tensor,
+        scalar_thr,
+        cmap,
+        conf,
+        top_c,
+        keep,
+        num_queries,
+        num_classes,
+        num_classes_total,
+        logits_c.stride(0),
+        PER_CLASS=1 if per_class else 0,
+        HAS_REMAPPING=1 if has_remap else 0,
+        BLOCK_C=BLOCK_C,
+    )
+    return conf, top_c, keep.bool()

--- a/inference_models/inference_models/models/rfdetr/triton_preprocess.py
+++ b/inference_models/inference_models/models/rfdetr/triton_preprocess.py
@@ -1,0 +1,204 @@
+"""Fused Triton preprocessing kernel for RF-DETR seg (stretch-to resize).
+
+Replaces: cv2.resize(BGR) -> torch.from_numpy.to(cuda) -> unsqueeze -> permute
+-> BGR->RGB fancy index -> /255 -> normalize. Eight+ CUDA launches on a
+tiny 312x312 tensor collapse into one Triton launch.
+"""
+from typing import Optional, Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    triton = None
+    tl = None
+    TRITON_AVAILABLE = False
+
+
+if TRITON_AVAILABLE:
+
+    @triton.jit
+    def _rfdetr_stretch_preprocess_kernel(
+        src_ptr,
+        dst_ptr,
+        src_h,
+        src_w,
+        src_stride_h,
+        src_stride_w,
+        target_h,
+        target_w,
+        scale_y,
+        scale_x,
+        inv_std_r_255,
+        inv_std_g_255,
+        inv_std_b_255,
+        offset_r,
+        offset_g,
+        offset_b,
+        dst_stride_c,
+        dst_stride_h,
+        BLOCK_H: tl.constexpr,
+        BLOCK_W: tl.constexpr,
+    ):
+        """Stretch-to resize + BGR->RGB + normalize, fused.
+
+        Src: uint8 HWC BGR.
+        Dst: fp32 (1, 3, target_h, target_w) CHW RGB, normalized to
+        (pixel / 255 - mean) / std.
+
+        We pre-fold the division: inv_std_c_255 = 1 / (255 * std_c), and
+        pre-fold the subtraction: offset_c = -mean_c / std_c (done on host).
+        So the per-pixel math becomes: pixel * inv_std_c_255 + offset_c.
+        """
+        pid_y = tl.program_id(0)
+        pid_x = tl.program_id(1)
+
+        offs_y = pid_y * BLOCK_H + tl.arange(0, BLOCK_H)
+        offs_x = pid_x * BLOCK_W + tl.arange(0, BLOCK_W)
+        mask_y = offs_y < target_h
+        mask_x = offs_x < target_w
+        mask = mask_y[:, None] & mask_x[None, :]
+
+        # Pixel-center bilinear sampling for parity with cv2.resize.
+        src_y_f = (offs_y.to(tl.float32) + 0.5) * scale_y - 0.5
+        src_x_f = (offs_x.to(tl.float32) + 0.5) * scale_x - 0.5
+
+        src_y_f_2d = src_y_f[:, None]
+        src_x_f_2d = src_x_f[None, :]
+
+        y0 = tl.floor(src_y_f_2d).to(tl.int32)
+        x0 = tl.floor(src_x_f_2d).to(tl.int32)
+        y1 = y0 + 1
+        x1 = x0 + 1
+
+        dy = src_y_f_2d - y0.to(tl.float32)
+        dx = src_x_f_2d - x0.to(tl.float32)
+
+        y0c = tl.maximum(tl.minimum(y0, src_h - 1), 0)
+        y1c = tl.maximum(tl.minimum(y1, src_h - 1), 0)
+        x0c = tl.maximum(tl.minimum(x0, src_w - 1), 0)
+        x1c = tl.maximum(tl.minimum(x1, src_w - 1), 0)
+
+        base_00 = y0c * src_stride_h + x0c * src_stride_w
+        base_01 = y0c * src_stride_h + x1c * src_stride_w
+        base_10 = y1c * src_stride_h + x0c * src_stride_w
+        base_11 = y1c * src_stride_h + x1c * src_stride_w
+
+        w_tl = (1.0 - dy) * (1.0 - dx)
+        w_tr = (1.0 - dy) * dx
+        w_bl = dy * (1.0 - dx)
+        w_br = dy * dx
+
+        # BGR source: channel 0=B, 1=G, 2=R. Output order is RGB.
+        p00_b = tl.load(src_ptr + base_00 + 0, mask=mask, other=0).to(tl.float32)
+        p01_b = tl.load(src_ptr + base_01 + 0, mask=mask, other=0).to(tl.float32)
+        p10_b = tl.load(src_ptr + base_10 + 0, mask=mask, other=0).to(tl.float32)
+        p11_b = tl.load(src_ptr + base_11 + 0, mask=mask, other=0).to(tl.float32)
+        b_val = p00_b * w_tl + p01_b * w_tr + p10_b * w_bl + p11_b * w_br
+
+        p00_g = tl.load(src_ptr + base_00 + 1, mask=mask, other=0).to(tl.float32)
+        p01_g = tl.load(src_ptr + base_01 + 1, mask=mask, other=0).to(tl.float32)
+        p10_g = tl.load(src_ptr + base_10 + 1, mask=mask, other=0).to(tl.float32)
+        p11_g = tl.load(src_ptr + base_11 + 1, mask=mask, other=0).to(tl.float32)
+        g_val = p00_g * w_tl + p01_g * w_tr + p10_g * w_bl + p11_g * w_br
+
+        p00_r = tl.load(src_ptr + base_00 + 2, mask=mask, other=0).to(tl.float32)
+        p01_r = tl.load(src_ptr + base_01 + 2, mask=mask, other=0).to(tl.float32)
+        p10_r = tl.load(src_ptr + base_10 + 2, mask=mask, other=0).to(tl.float32)
+        p11_r = tl.load(src_ptr + base_11 + 2, mask=mask, other=0).to(tl.float32)
+        r_val = p00_r * w_tl + p01_r * w_tr + p10_r * w_bl + p11_r * w_br
+
+        # Math: (pixel/255 - mean) / std  ==  pixel * (1/(255*std)) + (-mean/std).
+        # inv_std_c_255 and offset_c are computed on the host and passed in.
+        r_out = r_val * inv_std_r_255 + offset_r
+        g_out = g_val * inv_std_g_255 + offset_g
+        b_out = b_val * inv_std_b_255 + offset_b
+
+        out_row_offsets = offs_y[:, None] * dst_stride_h + offs_x[None, :]
+        tl.store(dst_ptr + 0 * dst_stride_c + out_row_offsets, r_out, mask=mask)
+        tl.store(dst_ptr + 1 * dst_stride_c + out_row_offsets, g_out, mask=mask)
+        tl.store(dst_ptr + 2 * dst_stride_c + out_row_offsets, b_out, mask=mask)
+
+
+def triton_preprocess_rfdetr_stretch(
+    src: torch.Tensor,
+    target_h: int,
+    target_w: int,
+    means: Tuple[float, float, float] = (0.485, 0.456, 0.406),
+    stds: Tuple[float, float, float] = (0.229, 0.224, 0.225),
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Fused preprocess: uint8 HWC BGR -> fp32 (1,3,target_h,target_w) CHW RGB
+    normalized (stretch-to resize, no padding)."""
+    if not TRITON_AVAILABLE:
+        raise RuntimeError("triton is not installed")
+    if not src.is_cuda:
+        raise ValueError(f"expected CUDA tensor, got device={src.device}")
+    if src.dtype != torch.uint8:
+        raise ValueError(f"expected uint8, got {src.dtype}")
+    if src.ndim != 3 or src.shape[2] != 3:
+        raise ValueError(f"expected HWC 3-channel, got shape={tuple(src.shape)}")
+
+    src = src.contiguous()
+    src_h, src_w = int(src.shape[0]), int(src.shape[1])
+    src_stride_h = int(src.stride(0))
+    src_stride_w = int(src.stride(1))
+
+    scale_y = src_h / target_h
+    scale_x = src_w / target_w
+
+    if out is None:
+        out = torch.empty(
+            (1, 3, target_h, target_w), dtype=torch.float32, device=src.device
+        )
+    else:
+        if tuple(out.shape) != (1, 3, target_h, target_w):
+            raise ValueError(
+                f"out has shape {tuple(out.shape)}, expected (1, 3, {target_h}, {target_w})"
+            )
+        if out.dtype != torch.float32 or not out.is_cuda:
+            raise ValueError("out must be fp32 CUDA tensor")
+
+    dst_stride_c = target_h * target_w
+    dst_stride_h = target_w
+
+    inv_std_r_255 = 1.0 / (255.0 * stds[0])
+    inv_std_g_255 = 1.0 / (255.0 * stds[1])
+    inv_std_b_255 = 1.0 / (255.0 * stds[2])
+    offset_r = -means[0] / stds[0]
+    offset_g = -means[1] / stds[1]
+    offset_b = -means[2] / stds[2]
+
+    BLOCK_H = 16
+    BLOCK_W = 16
+    grid = (
+        (target_h + BLOCK_H - 1) // BLOCK_H,
+        (target_w + BLOCK_W - 1) // BLOCK_W,
+    )
+    _rfdetr_stretch_preprocess_kernel[grid](
+        src,
+        out,
+        src_h,
+        src_w,
+        src_stride_h,
+        src_stride_w,
+        target_h,
+        target_w,
+        float(scale_y),
+        float(scale_x),
+        float(inv_std_r_255),
+        float(inv_std_g_255),
+        float(inv_std_b_255),
+        float(offset_r),
+        float(offset_g),
+        float(offset_b),
+        dst_stride_c,
+        dst_stride_h,
+        BLOCK_H=BLOCK_H,
+        BLOCK_W=BLOCK_W,
+    )
+    return out

--- a/jetson_parallel_streams_analysis.md
+++ b/jetson_parallel_streams_analysis.md
@@ -1,0 +1,156 @@
+# Roboflow Inference on Jetson — Static Analysis of Parallel-Stream Throughput
+
+## Engine Configuration (RESOLVED)
+
+The `trt_config.json` shipped alongside the `rfdetr-seg-nano` engine is available in-repo as a test asset:
+
+- `/home/ubuntu/inference/inference_models/tests/integration_tests/models/assets/models/rfdetr-seg-nano-t4-trt/unpacked/trt_config.json`:
+  `{"static_batch_size": 1, "dynamic_batch_size_min": null, "dynamic_batch_size_opt": null, "dynamic_batch_size_max": null}`
+- `inference_config.json` in the same directory: `training_input_size: 312×312`, stretch resize, ImageNet normalization, `dynamic_spatial_size_supported: false`.
+- Engine file size: ~187 MB.
+
+**What this means.** The shipped engine is **hard-coded to batch size 1**. The cross-stream batching path in `trt.py:607-675` cannot engage — with `max_batch_size=1`, any N-frame batch is split into N serial single-frame forwards in a Python loop (`trt.py:644-675`), each holding the `threading.Lock()` at `rfdetr_instance_segmentation_trt.py:253`. This confirms the static-analysis hypothesis: Opportunity #1 is real and blocked by engine config, not code.
+
+**Target hardware from the engine blob: Tesla T4 (sm_75, Turing).** Confirmed by dumping the TRT engine inspector JSON on `rfdetr-seg-nano-t4-trt/unpacked/engine.plan` — every kernel tactic in the engine is prefixed `sm75_xmma_*` (e.g., `sm75_xmma_gemm_f16f16_f16f16_f16_...`). `hardware_compatibility_level` is `NONE`, meaning the engine is locked to sm_75 and will not load on Orin NX (sm_87, Ampere). The `-t4-trt` filename suffix matches: this package is T4-only.
+
+**Implication for Orin NX deployment.** There is **no on-device rebuild path invoked at runtime** — `RUNS_ON_JETSON` appears in the codebase only at `inference/core/env.py:701` and `video_source.py:184` (for V4L2 capture-backend selection). The TRT compile entry points in `inference_models/development/compile_rfdetr.py` and `compilation/engine_builder.py` are developer scripts, not runtime hooks. Therefore, the Orin NX deployment must be pulling a **separate, Orin-built `.plan`** that is not present in this repo checkout. The `trt_config.json` we can see (`static_batch_size: 1`) is almost certainly the same config used for the Orin build, but this cannot be confirmed without reading the Orin model cache directly.
+
+**Other caveats:**
+- Training input size shown is 312×312, not 560×560 as in `development/compile_rfdetr.py:22`. The compile script is a different variant (base, not nano). Nano-seg genuinely runs at 312×312 — so inference is on a substantially smaller tensor than the 560×560 assumption in earlier notes.
+- This is a test asset snapshot (2026-04-21). The production Orin package could carry a different config.
+
+## Target Hardware
+
+**Jetson Orin NX** (confirmed by Brad). Implications for the analysis below:
+- Single NVDEC engine — easily handles 4× 1080p30 H.264/H.265 on paper, so NVDEC is a real lever (§1).
+- 2 DLA cores available (unlike Xavier NX's 2, Nano's 0), but DLA value for RF-DETR seg is still gated by the transformer head (§8).
+- 8 GB or 16 GB unified LPDDR5, shared with CPU — makes zero-copy / mapped-memory particularly attractive and makes large-batch engines memory-constrained (§3, §6).
+- 6 or 8 Cortex-A78AE cores — CPU decode + CPU preprocessing + Python GIL is a harder ceiling here than on AGX Orin (§1, §2, §7).
+- Current observed per-stream FPS and target FPS: **TBD — to be established by runtime measurement.**
+
+## Executive Summary
+
+- **Current architecture (one paragraph).** `InferencePipeline` spawns one decode thread per `VideoSource` using OpenCV `cv2.VideoCapture` (CPU decode). A multiplexer collects frames from N sources into a single batch list and hands them to a single inference thread, which invokes a compiled Workflow. The one model block (`RFDetrForInstanceSegmentationTRT`) holds a single TensorRT engine, a single `IExecutionContext`, and a `threading.Lock()` that serializes every forward pass. Pre-process runs on one CUDA stream, the forward runs on a second, post-process on a third, each followed by a `synchronize()`. With N parallel streams, only the decode stage is actually parallel; model execution is strictly sequential.
+- **Top 3 throughput opportunities, ranked.**
+  1. **Batched forward across streams.** High-confidence. N streams arrive as a list but batch size 1 engines are the default observed path; moving from N sequential forwards to one batched forward is the biggest potential lever. (`_infer_from_trt_engine_with_batch_size_boundaries`, `trt.py:588-604`).
+  2. **CPU video decode + CPU-side preprocessing.** High-confidence from code, size pending runtime evidence. Decode is pure `cv2.VideoCapture` (`video_source.py:140-142`); the numpy preprocessing path does `cv2.cvtColor`/`cv2.resize` on CPU before H2D copy (`pre_processing.py:973,1052-1053`). On Jetson this competes with the Python GIL and inference.
+  3. **Per-stage `stream.synchronize()` scaffolding.** Medium-confidence hypothesis. Each of pre/forward/post ends with a blocking sync (`rfdetr_instance_segmentation_trt.py:243, 293` plus the lock at 253); event-based chaining could overlap stages across frames.
+- **Negatives worth flagging early:** No NVDEC, GStreamer, DeepStream, VPI, or DLA code paths anywhere in the repo (see §1, §8, §10). INT8 flag is supported in builder but no calibration code is committed (§3).
+
+## Current Implementation Map
+
+Tracing one frame from a single stream:
+
+1. A `VideoSource` is constructed around `CV2VideoFrameProducer` (`inference/core/interfaces/camera/video_source.py:136-142`). On Jetson camera devices it uses `cv2.CAP_V4L2`; otherwise the default FFmpeg backend. No GStreamer/NVDEC pipeline string is ever passed.
+2. Each source runs a dedicated decode thread started at `video_source.py:635` (`_consume_video`), pushing decoded CPU `ndarray` frames into a per-source `frames_buffer` Queue.
+3. `InferencePipeline._generate_frames()` (`inference_pipeline.py:1031-1044`) delegates to `multiplex_videos()`, which calls `VideoSourcesManager.retrieve_frames_from_sources()` (`camera/utils.py:143-175`). That method loops over sources serially, appending whatever frame is ready within `batch_collection_timeout`.
+4. The inference thread (`inference_pipeline.py:914-922`) runs `predictions = self._on_video_frame(video_frames)` on the batch, then pushes `(predictions, video_frames)` onto a dispatch queue.
+5. `_on_video_frame` is a partial wrapping `WorkflowRunner.run_workflow` (`model_handlers/workflows.py:10-60`), which wraps each frame as `{"type": "numpy_object", "value": ndarray, ...}` and calls `execution_engine.run(...)`.
+6. The Workflow is compiled once at pipeline init (`inference_pipeline.py` init_with_workflow path; compilation cached at `workflows/execution_engine/v1/compiler/core.py:60-69`). The single-block Workflow executes the RF-DETR seg block, which calls `model.infer([...])`.
+7. Inside `RFDetrForInstanceSegmentationTRT`: `pre_process` (line 225) → `forward` (246) → `post_process` (268). Forward acquires `self._lock` and pushes the primary CUDA context (line 253-254). Under the hood, `_execute_trt_engine` either replays a cached CUDA graph (`trt.py:706-713`) or sets dynamic input shape and runs `execute_async_v3` (`trt.py:716-740`).
+
+**What changes with N parallel streams.** Decode remains N-way parallel (N OS threads, CPU). The multiplexer serializes retrieval into one list. The inference thread processes that list as one workflow invocation; the SIMD-batch workflow path (`workflows/execution_engine/v1/executor/core.py:317-378`) passes the full list to the block's single `run()` call. The block, however, receives a list of numpy arrays, and preprocessing loops over them one-by-one on CPU (`pre_processing.py:843-865`) before concatenating tensors. The TRT forward is thus the only place where batching across streams could pay off, and only if the engine was built with `dynamic_batch_size_max ≥ N`.
+
+## Findings by Category
+
+### 1. Stream ingestion and decode path
+
+- **What the code does:** All decoding goes through `cv2.VideoCapture(video)` or `cv2.VideoCapture(video, cv2.CAP_V4L2)` (`video_source.py:140-142`). There is no GStreamer pipeline string, no PyAV, no DeepStream, no Jetson Multimedia API usage anywhere in `inference/` or `inference_models/`. `retrieve()` returns a host `ndarray` (`video_source.py:150-151`).
+- **Why it matters:** On Jetson, FFmpeg-backed `VideoCapture` does CPU H.264/H.265 decode by default, bypassing NVDEC. For N 30fps streams this is N separate CPU decoders fighting the GIL alongside inference.
+- **Confidence:** verified from code for the decoder path; "FFmpeg CPU decode" is the default runtime behavior of OpenCV unless a GStreamer pipeline is passed, which it never is here.
+- **Estimated opportunity:** medium-to-large — NVDEC on Orin can decode many 1080p30 streams at negligible CPU cost.
+
+### 2. Preprocessing pipeline
+
+- **What the code does:** The numpy path (`pre_process_numpy_images_list`, `pre_processing.py:843-865`) calls `pre_process_numpy_image` per image in a Python `for` loop, concatenating tensors at the end. Within each iteration, grayscale/contrast transforms and resize use `cv2.cvtColor` (`:973`) and `cv2.resize` (`:1052`, `:1104`, `:1254`) on the CPU. Only after the resize does the code do `torch.from_numpy(...).to(target_device)` (`:1053, :1105, :1269`) — one H2D copy per image.
+- **Why it matters:** On N streams this is N CPU resizes plus N H2D copies per multiplex cycle. For RF-DETR nano seg at 560×560 input, this is non-trivial but small per-frame; it becomes the bottleneck when decode+preprocess time exceeds the available Python runtime budget between forwards.
+- **Confidence:** verified from code.
+- **Estimated opportunity:** medium — batching resize on GPU (e.g., via torchvision, VPI, or a single concat-then-resize) would remove the per-image Python overhead.
+
+### 3. TensorRT engine instantiation and batching (CRITICAL)
+
+- **Single context, lock-serialized.** `engine.create_execution_context()` is called once in `from_pretrained` (`rfdetr_instance_segmentation_trt.py:159`), stored as `self._execution_context`. Every `forward()` acquires `self._lock = threading.Lock()` (set at `:216`) before invoking the engine (`:253-265`). This lock is the choke point for parallel streams — even if the workflow hands the block a list of N frames, the forward is still a single lock-protected call.
+- **Dynamic shapes and batching are supported but splitting/padding happens automatically.** `_infer_from_trt_engine_with_batch_size_boundaries` (`trt.py:607-675`) pads a batch up to `min_batch_size` with zeros (`:619-631`) or splits anything larger than `max_batch_size` into serial sub-batches in a Python for loop (`:644-675`). The engine build profile reads `dynamic_batch_size_min/opt/max` from `trt_config.json` (`model_packages.py:146-196`).
+- **CUDA graphs, when enabled, require fixed shapes.** A separate `graph_context = engine.create_execution_context()` is created per captured shape (`trt.py:759`, comment at `:756-758`). The replay path (`:706-713`) is the fast path and avoids the per-call `set_input_shape`/`set_tensor_address` work at `:716-722`.
+- **Precision.** Builder supports FP32/FP16/INT8 (`engine_builder.py:80-87`). The RF-DETR compile script at `inference_models/development/compile_rfdetr.py:22` requests FP16/FP32 for 560×560 inputs, with 15 GB workspace (`:11`). No committed INT8 calibration code.
+- **Why it matters:** With `max_batch_size ≥ N`, N streams could be one forward. But if the `.plan` shipped to the Jetson was built with `static_batch_size=1` or `max=1`, the code at `trt.py:644-675` degrades to a Python loop of single-frame forwards. The practical throughput for parallel streams therefore depends entirely on what `trt_config.json` ships inside the RF-DETR seg model package — which we cannot see from this repo alone.
+- **Confidence:** single-context + global lock is verified from code; actual batch capabilities of the shipped `.plan` are a runtime artifact we cannot read.
+- **Estimated opportunity:** large — if the engine is batch-1, rebuilding with a dynamic profile unlocks the single biggest lever.
+
+### 4. CUDA stream usage and async execution
+
+- **What the code does:** Three CUDA streams per model instance — one inference stream on the class (`rfdetr_instance_segmentation_trt.py:217`), plus per-thread pre- and post-process streams via `threading.local()` (`:218`, `:297-310`). The forward uses `execute_async_v3(stream_handle=stream.cuda_stream)` (`trt.py:740`). However, each stage ends with an explicit `stream.synchronize()` (`:243`, `:293`, `trt.py:712`).
+- **Why it matters:** The streams are real, but the synchronize barriers between stages mean pre-process finishes → sync → forward → sync → post → sync, serially. Within a single forward call, the async execution is in principle overlapping with any prior post-process work on a different stream; in practice the `synchronize()` at end of each stage blocks until completion and the downstream stage waits.
+- **Confidence:** verified from code for the sync points; whether they are required for correctness or just defensive is a code-reading judgment — the post-process sync at `:293` is plausibly redundant because consumers of the returned `InstanceDetections` will cause their own syncs.
+- **Estimated opportunity:** small-to-medium — cross-frame pipelining would require a redesign of the model handler; the per-frame overhead is likely tens of milliseconds total but won't multiply with N.
+
+### 5. Postprocessing
+
+- **What the code does:** RF-DETR seg post-processing runs entirely on GPU tensors (`inference_models/models/rfdetr/common.py:45-129`): sigmoid, top-k, gather on masks, cxcywh→xyxy. `align_instance_segmentation_results` is GPU-based. No `.cpu()`, `.numpy()`, or `.item()` calls inside the post_process method at `rfdetr_instance_segmentation_trt.py:268-294`. Final `.cpu()` transfers happen at the workflow boundary, not inside the model.
+- **Why it matters:** Post-processing is already well-structured. It is not a major target.
+- **Confidence:** verified from code.
+- **Estimated opportunity:** small.
+
+### 6. Memory management
+
+- **What the code does:** CUDA graphs reuse `input_buffer`/`output_buffers` allocated at capture time (`trt.py:761, 779-789`), cached in an LRU keyed by input shape (`TRTCudaGraphCache`, `trt.py:83-272`, default size 8). The non-graph path, however, allocates a fresh output tensor every forward (`trt.py:732-736`: `result = torch.empty(tuple(output_tensor_shape), ...)`). No `cudaHostAlloc` with mapped flag, no `cudaMallocManaged`, no pinned-memory pool — the only pinning comes from PyTorch's default allocator.
+- **Why it matters:** Jetson's physically unified memory means CPU→GPU copies are logical, not over PCIe, but Torch still does a staged copy by default. Zero-copy of the decoded frame into a GPU-addressable buffer would cut a full frame-sized H2D per stream per frame. This repo has no such path.
+- **Confidence:** verified from code for absence of zero-copy.
+- **Estimated opportunity:** medium on Jetson; same change on discrete GPU would be small.
+
+### 7. Threading / process model in InferencePipeline
+
+- **What the code does:** N decode threads (one per `VideoSource`) → shared queues → one inference thread (`inference_pipeline.py:906-922`) → one dispatch thread. Workflow block execution can use a `ThreadPoolExecutor` but for a single-block workflow there is nothing to parallelize.
+- **Why it matters:** This topology is actually good for batching — the multiplexer already produces a per-iteration list of frames, one per active source. The missed opportunity is downstream: the model handler serializes that list through one lock.
+- **Confidence:** verified from code.
+- **Estimated opportunity:** small in isolation (the topology is already set up to feed a batch); the value comes from pairing with batched inference (§3).
+
+### 8. DLA usage
+
+- **What the code does:** Nothing. `grep` for `DLA`, `useDLACore`, `setDeviceType`, `kDLA` across `inference_models/` returns no matches (confirmed by the TRT exploration). The only builder config beyond precision is `hardware_compatibility_level = trt.HardwareCompatibilityLevel.SAME_COMPUTE_CAPABILITY` (`engine_builder.py:91`).
+- **Why it matters:** RF-DETR's transformer blocks almost certainly cannot target DLA, but the CNN backbone could if split. No such path exists.
+- **Confidence:** verified from code (absence).
+- **Estimated opportunity:** unknown — likely small for seg because of the transformer head, and would require engine-graph surgery.
+
+### 9. Workflow / single-block overhead
+
+- **What the code does:** Workflow compilation is cached (`workflows/execution_engine/v1/compiler/core.py:60-69`). Per frame, however, `assemble_runtime_parameters` pydantic-validates inputs (`runtime_input_assembler.py:16-42`), fresh `ExecutionCache`/`DynamicBatchesManager`/`BranchingManager` instances are created in `ExecutionDataManager.init()` (`execution_data_manager/manager.py:48-66`), and step-input assembly traverses the compound input graph. For a single-block SIMD workflow the block is called once per batch with the full list, so the overhead is amortized across all N frames in the batch.
+- **Why it matters:** Python orchestration is per-*batch* not per-*frame*, which is a relief at higher stream counts. But per-batch it is still measurable.
+- **Confidence:** verified from code.
+- **Estimated opportunity:** small — would only show up at very high N or very fast inference (where Python overhead approaches forward time).
+
+### 10. Jetson-specific code paths
+
+- **What the code does:** Jetson detection exists (`inference/core/devices/utils.py:68-86`, reading `/proc/device-tree/serial-number`) and is used for device-id reporting and the V4L2 capture-backend choice (`video_source.py:183-188`). The adaptive buffer-filling strategy is the default for streams (`video_source.py:932` per agent report). No `nvpmodel`, `jetson_clocks`, JetPack version check, VPI library usage, or DeepStream integration anywhere.
+- **Why it matters:** There is essentially no Jetson-specific optimization beyond "use V4L2 for USB cameras." RF-DETR on Jetson runs the same code path as on desktop CUDA.
+- **Confidence:** verified from code.
+- **Estimated opportunity:** medium — Jetson-specific hooks (NVDEC, VPI, mapped-memory frames) are untouched ground.
+
+## Top Opportunities, Ranked
+
+1. **Batched TRT forward across streams.** Feed the multiplexer's N-frame list as a single batched tensor to one `execute_async_v3`. *Impact (static-analysis estimate): 1.5–2x on N=4 if the engine supports it.* **Runtime evidence needed:** the `trt_config.json` shipped in the RF-DETR seg model package (look at `static_batch_size` and `dynamic_batch_size_max`), and a `trtexec --loadEngine --shapes` run at batch 1 vs 4 to confirm that amortized kernel time scales sublinearly.
+2. **GPU video decode via NVDEC / GStreamer pipeline string into `VideoCapture`.** Replace `cv2.VideoCapture(video)` at `video_source.py:140-142` with a GStreamer appsink pipeline that uses `nvv4l2decoder`/`nvvidconv` on Jetson. *Impact: 10–30% CPU headroom at N=4, 30fps 1080p; also removes GIL contention with the inference thread.* **Runtime evidence:** `tegrastats` during a 4-stream run showing CPU saturation; Nsight Systems trace showing decode threads blocking inference.
+3. **GPU-side batched preprocessing (skip the per-image Python loop).** The current `pre_process_numpy_images_list` loop (`pre_processing.py:843-865`) with its per-image `cv2.resize` → `from_numpy` → `.to(device)` chain is a serial CPU gauntlet. *Impact: 1.1–1.3x at N=4.* **Runtime evidence:** Nsight kernel timeline showing gaps between H2D copies; CPU sampling profiler (py-spy) showing time in `cv2.resize` and `to_numpy`.
+4. **Eliminate mid-pipeline `stream.synchronize()` barriers.** The three stage-ending syncs (`rfdetr_instance_segmentation_trt.py:243, 293`, `trt.py:712`) plus the global lock mean no overlap across frames. *Impact: 5–20% at N=4, depending on how close pre/post times are to forward time.* **Runtime evidence:** Nsight Systems trace showing gaps between kernels on the inference stream.
+5. **Zero-copy or pinned-memory input buffer on Jetson.** The non-CUDA-graph path allocates output tensors every forward (`trt.py:732-736`); the input also transits a staged copy. *Impact: 5–15% at N=4.* **Runtime evidence:** Nsight memory trace showing H2D/D2H transfer time relative to compute.
+
+## What Static Analysis Cannot Tell Us
+
+- **The actual batch capabilities of the shipped `.plan` file.** `dynamic_batch_size_max` lives in the model package `trt_config.json`, not in this repo. *Resolves with:* reading `trt_config.json` from the cached model package directory, or `trtexec --loadEngine=engine.plan --verbose` dumping profile ranges.
+- **Where wall-clock time is actually being spent.** Decode vs preprocess vs forward vs post vs Python overhead. *Resolves with:* Nsight Systems CPU+GPU timeline for a 4-stream run.
+- **Whether `execute_async_v3` kernels on the three streams actually overlap, or serialize on a single engine queue.** TRT execution contexts cannot run two enqueues concurrently on one context regardless of stream. *Resolves with:* Nsight GPU kernel timeline showing kernel concurrency or lack thereof.
+- **Whether CUDA graph capture is actually in use for the RF-DETR seg workload.** The cache is set up (`establish_trt_cuda_graph_cache`) but activation depends on `disable_cuda_graphs` and input-shape stability. *Resolves with:* a log line or trace confirming graph replay vs full enqueue.
+- **Whether the OpenCV build on this Jetson is compiled with GStreamer support.** Without GStreamer in OpenCV, no pipeline-string backdoor is possible. *Resolves with:* `cv2.getBuildInformation()` on the target.
+- **Python GIL contention between decode threads and the inference thread.** *Resolves with:* py-spy sampled profile during a 4-stream run.
+- **Whether the `nvpmodel` / `jetson_clocks` state on the deployment unit has the GPU clocked to max.** *Resolves with:* `sudo nvpmodel -q` and `sudo jetson_clocks --show`.
+
+## Open Questions for Brad / Pawel
+
+1. **[OPEN — answer not yet known] What is the `.plan` file's dynamic shape profile** for RF-DETR nano seg as currently shipped from the inference-models cache? Specifically: what are `dynamic_batch_size_min/opt/max` in the shipped `trt_config.json`? This changes which optimization is first. Can be answered by reading the cached model package on an Orin NX that has already pulled the engine.
+2. **[PARTIALLY RESOLVED — code supports both patterns, production choice still unknown]** The codebase supports two deployment patterns:
+   - **Pattern A (single process, multiple streams):** `InferencePipeline.init_with_workflow(video_reference=[...])` — `inference_pipeline.py:90-91` accepts a list; docs at `docs/workflows/video_processing/overview.md:71` demonstrate it. Example in-repo: `development/stream_interface/yolo_world_demo.py:19`. One model instance, one lock, one TRT context.
+   - **Pattern B (multiple processes):** Enterprise Stream Manager spawns one `InferencePipelineManager(Process)` per pipeline (`inference/enterprise/stream_management/manager/inference_pipeline_manager.py:44`, spawned from `manager/app.py:146`). Each process independent: own engine, own context, no shared lock. On Jetson without MPS, contexts time-slice the GPU.
+   - **Impact on opportunities:** batched-forward (#1) only helps Pattern A; CUDA MPS and per-process engine-sharing tricks only help Pattern B; NVDEC decode, stage-sync removal, and GPU preprocessing help both. Needs product confirmation which is in use for the Orin NX deployment.
+3. **[ANSWERED] Target Jetson:** Orin NX. Captured in the "Target Hardware" section above.
+4. **[TO BE MEASURED] Actual observed per-stream FPS today on Orin NX, and expected FPS at 2x.** Needs a profiling run; gives us the budget to compare against the static-analysis estimates above.
+5. **[OPEN — answer not yet known] Was the `.plan` built on-device via the `RUNS_ON_JETSON` compile path, or shipped prebuilt?** Relevant because engines built with different `max_batch` may exist in the model cache, and rebuilding with a new profile is a different task from swapping an engine. Folds into Q1 — both resolve by inspecting what's in the model cache on a live Orin NX.


### PR DESCRIPTION
## Summary

Standalone PR: RF-DETR nano seg TensorRT e2e latency optimizations through to a depth-2 frame pipeline, benchmarked on `vehicles_312px.mp4` (538 frames, 312×176) with the minimal InferencePipeline benchmark script.

| Metric | Baseline | depth=1 (default after this PR) | depth=2 (opt-in via `RFDETR_PIPELINE_DEPTH=2`) |
|---|---|---|---|
| **Avg FPS** (Tesla T4, FP16 TRT) | **109** | **151** (+38%) | **241** (+121%) |
| Parity vs v16 best | — | 0 diff across 538 frames | 0 diff on 537 shifted pairs |

All new paths are opt-in behind env vars; defaults preserve current behavior (except for the two always-on CPU-side fixes noted below).

**Benchmark:**
```bash
python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
    --video_reference /home/ubuntu/inference/vehicles_312px.mp4
```

**Flags to enable (depth=1, matches 151 FPS row):**
- `RFDETR_USE_TRITON_PREPROC=true`
- `RFDETR_TRITON_FULLPOSTPROC=true`
- `ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND=true`

**Flags to enable (depth=2, matches 241 FPS row):** above three **plus** `RFDETR_PIPELINE_DEPTH=2`.

---

## Commit-by-commit

| # | Commit | Summary |
|---|---|---|
| 1 | `419c5a7` initial point | Branch starting point. |
| 2 | `9ec6a50` fused Triton pre/postproc kernels, GPU mask decode, stream sync reduction | First landing: Triton preprocess kernel, Triton conf-filter postprocess, CUDA-graph enablement, drop pre/post stream syncs. |
| 3 | `807ea1a` replace benchmark script with minimal InferencePipeline-based version | Switch benchmark harness to a 116-line InferencePipeline driver so measurements match production code paths. |
| 4 | `5ff27d1` full Triton postproc fusion + deferred counter sync (W2) | Collapses the post-TRT chain into two Triton kernels (`_rfdetr_fullpost_filter_kernel` + `_rfdetr_fullpost_mask_kernel_compact`). Removes the CPU-blocking `counter.item()` in the Triton wrapper; counter is now pinned-DtoH'd from the adapter under a `torch.cuda.Event` guard. Includes atomic-counter compaction, `_trt_reuse_as_input_buffer` marker (eliminates per-frame DtoD from preproc output → graph input buffer), pinned async DtoH, cross-stream event plumbing (no more `stream.synchronize()` in the graph-replay branch). |
| 5 | `c1406a8` cache per-call scratch + class_mapping int32 view (W7) | Eliminates two stray per-frame kernel launches that nsys flagged: `direct_copy_kernel_cuda` (from `class_mapping.to(dtype=torch.int32)` every frame — now cached by `id()`) and the three `torch.empty` allocator calls per frame (now a persistent scratch cache keyed on `(num_queries, device)`). |
| 6 | `1b169b7` depth-2 frame pipeline (151 → 241 FPS) | Opt-in ping-pong of Triton postproc scratch slots so the adapter drains frame N-1's results while frame N's kernels are launching. Gated behind `RFDETR_PIPELINE_DEPTH=2`; default 1 is bit-exact-unchanged. |

---

## What's in

### New Triton kernels

- **`inference_models/models/rfdetr/triton_preprocess.py`** — fused stretch-to resize + BGR→RGB + /255 + ImageNet normalize. Replaces ~8 torch CUDA kernels with 1.
- **`inference_models/models/rfdetr/triton_postprocess.py`** — fused sigmoid + argmax-over-classes + class-remap + confidence-threshold filter. Used when `RFDETR_TRITON_POSTPROC=true` alone.
- **`inference_models/models/rfdetr/triton_fullpostproc.py`** — full post-process fusion:
  - `_rfdetr_fullpost_filter_kernel` — per-query: sigmoid argmax + class remap + conf threshold + cxcywh→xyxy + letterbox-denormalize + clip + banker's rounding; `tl.atomic_add(counter, 1)` reserves a compact output slot.
  - `_rfdetr_fullpost_mask_kernel_compact` — GPU-side bilinear upsample 78×78 → orig_h × orig_w + threshold > 0 + uint8 emit. Reads counter on GPU for early-exit so no CPU sync between the two launches.
  - Returns unsliced buffers + `counter` + `done_event`; adapter does the host-side slice after a single pinned counter DtoH.
  - **depth-2 extension:** `_get_scratch_buffers` / `_get_mask_bin_buffer` keyed by `(num_queries, device, slot_idx)`; `triton_rfdetr_fullpost` accepts `num_slots` (default 1 = legacy single-slot).
- **`inference/models/rfdetr/triton_preprocess.py`** — same preprocess kernel wired into the legacy `inference/models/rfdetr` path for parity.

### Wiring / dispatch

- **`inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py`**
  - Triton preprocess fast-path in `pre_process()` with strict guard (STRETCH_TO, numpy HWC BGR uint8, no static crop).
  - Pre-allocated input buffer with `_trt_reuse_as_input_buffer` marker — graph capture bakes this tensor's address as the engine's input buffer, eliminating the per-frame 1.1 MB DtoD copy.
  - Pinned host staging buffer (`_fast_src_host_pinned`) so `copy_(non_blocking=True)` actually runs async.
  - Cross-stream event recording (`_fast_preproc_event`) instead of `pre_process_stream.synchronize()`.
- **`inference_models/models/rfdetr/common.py`** — dispatches `RFDETR_TRITON_FULLPOSTPROC` first (batch=1, no static crop, no nonsquare-intermediate resize, class remapping active), falls back to Triton conf-filter, then to torch. Reads `RFDETR_PIPELINE_DEPTH` and passes `num_slots=RFDETR_PIPELINE_DEPTH` to `triton_rfdetr_fullpost`.
- **`inference_models/models/common/trt.py`**:
  - `TRTCudaGraphState.consumer_done_event` lets the next graph replay wait on the consumer's last use of the output buffers (avoids DtoD clones of output buffers).
  - `_capture_cuda_graph(use_pre_processed_images_as_input_buffer=...)` supports capturing with an externally-owned input tensor.
  - Removed `stream.synchronize()` in `infer_from_trt_engine`'s graph-replay branch; replaced with a `produce_event` recorded on the graph's own stream.
- **`inference/core/models/inference_models_adapters.py`**
  - GPU fast-path for the `_combined_gpu` / `_counter_gpu` / `_postproc_done_event` side channels: waits the done_event, pinned-DtoH's the 4-byte counter, syncs once to read `n_survivors`, then slices `combined[:n]` + `mask[:n]` and pinned-DtoH's both async with a second sync. Bitcasts column 4 of the combined int32 buffer to fp32 via `numpy.view(np.float32)` for confidence.
  - Factored per-det response-build into `_build_response_from_det` (used by both depth=1 and depth=2 code paths for bit-exact responses).
  - depth=2 branch: saves `(det, H, W, class_filter)` as `_pipeline_pending` so the scratch slot stays alive; drains previous pending (waits its `done_event`, pinned-DtoH counter+combined+mask, builds response, returns frame N-1's response). First call returns an empty response.

### Scratch caching (W7)

- `_SCRATCH_CACHE` — combined/survivor_idx/mask_any/counter tensors reused across frames, keyed by `(num_queries, device)` (+ `slot_idx` for depth=2).
- `_CLASS_MAPPING_INT32_CACHE` — int32 view of the class_mapping tensor cached by `id(source_tensor)`; previously re-converted every frame because upstream stores it as int64.

### Benchmark harness

- `development/stream_interface/rfdetr_nano_seg_trt_workflow.py` — replaced with a minimal 116-line InferencePipeline-based driver. Uses the `roboflow_core/roboflow_instance_segmentation_model@v3` workflow block; single video source, single sink, no annotators/buffering/rate-limiting. `--backend` flag pre-import sets `DISABLED_INFERENCE_MODELS_BACKENDS` for unambiguous backend attribution.

### Env vars (all opt-in)

| Var | Default | Effect |
|---|---|---|
| `RFDETR_USE_TRITON_PREPROC` | off | Enable fused Triton preprocess kernel |
| `RFDETR_TRITON_POSTPROC` | off | Enable Triton conf-filter (partial postproc fusion) |
| `RFDETR_TRITON_FULLPOSTPROC` | off | Enable full postproc fusion (W2) |
| `RFDETR_GPU_POSTPROCESS` | on | GPU mask-emptiness skip |
| `RFDETR_DISABLE_GPU_PREPROC` | off | Opt-out for torch GPU preprocess branch |
| `ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND` | off | Enables `TRTCudaGraphCache` |
| `RFDETR_PIPELINE_DEPTH` | `1` | Set to `2` to enable depth-2 frame pipeline (see caveats below) |

---

## How depth-2 works

Before depth-2, the inference thread was serial per frame:

```
HtoD -> TRT -> Triton postproc -> counter DtoH (sync) -> mask DtoH (sync) -> build response -> return
```

`cudaStreamSynchronize` was **80.9% of CUDA API time** per nsys — the CPU sat idle waiting for GPU work to complete, then blocked on DtoH.

Depth-2 ping-pongs the Triton postproc scratch buffers between two slots so the adapter can drain frame N-1's results while frame N's kernels are launching into the other slot. The `cudaStreamSynchronize` cost is now overlapped with the next frame's GPU work instead of blocking the workflow thread.

Per-frame flow (depth=2):

1. Frame N's Triton kernels write to scratch slot `N % 2`.
2. Adapter's `postprocess()` receives frame N's detections.
3. Instead of draining frame N's scratch, it:
   - Saves `(det, H, W, class_filter)` as the new `_pipeline_pending` — the refs keep slot `N % 2` alive.
   - Drains the **previous** pending (slot `(N-1) % 2`): waits its `done_event`, pinned-DtoH counter+combined+mask, builds response.
   - Returns frame N-1's response.
4. First call (frame 0): no previous pending → returns an empty response.

The scratch slot that frame N writes is different from the slot frame N-1 is reading, so the two frames' work genuinely runs in parallel on the GPU.

### Caveats (depth=2 only, clearly gated)

| Aspect | depth=1 | depth=2 |
|---|---|---|
| Response-to-frame binding | exact | **shifted by 1** (response_N-1 paired with video_frame_N in `on_prediction`) |
| Frame 0 | normal response | empty response |
| Final frame | emitted | **dropped** (no subsequent call to drain its pending slot) |
| Per-frame wall time on workflow thread | ~6.6 ms | ~4.1 ms |

At 241 FPS the 1-frame skew is **~4 ms** between a detection's underlying pixels and the `video_frame` it's paired with in the sink callback. Imperceptible for annotation rendering, dashboards, downstream analytics. For strict frame-detection pairing (e.g. training label generation), keep depth=1.

The final-frame drop is a real loss (one `Prediction` per stream). If that matters, an explicit `flush()` method could be added on adapter teardown — not plumbed in this PR because `InferencePipeline` doesn't currently call into the model on shutdown.

---

## Parity verification

- **depth=1** (default): 0 diff across all 538 frames vs v16 best (bit-exact xyxy, confidence, class_id, per-detection mask MD5).
- **depth=2**:
  - Frame 0: empty response — matches "warmup slot" design.
  - Frames 1..537: bit-exact match to frames 0..536 of the depth=1 capture. **Zero mismatches across 537 shifted pairs.**
  - Frame 537 of depth=1 (`1 detection, c2:0.9024:68,153,105,176`): dropped in depth=2 (stream ended before next call could drain its pending slot).

---

## Test plan

- [x] `pytest tests/inference/unit_tests/models/test_rfdetr.py -x -q` — 11/11 pass
- [x] depth=1 benchmark: 151 FPS (baseline 109). No regression.
- [x] depth=1 parity: 0 diff across 538 frames vs baseline.
- [x] depth=2 benchmark: 241 / 240 / 242 FPS across 3 runs (stable).
- [x] depth=2 parity: 0 mismatches on 537 shifted pairs. Empty frame 0 + dropped final frame confirmed as designed.
- [x] nsys: kernel count 170,530 → 2,931 (-98.3%) with CUDA graphs + full postproc fusion enabled; DtoD per-run 439 → 8 with `_trt_reuse_as_input_buffer`.
- [x] Tracer confirms zero `class_mapping.to()` / `direct_copy_kernel_cuda` launches per frame after W7.
- [ ] Higher-resolution video (mask kernel compute scales with orig_h × orig_w; pipelining win should scale with DtoH size).
- [ ] Multi-batch workflow (depth=2 currently gated to `len(detections_list) == 1` — larger batches fall through to depth=1).
- [ ] Jetson Orin NX (pinned-memory + async-transfer + pipelining wins should scale better).

---

## Relationship to #22

This PR now **subsumes** #22 — it contains all the commits from #22 plus the depth-2 pipeline commit on top. Merging this PR makes #22 redundant; #22 can be closed once this lands. If you prefer to land the 151-FPS work first without depth-2, #22 is still the smaller PR and this one can be rebased on main afterward.
