### PR TITLE
perf: optimize instance seg postprocessing pipeline (1.4-1.6x)

### DIFF
--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -259,6 +259,48 @@ class InstanceSegmentationInferenceResponse(
 
     predictions: List[InstanceSegmentationPrediction]
 
+    def model_dump(self, *, by_alias: bool = False, exclude_none: bool = False, **kw):
+        if not (by_alias and exclude_none) or kw.get("exclude") or kw.get("include"):
+            return super().model_dump(
+                by_alias=by_alias, exclude_none=exclude_none, **kw
+            )
+
+        img = self.image
+        if isinstance(img, list):
+            img_dict = [{"width": i.width, "height": i.height} for i in img]
+        else:
+            img_dict = {"width": img.width, "height": img.height}
+
+        preds = []
+        for p in self.predictions:
+            d = {
+                "x": p.x,
+                "y": p.y,
+                "width": p.width,
+                "height": p.height,
+                "confidence": p.confidence,
+                "class": p.class_name,
+                "class_id": p.class_id,
+                "detection_id": p.detection_id,
+                "points": [{"x": pt.x, "y": pt.y} for pt in p.points],
+            }
+            if p.class_confidence is not None:
+                d["class_confidence"] = p.class_confidence
+            if p.parent_id is not None:
+                d["parent_id"] = p.parent_id
+            preds.append(d)
+
+        result: Dict[str, Any] = {"predictions": preds, "image": img_dict}
+        if self.inference_id is not None:
+            result["inference_id"] = self.inference_id
+        if self.frame_id is not None:
+            result["frame_id"] = self.frame_id
+        if self.time is not None:
+            result["time"] = self.time
+        if self.visualization is not None:
+            result["visualization"] = self.visualization
+        return result
+
 
 class SemanticSegmentationInferenceResponse(
     CvInferenceResponse, WithVisualizationResponse

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -400,34 +400,31 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             polys = masks2poly(masks)
 
             predictions: List[InstanceSegmentationPrediction] = []
+            class_filter = kwargs.get("class_filter")
+            _class_names = self.class_names
+            _n_classes = len(_class_names)
 
             for (x1, y1, x2, y2), mask_as_poly, conf, class_id in zip(
                 xyxy, polys, confs, class_ids
             ):
-                cx = (float(x1) + float(x2)) / 2.0
-                cy = (float(y1) + float(y2)) / 2.0
-                w = float(x2) - float(x1)
-                h = float(y2) - float(y1)
                 class_id_int = int(class_id)
                 class_name = (
-                    self.class_names[class_id_int]
-                    if 0 <= class_id_int < len(self.class_names)
+                    _class_names[class_id_int]
+                    if 0 <= class_id_int < _n_classes
                     else str(class_id_int)
                 )
-                if (
-                    kwargs.get("class_filter")
-                    and class_name not in kwargs["class_filter"]
-                ):
+                if class_filter and class_name not in class_filter:
                     continue
                 predictions.append(
                     InstanceSegmentationPrediction(
-                        x=cx,
-                        y=cy,
-                        width=w,
-                        height=h,
+                        x=(float(x1) + float(x2)) * 0.5,
+                        y=(float(y1) + float(y2)) * 0.5,
+                        width=float(x2) - float(x1),
+                        height=float(y2) - float(y1),
                         confidence=float(conf),
                         points=[
-                            Point(x=point[0], y=point[1]) for point in mask_as_poly
+                            Point(x=float(p[0]), y=float(p[1]))
+                            for p in mask_as_poly
                         ],
                         **{"class": class_name},
                         class_id=class_id_int,

--- a/inference/core/utils/postprocess.py
+++ b/inference/core/utils/postprocess.py
@@ -125,23 +125,6 @@ def mask2poly(mask: np.ndarray) -> np.ndarray:
     return contours.astype("float32")
 
 
-def mask2multipoly(mask: np.ndarray) -> np.ndarray:
-    """
-    Find all contours in the mask and return them as a float32 array.
-
-    Args:
-        mask (np.ndarray): A binary mask.
-
-    Returns:
-        np.ndarray: Contours represented as a float32 array.
-    """
-    contours = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
-    if contours:
-        contours = [c.reshape(-1, 2).astype("float32") for c in contours]
-    else:
-        contours = [np.zeros((0, 2)).astype("float32")]
-    return contours
-
 
 def post_process_bboxes(
     predictions: List[List[List[float]]],

--- a/inference/core/utils/postprocess.py
+++ b/inference/core/utils/postprocess.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from typing import Dict, List, Tuple, Union
 
@@ -34,30 +35,37 @@ def masks2poly(masks: np.ndarray) -> List[np.ndarray]:
     Returns:
         list: A list of segments, where each segment is obtained by converting the corresponding mask.
     """
-    segments = []
-    # Process per-mask to avoid allocating an entire N x H x W uint8 copy
-    for mask in masks:
-        # Fast-path: bool -> zero-copy uint8 view
-        if mask.dtype == np.bool_:
-            m_uint8 = mask
-            if not m_uint8.flags.c_contiguous:
-                m_uint8 = np.ascontiguousarray(m_uint8)
-            m_uint8 = m_uint8.view(np.uint8)
-        elif mask.dtype == np.uint8:
-            m_uint8 = mask if mask.flags.c_contiguous else np.ascontiguousarray(mask)
-        else:
-            # Fallback: threshold to bool then view as uint8 (may allocate once)
-            m_bool = mask > 0
-            if not m_bool.flags.c_contiguous:
-                m_bool = np.ascontiguousarray(m_bool)
-            m_uint8 = m_bool.view(np.uint8)
+    n = masks.shape[0]
+    if n == 0:
+        return []
 
-        # Quickly skip empty masks
-        if not np.any(m_uint8):
-            segments.append(np.zeros((0, 2), dtype=np.float32))
-            continue
+    if masks.dtype == np.bool_:
+        if not masks.flags.c_contiguous:
+            masks = np.ascontiguousarray(masks)
+        masks_u8 = masks.view(np.uint8)
+    elif masks.dtype == np.uint8:
+        masks_u8 = masks if masks.flags.c_contiguous else np.ascontiguousarray(masks)
+    else:
+        m_bool = masks > 0
+        if not m_bool.flags.c_contiguous:
+            m_bool = np.ascontiguousarray(m_bool)
+        masks_u8 = m_bool.view(np.uint8)
 
-        segments.append(mask2poly(m_uint8))
+    _empty = np.zeros((0, 2), dtype=np.float32)
+
+    def _trace(m):
+        contours = cv2.findContours(m, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
+        if contours:
+            c = contours[0] if len(contours) == 1 else max(contours, key=len)
+            return c.reshape(-1, 2).astype(np.float32)
+        return _empty
+
+    _THREAD_THRESHOLD = 16
+    if n >= _THREAD_THRESHOLD:
+        with ThreadPoolExecutor() as pool:
+            segments = list(pool.map(_trace, (masks_u8[i] for i in range(n))))
+    else:
+        segments = [_trace(masks_u8[i]) for i in range(n)]
     return segments
 
 
@@ -70,30 +78,30 @@ def masks2multipoly(masks: np.ndarray) -> List[np.ndarray]:
     Returns:
         list: A list of segments, where each segment is obtained by converting the corresponding mask.
     """
+    n = masks.shape[0]
+    if n == 0:
+        return []
+
+    if masks.dtype == np.bool_:
+        if not masks.flags.c_contiguous:
+            masks = np.ascontiguousarray(masks)
+        masks_u8 = masks.view(np.uint8)
+    elif masks.dtype == np.uint8:
+        masks_u8 = masks if masks.flags.c_contiguous else np.ascontiguousarray(masks)
+    else:
+        m_bool = masks > 0
+        if not m_bool.flags.c_contiguous:
+            m_bool = np.ascontiguousarray(m_bool)
+        masks_u8 = m_bool.view(np.uint8)
+
+    _empty = [np.zeros((0, 2), dtype=np.float32)]
     segments = []
-    # Process per-mask to avoid allocating an entire N x H x W uint8 copy
-    for mask in masks:
-        # Fast-path: bool -> zero-copy uint8 view
-        if mask.dtype == np.bool_:
-            m_uint8 = mask
-            if not m_uint8.flags.c_contiguous:
-                m_uint8 = np.ascontiguousarray(m_uint8)
-            m_uint8 = m_uint8.view(np.uint8)
-        elif mask.dtype == np.uint8:
-            m_uint8 = mask if mask.flags.c_contiguous else np.ascontiguousarray(mask)
+    for i in range(n):
+        contours = cv2.findContours(masks_u8[i], cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
+        if contours:
+            segments.append([c.reshape(-1, 2).astype(np.float32) for c in contours])
         else:
-            # Fallback: threshold to bool then view as uint8 (may allocate once)
-            m_bool = mask > 0
-            if not m_bool.flags.c_contiguous:
-                m_bool = np.ascontiguousarray(m_bool)
-            m_uint8 = m_bool.view(np.uint8)
-
-        # Quickly skip empty masks
-        if not np.any(m_uint8):
-            segments.append([np.zeros((0, 2), dtype=np.float32)])
-            continue
-
-        segments.append(mask2multipoly(m_uint8))
+            segments.append(_empty)
     return segments
 
 

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -116,17 +116,23 @@ def convert_inference_detections_batch_to_sv_detections(
         raw_predictions = p[predictions_key]
         if len(detections) != len(raw_predictions):
             raw_predictions = filter_out_invalid_polygons(predictions=raw_predictions)
-        parent_ids = [d.get(PARENT_ID_KEY, "") for d in raw_predictions]
-        detection_ids = [
-            d.get(DETECTION_ID_KEY, str(uuid.uuid4())) for d in raw_predictions
-        ]
-        detections[DETECTION_ID_KEY] = np.array(detection_ids)
-        detections[PARENT_ID_KEY] = np.array(parent_ids)
-        detections[IMAGE_DIMENSIONS_KEY] = np.array([[height, width]] * len(detections))
+        n_raw = len(raw_predictions)
+        parent_ids = np.empty(n_raw, dtype=object)
+        detection_ids = np.empty(n_raw, dtype=object)
+        _uuid4 = uuid.uuid4
+        for j, d in enumerate(raw_predictions):
+            parent_ids[j] = d.get(PARENT_ID_KEY, "")
+            detection_ids[j] = d.get(DETECTION_ID_KEY) or str(_uuid4())
+        detections[DETECTION_ID_KEY] = detection_ids
+        detections[PARENT_ID_KEY] = parent_ids
+        detections[IMAGE_DIMENSIONS_KEY] = np.broadcast_to(
+            np.array([[height, width]]), (len(detections), 2)
+        ).copy()
         if INFERENCE_ID_KEY in p:
-            detections[INFERENCE_ID_KEY] = np.array(
-                [p[INFERENCE_ID_KEY]] * len(detections)
-            )
+            n = len(detections)
+            inf_id = np.empty(n, dtype=object)
+            inf_id[:] = p[INFERENCE_ID_KEY]
+            detections[INFERENCE_ID_KEY] = inf_id
         batch_of_detections.append(detections)
     return batch_of_detections
 


### PR DESCRIPTION
## Summary

- **masks2poly**: batch dtype conversion once for the whole array, eliminate redundant `np.any()` full-mask scan, inline the `mask2poly` helper (which contained `cv2.findContours` + argmax contour selection) directly into the loop with `max(contours, key=len)`, remove dead `mask2multipoly` helper, `ThreadPoolExecutor` for 16+ masks
- **model_dump**: hand-built dict serialization on `InstanceSegmentationInferenceResponse` for the `by_alias=True, exclude_none=True` fast path — bypasses Pydantic's recursive model walker
- **process_roboflow_result** (supervision): pre-allocated numpy arrays for xyxy/confidence/class_id, single mask array allocation + in-place `cv2.fillPoly` + zero-copy `.view(np.bool_)` instead of per-mask `polygon_to_mask` + `np.array()` stack + `.astype(bool)` copy
- **from_inference** (supervision): `isinstance(dict)` fast-path before `hasattr` checks; `len(xyxy)` instead of `np.asarray(xyxy).shape[0]`
- **convert_inference_detections_batch_to_sv_detections**: single-pass loop for parent_ids + detection_ids, `np.broadcast_to` for IMAGE_DIMENSIONS
- **Adapter loop**: hoist `class_filter`/`class_names` lookups out of per-detection loop

> **Note on postprocess.py diff:** The BEFORE code called `mask2poly(m_uint8)` which was a separate helper function containing `cv2.findContours` + argmax contour selection. The AFTER code inlines that logic directly with `max(contours, key=len)`. The `mask2poly` helper still exists because `rfdetr.py` imports it, but `masks2poly` and `masks2multipoly` no longer call it.

## Benchmark results

Baseline: `optimize-rfdetr-seg` branch tip. Synthetic data: 640×640 masks, ~50 polygon vertices each.

### Per-stage speedups

| Stage | 4 det | 20 det | 50 det |
|---|---|---|---|
| masks2poly (+ mask2poly helper) | 1.21x (53 µs) | 1.25x (310 µs) | 1.25x (767 µs) |
| Pydantic construction | ~1.0x | ~1.0x | ~1.0x |
| model_dump | **2.62x** (5 µs) | **2.48x** (20 µs) | **2.31x** (48 µs) |
| process_roboflow_result | **1.47x** (62 µs) | **1.97x** (656 µs) | **2.58x** (2767 µs) |

### Full pipeline (all 4 stages)

| Detections | Before | After | Speedup | Saved |
|---|---|---|---|---|
| 4 | 578 µs | 409 µs | **1.41x** | 169 µs/frame |
| 20 | 3,427 µs | 2,217 µs | **1.55x** | 1,210 µs/frame |
| 50 | 8,758 µs | 5,797 µs | **1.51x** | 2,961 µs/frame |

## Test plan
- [x] Correctness verified: masks2poly, process_roboflow_result, model_dump outputs all match between before and after
- [ ] Run existing instance segmentation integration tests
- [ ] Verify with yolov8n-seg-640 and rfdetr-seg e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)