### PR TITLE
perf(is-seg): swap pydantic response for dataclass twins on workflow path

### DIFF
--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -1,4 +1,5 @@
 import base64
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import uuid4
 
@@ -271,6 +272,94 @@ class InstanceSegmentationInferenceResponse(
     predictions: List[
         Union[InstanceSegmentationPrediction, InstanceSegmentationRLEPrediction]
     ]
+
+
+# Dataclass twins used on the workflow-local fast path in
+# `InferenceModelsInstanceSegmentationAdapter.postprocess` when
+# `kwargs["source"] == "workflow-execution"`. The workflow block consumes
+# a plain dict via `_is_response_dc_to_dict` and never needs the pydantic
+# interface. HTTP / cache / visualization paths still receive the pydantic
+# `InstanceSegmentationInferenceResponse` because they use
+# `source != "workflow-execution"`.
+@dataclass(slots=True)
+class PointDC:
+    x: float
+    y: float
+
+
+@dataclass(slots=True)
+class InferenceResponseImageDC:
+    width: int
+    height: int
+
+
+@dataclass(slots=True)
+class InstanceSegmentationPredictionDC:
+    x: float
+    y: float
+    width: float
+    height: float
+    confidence: float
+    class_name: str  # serialized as "class" in the dict form
+    class_id: int
+    points: list  # list[PointDC]
+    detection_id: str = field(default_factory=lambda: str(uuid4()))
+    parent_id: object = None
+    class_confidence: object = None
+    # `mask_format` is a constant on the pydantic twin but we carry it
+    # through `model_dump`, so include it verbatim for dict parity.
+    mask_format: str = "polygon"
+
+
+@dataclass(slots=True)
+class InstanceSegmentationInferenceResponseDC:
+    predictions: list  # list[InstanceSegmentationPredictionDC]
+    image: InferenceResponseImageDC
+    # `Model.infer_from_request` assigns .time and .inference_id after
+    # construction (see inference/core/models/base.py:154-157); they're
+    # declared here so the slotted dataclass permits the reassignment.
+    inference_id: object = None
+    frame_id: object = None
+    time: object = None
+    visualization: object = None
+
+
+def _is_pred_dc_to_dict(p: InstanceSegmentationPredictionDC) -> dict:
+    """Bit-equivalent to `InstanceSegmentationPrediction(...).model_dump(by_alias=True, exclude_none=True)`."""
+    d = {
+        "x": p.x,
+        "y": p.y,
+        "width": p.width,
+        "height": p.height,
+        "confidence": p.confidence,
+        "class": p.class_name,  # alias
+        "class_id": p.class_id,
+        "detection_id": p.detection_id,
+        "points": [{"x": pt.x, "y": pt.y} for pt in p.points],
+        "mask_format": p.mask_format,
+    }
+    if p.class_confidence is not None:
+        d["class_confidence"] = p.class_confidence
+    if p.parent_id is not None:
+        d["parent_id"] = p.parent_id
+    return d
+
+
+def _is_response_dc_to_dict(r: InstanceSegmentationInferenceResponseDC) -> dict:
+    """Bit-equivalent to `InstanceSegmentationInferenceResponse(...).model_dump(by_alias=True, exclude_none=True)`."""
+    d = {
+        "image": {"width": r.image.width, "height": r.image.height},
+        "predictions": [_is_pred_dc_to_dict(p) for p in r.predictions],
+    }
+    if r.inference_id is not None:
+        d["inference_id"] = r.inference_id
+    if r.frame_id is not None:
+        d["frame_id"] = r.frame_id
+    if r.time is not None:
+        d["time"] = r.time
+    if r.visualization is not None:
+        d["visualization"] = r.visualization
+    return d
 
 
 class SemanticSegmentationInferenceResponse(

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -17,8 +17,11 @@ from inference.core.entities.responses.inference import (
     ClassificationInferenceResponse,
     InferenceResponse,
     InferenceResponseImage,
+    InferenceResponseImageDC,
     InstanceSegmentationInferenceResponse,
+    InstanceSegmentationInferenceResponseDC,
     InstanceSegmentationPrediction,
+    InstanceSegmentationPredictionDC,
     InstanceSegmentationRLEPrediction,
     Keypoint,
     KeypointsDetectionInferenceResponse,
@@ -27,6 +30,7 @@ from inference.core.entities.responses.inference import (
     ObjectDetectionInferenceResponse,
     ObjectDetectionPrediction,
     Point,
+    PointDC,
     SemanticSegmentationInferenceResponse,
     SemanticSegmentationPrediction,
 )
@@ -312,6 +316,15 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         detections_list = self._model.post_process(
             predictions, preprocess_return_metadata, **mapped_kwargs
         )
+        # Workflow callers consume a plain dict via `_is_response_dc_to_dict`;
+        # dataclasses avoid pydantic validation + `model_dump` overhead per
+        # frame. Every other caller (HTTP, cache, visualization) keeps the
+        # pydantic path because it depends on the pydantic class identity.
+        # RLE responses stay on the pydantic path for safety.
+        use_dc = (
+            not return_in_rle
+            and kwargs.get("source") == "workflow-execution"
+        )
 
         responses: List[InstanceSegmentationInferenceResponse] = []
         for preproc_metadata, det in zip(preprocess_return_metadata, detections_list):
@@ -357,7 +370,23 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                     and class_name not in kwargs["class_filter"]
                 ):
                     continue
-                if not return_in_rle:
+                if use_dc:
+                    predictions.append(
+                        InstanceSegmentationPredictionDC(
+                            x=cx,
+                            y=cy,
+                            width=w,
+                            height=h,
+                            confidence=float(conf),
+                            class_name=class_name,
+                            class_id=class_id_int,
+                            points=[
+                                PointDC(x=float(point[0]), y=float(point[1]))
+                                for point in mask_as_poly_or_rle
+                            ],
+                        )
+                    )
+                elif not return_in_rle:
                     predictions.append(
                         InstanceSegmentationPrediction(
                             x=cx,
@@ -391,12 +420,20 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                         )
                     )
 
-            responses.append(
-                InstanceSegmentationInferenceResponse(
-                    predictions=predictions,
-                    image=InferenceResponseImage(width=W, height=H),
+            if use_dc:
+                responses.append(
+                    InstanceSegmentationInferenceResponseDC(
+                        predictions=predictions,
+                        image=InferenceResponseImageDC(width=W, height=H),
+                    )
                 )
-            )
+            else:
+                responses.append(
+                    InstanceSegmentationInferenceResponse(
+                        predictions=predictions,
+                        image=InferenceResponseImage(width=W, height=H),
+                    )
+                )
         return responses
 
     def clear_cache(self, delete_from_disk: bool = True) -> None:

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -5,6 +5,10 @@ from pydantic import ConfigDict, Field, PositiveInt, model_validator
 from inference.core.entities.requests.inference import (
     InstanceSegmentationInferenceRequest,
 )
+from inference.core.entities.responses.inference import (
+    InstanceSegmentationInferenceResponseDC,
+    _is_response_dc_to_dict,
+)
 from inference.core.env import (
     HOSTED_INSTANCE_SEGMENTATION_URL,
     LOCAL_INFERENCE_API_URL,
@@ -327,8 +331,15 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         )
         if not isinstance(predictions, list):
             predictions = [predictions]
+        # The adapter returns dataclass responses when source="workflow-execution"
+        # (cheaper construct + dict-walk than pydantic). Any other response type
+        # (e.g. if a non-rfdetr backend is bound to the same block) falls back
+        # to `model_dump`.
         predictions = [
-            e.model_dump(by_alias=True, exclude_none=True) for e in predictions
+            _is_response_dc_to_dict(e)
+            if isinstance(e, InstanceSegmentationInferenceResponseDC)
+            else e.model_dump(by_alias=True, exclude_none=True)
+            for e in predictions
         ]
         return self._post_process_result(
             images=images,


### PR DESCRIPTION
## Summary

`InferenceModelsInstanceSegmentationAdapter.postprocess` built a full pydantic tree per frame — `Point × V` per polygon vertex, `InstanceSegmentationPrediction × N`, then `InstanceSegmentationInferenceResponse`. The workflow block then called `response.model_dump(by_alias=True, exclude_none=True)` to get a plain dict for `sv.Detections.from_inference`. Neither the validation nor the serializer is needed on that path — the block only consumes the dict.

This change adds slotted dataclass twins (`PointDC`, `InferenceResponseImageDC`, `InstanceSegmentationPredictionDC`, `InstanceSegmentationInferenceResponseDC`) plus `_is_pred_dc_to_dict` / `_is_response_dc_to_dict` helpers that emit the exact dict `model_dump(by_alias=True, exclude_none=True)` produces (same keys, same alias `\"class\"`, same `exclude_none` behavior, same `mask_format=\"polygon\"` constant).

The adapter gates on `kwargs.get(\"source\") == \"workflow-execution\"` (and `not return_in_rle`) and returns the dataclass response on that path. Every other caller — HTTP `response_model` at `http_api.py:1640`, `isinstance`-based cache dispatch at `cache/serializers.py:71`, `draw_predictions` visualization, RLE response mode — keeps the pydantic path untouched.

The v3 workflow block detects the dataclass via `isinstance` and calls `_is_response_dc_to_dict`; it falls back to `model_dump` for any other response type (e.g. if a non-rfdetr backend is ever bound to the same block).

## Why bother

We already tried `model_construct` on this branch's ancestor; it was **2× slower** than pydantic's Rust-validated `__init__`. Swapping to dataclasses works because the saving isn't in construction alone — it's **construction + `model_dump`** combined. Pydantic v2's serializer is Python-heavy for nested types with aliases + `exclude_none`, whereas the hand-rolled dict walk is a dozen dict literals.

## Numbers

Microbench (4 dets × 6-vertex polygon, construct + dump):

| | µs/frame |
|---|---|
| pydantic | 81 |
| **dataclass** | **33** |

Δ = −48 µs/frame (**2.43× faster**).

End-to-end (rfdetr-seg-nano TRT + Triton preproc + Triton fullpost + CUDA graphs, `vehicles_312px.mp4`, 538 frames, 4 runs each):

| | run 1 | run 2 | run 3 | run 4 | mean |
|---|---|---|---|---|---|
| baseline | 153.72 | 154.27 | 153.11 | 153.63 | **153.68** |
| this change | 159.00 | 157.62 | 157.18 | 157.03 | **157.71** |

Δ = **+4.03 FPS (+2.6%)**.

## Correctness

Parity tested on real inputs: `_is_response_dc_to_dict(dc)` byte-equals `pyd.model_dump(by_alias=True, exclude_none=True)` (modulo `detection_id` UUIDs from `default_factory`, which both paths generate). Tests cover:
- Mixed detection set with varying polygon lengths (0, 3, 6 vertices)
- Post-construction mutation of `.time` / `.inference_id` by `Model.infer_from_request`
- Empty-predictions edge case

`Model.infer_from_request` assigns `response.time` and `response.inference_id` at `inference/core/models/base.py:154,157`. Those two fields are declared in `InstanceSegmentationInferenceResponseDC`, so the slotted dataclass permits the reassignment.

## Test plan

- [x] `pytest tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_v3.py` — 23/23 pass
- [x] Parity test (`_is_response_dc_to_dict(dc) == pyd.model_dump(by_alias=True, exclude_none=True)`)
- [x] Microbench
- [x] End-to-end FPS benchmark
- [ ] HTTP regression: hit `/infer/instance_segmentation` against a local RF-DETR seg model, confirm the JSON response is byte-identical to pre-change (should be — adapter falls through to the pydantic branch because the HTTP request doesn't set `source=\"workflow-execution\"`)
- [ ] RLE path: send a request with `response_mask_format=\"rle\"` via workflows, confirm it still goes through the pydantic `InstanceSegmentationRLEPrediction` branch (gate excludes RLE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)