### PR TITLE
perf(postprocess): drop redundant np.any in masks2poly

### DIFF
--- a/inference/core/utils/postprocess.py
+++ b/inference/core/utils/postprocess.py
@@ -35,28 +35,21 @@ def masks2poly(masks: np.ndarray) -> List[np.ndarray]:
         list: A list of segments, where each segment is obtained by converting the corresponding mask.
     """
     segments = []
-    # Process per-mask to avoid allocating an entire N x H x W uint8 copy
+    # Dispatch: the RF-DETR hot path produces uint8 C-contiguous masks, so
+    # the common branch is a single dtype check + no-op contiguity guard.
+    # `cv2.findContours` handles all-zero masks cheaply and returns (), so
+    # the former `np.any(m_uint8)` pre-check was redundant work on the
+    # populated-mask path (every mask here survived Triton-fullpost filtering).
+    # `mask2poly` returns a zero-row float32 array for that case already.
     for mask in masks:
-        # Fast-path: bool -> zero-copy uint8 view
-        if mask.dtype == np.bool_:
-            m_uint8 = mask
-            if not m_uint8.flags.c_contiguous:
-                m_uint8 = np.ascontiguousarray(m_uint8)
-            m_uint8 = m_uint8.view(np.uint8)
-        elif mask.dtype == np.uint8:
+        dt = mask.dtype
+        if dt == np.uint8:
             m_uint8 = mask if mask.flags.c_contiguous else np.ascontiguousarray(mask)
-        else:
-            # Fallback: threshold to bool then view as uint8 (may allocate once)
-            m_bool = mask > 0
-            if not m_bool.flags.c_contiguous:
-                m_bool = np.ascontiguousarray(m_bool)
+        elif dt == np.bool_:
+            m_bool = mask if mask.flags.c_contiguous else np.ascontiguousarray(mask)
             m_uint8 = m_bool.view(np.uint8)
-
-        # Quickly skip empty masks
-        if not np.any(m_uint8):
-            segments.append(np.zeros((0, 2), dtype=np.float32))
-            continue
-
+        else:
+            m_uint8 = np.ascontiguousarray(mask > 0).view(np.uint8)
         segments.append(mask2poly(m_uint8))
     return segments
 


### PR DESCRIPTION
## Summary

`masks2poly` scans each mask with `np.any(m_uint8)` before calling `mask2poly`. But `mask2poly` → `cv2.findContours` already handles all-zero masks fast (returns an empty tuple) and `mask2poly` already returns a zero-row float32 array for that case. The pre-check scanned the full mask on every *populated* mask just to avoid a cheap early-return that happens anyway.

On the instance-segmentation hot path every mask reaching `masks2poly` is populated (below-threshold queries are filtered upstream), so the check is pure waste.

Also simplifies the dtype-dispatch branches: the common `uint8 C-contiguous` case is one check, one no-op guard.

## Numbers

Microbench, 4-mask stack of 240×426 uint8 (5000 iters warmed):

| | us/call |
|---|---|
| before | 221 |
| after | **141** |

Δ = −80 µs/call (−36%).

End-to-end on the RF-DETR seg Triton stack (rfdetr-seg-nano TRT + Triton preproc + Triton fullpost + CUDA graphs, `vehicles_312px.mp4`, 538 frames, 4 runs each):

| | mean FPS |
|---|---|
| baseline | 152.42 |
| this change | **154.79** |

Δ = +2.4 FPS (+1.6%).

## Correctness

Bit-exact parity verified on a 9-mask test stack covering: empty masks, sparse uint8, bool dtype, non-contiguous views, float dtype (fallback branch), and masks with disconnected fragments + interior holes. Each element in the returned list is `np.array_equal` between old and new implementations — same dtype (`float32`), same shape, same values.

## Test plan

- [x] `pytest tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_v3.py` — 23/23 pass
- [x] Microbench (above)
- [x] End-to-end FPS benchmark (above)
- [x] 9-mask parity test covering all dtype/contiguity branches
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)