### PR TITLE
perf(rfdetr-seg): fused Triton preproc kernel for TRT path

### DIFF
--- a/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
+++ b/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
@@ -1,0 +1,116 @@
+"""Minimal benchmark: RF-DETR instance segmentation through inference-models,
+run via InferencePipeline on a single video source.
+
+Workflow has exactly one block — the segmentation model. No annotators, no
+buffer strategies, no rate limiting.
+
+The `--backend` flag (trt | onnx | torch) is parsed before importing
+`inference` and pins the auto-loader by setting
+`DISABLED_INFERENCE_MODELS_BACKENDS` to every backend except the chosen one,
+so the benchmark numbers correspond unambiguously to a single execution path.
+
+Defaults: rfdetr-seg-nano @ confidence 0.4 on the native TRT backend.
+"""
+import argparse
+import os
+
+_ALL_BACKENDS = {
+    "torch",
+    "torch-script",
+    "onnx",
+    "trt",
+    "hugging-face",
+    "ultralytics",
+    "mediapipe",
+    "custom",
+}
+def _select_backend_from_argv() -> str:
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--backend", choices=("trt", "onnx", "torch"), default="trt")
+    args, _ = pre.parse_known_args()
+    return args.backend
+
+
+_BACKEND = _select_backend_from_argv()
+os.environ.setdefault(
+    "ONNXRUNTIME_EXECUTION_PROVIDERS",
+    "[TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider]",
+)
+os.environ["DISABLED_INFERENCE_MODELS_BACKENDS"] = ",".join(
+    sorted(_ALL_BACKENDS - {_BACKEND})
+)
+
+from time import perf_counter
+
+from inference import InferencePipeline
+
+
+def build_workflow(model_id: str, confidence: float) -> dict:
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+                "name": "segmentation",
+                "images": "$inputs.image",
+                "model_id": model_id,
+                "confidence_mode": "custom",
+                "custom_confidence": confidence,
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.segmentation.predictions",
+            },
+        ],
+    }
+
+FRAME_COUNT = 0
+START_TIME = None
+PROGRESS_EVERY = 50
+
+
+def sink(predictions, _video_frames) -> None:
+    global FRAME_COUNT, START_TIME
+    del _video_frames
+    if not isinstance(predictions, list):
+        predictions = [predictions]
+    FRAME_COUNT += sum(p is not None for p in predictions)
+    if START_TIME is None:
+        START_TIME = perf_counter()
+    if FRAME_COUNT % PROGRESS_EVERY == 0:
+        fps = FRAME_COUNT / (perf_counter() - START_TIME)
+        print(f"[progress] frames={FRAME_COUNT} fps={fps:.2f}", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--video_reference", required=True)
+    parser.add_argument("--model_id", default="rfdetr-seg-nano")
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument(
+        "--backend",
+        choices=("trt", "onnx", "torch"),
+        default="trt",
+        help="inference-models backend (consumed pre-import via env var).",
+    )
+    args = parser.parse_args()
+
+    pipeline = InferencePipeline.init_with_workflow(
+        video_reference=args.video_reference,
+        workflow_specification=build_workflow(args.model_id, args.confidence),
+        on_prediction=sink,
+    )
+    pipeline.start()
+    pipeline.join()
+
+    elapsed = perf_counter() - START_TIME if START_TIME else 0.0
+    fps = FRAME_COUNT / elapsed if elapsed > 0 else 0.0
+    print(f"frames={FRAME_COUNT} elapsed={elapsed:.2f}s fps={fps:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
@@ -26,10 +26,13 @@ from inference_models.models.common.cuda import (
     use_primary_cuda_context,
 )
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.entities import ImageDimensions
 from inference_models.models.common.roboflow.model_packages import (
+    ColorMode,
     InferenceConfig,
     PreProcessingMetadata,
     ResizeMode,
+    StaticCropOffset,
     TRTConfig,
     parse_class_names_file,
     parse_inference_config,
@@ -52,6 +55,17 @@ from inference_models.models.rfdetr.common import (
     post_process_instance_segmentation_results_to_rle_masks,
 )
 from inference_models.models.rfdetr.pre_processing import pre_process_network_input
+
+try:
+    from inference_models.models.rfdetr.triton_preprocess import (
+        TRITON_AVAILABLE as _TRITON_AVAILABLE,
+        build_resample_tables,
+        triton_preprocess_rfdetr_stretch,
+    )
+except ImportError:
+    _TRITON_AVAILABLE = False
+    build_resample_tables = None
+    triton_preprocess_rfdetr_stretch = None
 from inference_models.weights_providers.entities import RecommendedParameters
 
 try:
@@ -83,6 +97,84 @@ except ImportError as import_error:
         f"we will really appreciate letting us know - https://github.com/roboflow/inference/issues",
         help_url="https://inference-models.roboflow.com/errors/runtime-environment/#missingdependencyerror",
     ) from import_error
+
+
+class _FastPathState:
+    """Per-(src_shape, target_shape) cache of GPU buffers + resample tables
+    that the Triton fast path reuses across frames."""
+
+    __slots__ = (
+        "src_h",
+        "src_w",
+        "target_h",
+        "target_w",
+        "pinned_host",
+        "src_gpu",
+        "out_buffer",
+        "tables",
+    )
+
+    def __init__(
+        self,
+        src_h: int,
+        src_w: int,
+        target_h: int,
+        target_w: int,
+        pinned_host: torch.Tensor,
+        src_gpu: torch.Tensor,
+        out_buffer: torch.Tensor,
+        tables,
+    ) -> None:
+        self.src_h = src_h
+        self.src_w = src_w
+        self.target_h = target_h
+        self.target_w = target_w
+        self.pinned_host = pinned_host
+        self.src_gpu = src_gpu
+        self.out_buffer = out_buffer
+        self.tables = tables
+
+    @classmethod
+    def build(
+        cls,
+        src_h: int,
+        src_w: int,
+        target_h: int,
+        target_w: int,
+        device: torch.device,
+    ) -> "_FastPathState":
+        pinned_host = torch.empty((src_h, src_w, 3), dtype=torch.uint8, pin_memory=True)
+        src_gpu = torch.empty((src_h, src_w, 3), dtype=torch.uint8, device=device)
+        out_buffer = torch.empty(
+            (1, 3, target_h, target_w), dtype=torch.float32, device=device
+        )
+        tables = build_resample_tables(
+            src_h=src_h,
+            src_w=src_w,
+            target_h=target_h,
+            target_w=target_w,
+            device=device,
+        )
+        return cls(
+            src_h=src_h,
+            src_w=src_w,
+            target_h=target_h,
+            target_w=target_w,
+            pinned_host=pinned_host,
+            src_gpu=src_gpu,
+            out_buffer=out_buffer,
+            tables=tables,
+        )
+
+    def is_stale(
+        self, src_h: int, src_w: int, target_h: int, target_w: int
+    ) -> bool:
+        return (
+            self.src_h != src_h
+            or self.src_w != src_w
+            or self.target_h != target_h
+            or self.target_w != target_w
+        )
 
 
 class RFDetrForInstanceSegmentationTRT(
@@ -220,6 +312,7 @@ class RFDetrForInstanceSegmentationTRT(
         self._inference_stream = torch.cuda.Stream(device=self._device)
         self._thread_local_storage = threading.local()
         self.recommended_parameters = recommended_parameters
+        self._fast_path_state: Optional[_FastPathState] = None
 
     @property
     def class_names(self) -> List[str]:
@@ -237,6 +330,14 @@ class RFDetrForInstanceSegmentationTRT(
         pre_processing_overrides: Optional[PreProcessingOverrides] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
+        fast = self._try_fast_preprocess(
+            images=images,
+            input_color_format=input_color_format,
+            image_size=image_size,
+            pre_processing_overrides=pre_processing_overrides,
+        )
+        if fast is not None:
+            return fast
         with torch.cuda.stream(self._pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
@@ -249,6 +350,128 @@ class RFDetrForInstanceSegmentationTRT(
             )
         self._pre_process_stream.synchronize()
         return pre_processed_images, pre_processing_meta
+
+    def _try_fast_preprocess(
+        self,
+        images,
+        input_color_format,
+        image_size,
+        pre_processing_overrides,
+    ) -> Optional[Tuple[torch.Tensor, List[PreProcessingMetadata]]]:
+        if not _TRITON_AVAILABLE:
+            return None
+        if image_size is not None:
+            return None
+        # pre_processing_overrides can only *disable* transforms; it has no
+        # "enable" knob. The fast path never applies static_crop / grayscale /
+        # contrast regardless, so the override flags are irrelevant — we just
+        # gate on whether the image_pre_processing config itself asks for them.
+        ipp = self._inference_config.image_pre_processing
+        if (
+            (ipp.static_crop is not None and ipp.static_crop.enabled)
+            or (ipp.contrast is not None and ipp.contrast.enabled)
+            or (ipp.grayscale is not None and ipp.grayscale.enabled)
+        ):
+            return None
+
+        ni = self._inference_config.network_input
+        if ni.dataset_version_resize_dimensions is not None:
+            return None
+        if ni.input_channels != 3:
+            return None
+        if ni.scaling_factor not in (None, 255):
+            return None
+        if ni.normalization is None:
+            return None
+        # When dataset_version_resize_dimensions is None, the prod path collapses
+        # non-stretch resize modes to a single PIL stretch as well
+        # (pre_processing.py:_needs_two_step_resize), so we accept all modes here.
+        if ni.resize_mode not in (
+            ResizeMode.STRETCH_TO,
+            ResizeMode.LETTERBOX,
+            ResizeMode.CENTER_CROP,
+            ResizeMode.LETTERBOX_REFLECT_EDGES,
+        ):
+            return None
+
+        if isinstance(images, list):
+            if len(images) != 1:
+                return None
+            candidate = images[0]
+        else:
+            candidate = images
+        if not isinstance(candidate, np.ndarray):
+            return None
+        if (
+            candidate.dtype != np.uint8
+            or candidate.ndim != 3
+            or candidate.shape[2] != 3
+        ):
+            return None
+
+        caller_mode = (
+            ColorMode(input_color_format)
+            if input_color_format is not None
+            else ColorMode.BGR
+        )
+        swap_rb = caller_mode != ni.color_mode
+
+        means, stds = ni.normalization
+        means_t = (float(means[0]), float(means[1]), float(means[2]))
+        stds_t = (float(stds[0]), float(stds[1]), float(stds[2]))
+        target_h = ni.training_input_size.height
+        target_w = ni.training_input_size.width
+        orig_h, orig_w = int(candidate.shape[0]), int(candidate.shape[1])
+
+        state = self._fast_path_state
+        if state is None or state.is_stale(
+            src_h=orig_h,
+            src_w=orig_w,
+            target_h=target_h,
+            target_w=target_w,
+        ):
+            state = _FastPathState.build(
+                src_h=orig_h,
+                src_w=orig_w,
+                target_h=target_h,
+                target_w=target_w,
+                device=self._device,
+            )
+            self._fast_path_state = state
+
+        pinned_np = state.pinned_host.numpy()
+        np.copyto(pinned_np, candidate, casting="no")
+
+        with torch.cuda.stream(self._pre_process_stream):
+            state.src_gpu.copy_(state.pinned_host, non_blocking=True)
+            triton_preprocess_rfdetr_stretch(
+                src=state.src_gpu,
+                tables=state.tables,
+                target_h=target_h,
+                target_w=target_w,
+                means=means_t,
+                stds=stds_t,
+                swap_rb=swap_rb,
+                out=state.out_buffer,
+            )
+            state.out_buffer.record_stream(self._pre_process_stream)
+        self._pre_process_stream.synchronize()
+
+        meta = PreProcessingMetadata(
+            pad_left=0,
+            pad_top=0,
+            pad_right=0,
+            pad_bottom=0,
+            original_size=ImageDimensions(width=orig_w, height=orig_h),
+            size_after_pre_processing=ImageDimensions(width=orig_w, height=orig_h),
+            inference_size=ImageDimensions(width=target_w, height=target_h),
+            scale_width=target_w / orig_w,
+            scale_height=target_h / orig_h,
+            static_crop_offset=StaticCropOffset(
+                offset_x=0, offset_y=0, crop_width=orig_w, crop_height=orig_h
+            ),
+        )
+        return state.out_buffer, [meta]
 
     def forward(
         self,

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
@@ -55,6 +55,7 @@ from inference_models.models.rfdetr.common import (
     post_process_instance_segmentation_results_to_rle_masks,
 )
 from inference_models.models.rfdetr.pre_processing import pre_process_network_input
+from inference_models.utils.environment import get_boolean_from_env
 
 try:
     from inference_models.models.rfdetr.triton_preprocess import (
@@ -66,6 +67,12 @@ except ImportError:
     _TRITON_AVAILABLE = False
     build_resample_tables = None
     triton_preprocess_rfdetr_stretch = None
+
+# Kill switch: set INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false to force
+# the PIL reference path for every call, regardless of other predicates.
+_FAST_PATH_ENABLED = get_boolean_from_env(
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED", default=True
+)
 from inference_models.weights_providers.entities import RecommendedParameters
 
 try:
@@ -358,6 +365,8 @@ class RFDetrForInstanceSegmentationTRT(
         image_size,
         pre_processing_overrides,
     ) -> Optional[Tuple[torch.Tensor, List[PreProcessingMetadata]]]:
+        if not _FAST_PATH_ENABLED:
+            return None
         if not _TRITON_AVAILABLE:
             return None
         if image_size is not None:

--- a/inference_models/inference_models/models/rfdetr/triton_preprocess.py
+++ b/inference_models/inference_models/models/rfdetr/triton_preprocess.py
@@ -1,0 +1,383 @@
+"""Fused Triton preprocessing kernel for RF-DETR.
+
+Byte-exact port of PIL's separable bilinear-antialias resize (the algorithm
+torchvision's `TF.resize(pil, ..., antialias=True)` uses on PIL inputs), with
+the subsequent `/255` + ImageNet normalize fused into the same pass.
+
+PIL's scheme (src/libImaging/Resample.c):
+
+    PRECISION_BITS = 22
+    scale       = in_size / out_size
+    filterscale = max(1.0, scale)
+    support     = 1.0 * filterscale          # triangle radius = 1
+    ksize       = ceil(support) * 2 + 1
+    center(o)   = (o + 0.5) * scale
+    xmin(o)     = int(center - support + 0.5)                  clipped to [0, in]
+    xmax(o)     = int(center + support + 0.5)                  clipped to [0, in]
+    w_f(o, k)   = triangle((k + xmin - center + 0.5) / filterscale)
+    w_f normalised to sum to 1 per output pixel
+    w_i(o, k)   = round(w_f(o, k) * (1 << PRECISION_BITS))      int32
+    out(o)      = clamp((Σ w_i(o, k) * src_u8) + (1 << (PRECISION_BITS-1)) >> PRECISION_BITS, 0, 255)
+
+Single fused kernel: the horizontal uint8 intermediate lives in registers
+rather than a DRAM scratch buffer. For each output tile we loop over
+KSIZE_Y source rows; for each contributing source row we recompute the
+horizontal convolution (int32 fixed-point, uint8 quantize) on the fly,
+multiply by the vertical weight, and accumulate. Final: uint8 quantize,
+BGR↔RGB swap, /255, ImageNet normalize, fp32 CHW store.
+
+A separable two-pass variant (horizontal then vertical, via a DRAM uint8
+intermediate) is ~0.4 fps faster end-to-end on the 312² RF-DETR workload
+because it avoids redoing KSIZE_X MACs per output row. We picked the fused
+version for simplicity (no intermediate buffer, one launch, one piece of
+math).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    triton = None
+    tl = None
+    TRITON_AVAILABLE = False
+
+
+PRECISION_BITS = 22
+
+
+def _bilinear_antialias_weights_1d_int(
+    in_size: int, out_size: int
+) -> Tuple[np.ndarray, np.ndarray, int]:
+    """PIL's precompute_coeffs, int32 fixed-point form."""
+    scale = in_size / out_size
+    filterscale = max(1.0, scale)
+    support = filterscale
+    ksize = int(math.ceil(support)) * 2 + 1
+
+    starts = np.zeros(out_size, dtype=np.int32)
+    weights_fp = np.zeros((out_size, ksize), dtype=np.float64)
+    inv_fs = 1.0 / filterscale
+
+    for o in range(out_size):
+        center = (o + 0.5) * scale
+        xmin = int(center - support + 0.5)
+        if xmin < 0:
+            xmin = 0
+        xmax = int(center + support + 0.5)
+        if xmax > in_size:
+            xmax = in_size
+        actual = xmax - xmin
+        starts[o] = xmin
+        total = 0.0
+        for k in range(actual):
+            t = (k + xmin - center + 0.5) * inv_fs
+            t_abs = -t if t < 0.0 else t
+            w = 1.0 - t_abs if t_abs < 1.0 else 0.0
+            weights_fp[o, k] = w
+            total += w
+        if total != 0.0:
+            weights_fp[o, :actual] /= total
+
+    weights_int = np.rint(weights_fp * (1 << PRECISION_BITS)).astype(np.int32)
+    return starts, weights_int, ksize
+
+
+if TRITON_AVAILABLE:
+
+    _HALF = 1 << (PRECISION_BITS - 1)
+
+    @triton.jit
+    def _fused_resize_normalize_kernel(
+        src_ptr,
+        dst_ptr,
+        ymin_ptr,
+        xmin_ptr,
+        wy_ptr,
+        wx_ptr,
+        src_h,
+        src_w,
+        src_stride_h,
+        src_stride_w,
+        dst_stride_c,
+        dst_stride_h,
+        target_h,
+        target_w,
+        inv_std_255_r,
+        inv_std_255_g,
+        inv_std_255_b,
+        offset_r,
+        offset_g,
+        offset_b,
+        CH_R: tl.constexpr,
+        CH_G: tl.constexpr,
+        CH_B: tl.constexpr,
+        KSIZE_Y: tl.constexpr,
+        KSIZE_X: tl.constexpr,
+        PRECISION_BITS_C: tl.constexpr,
+        HALF_C: tl.constexpr,
+        BLOCK_H: tl.constexpr,
+        BLOCK_W: tl.constexpr,
+    ):
+        """One kernel per (tile_y, tile_x) over target image.
+
+        In : src uint8 HWC (src_h, src_w, 3), source color order.
+        Out: dst fp32 CHW (1, 3, target_h, target_w), network color order,
+             (pixel/255 - mean)/std.
+        """
+        pid_y = tl.program_id(0)
+        pid_x = tl.program_id(1)
+
+        offs_y = pid_y * BLOCK_H + tl.arange(0, BLOCK_H)
+        offs_x = pid_x * BLOCK_W + tl.arange(0, BLOCK_W)
+        mask_y = offs_y < target_h
+        mask_x = offs_x < target_w
+        mask_out = mask_y[:, None] & mask_x[None, :]
+
+        ymin = tl.load(ymin_ptr + offs_y, mask=mask_y, other=0)
+        xmin = tl.load(xmin_ptr + offs_x, mask=mask_x, other=0)
+
+        # Vertical pass accumulators (int32 fixed-point) for 3 channels.
+        vacc_0 = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+        vacc_1 = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+        vacc_2 = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+
+        for ky in tl.static_range(KSIZE_Y):
+            # Source row contributing to each output row in this tile.
+            sy = ymin + ky
+            sy_c = tl.maximum(tl.minimum(sy, src_h - 1), 0)
+            wy = tl.load(wy_ptr + offs_y * KSIZE_Y + ky, mask=mask_y, other=0)
+
+            # Horizontal pass for (output_rows_in_tile, output_cols_in_tile):
+            # for each source column in the kernel, gather src[sy_c, sx_c, :]
+            # and accumulate with wx[output_col, kx].
+            hacc_0 = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+            hacc_1 = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+            hacc_2 = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+
+            for kx in tl.static_range(KSIZE_X):
+                sx = xmin + kx
+                sx_c = tl.maximum(tl.minimum(sx, src_w - 1), 0)
+                wx = tl.load(wx_ptr + offs_x * KSIZE_X + kx, mask=mask_x, other=0)
+                base = sy_c[:, None] * src_stride_h + sx_c[None, :] * src_stride_w
+                p0 = tl.load(src_ptr + base + 0, mask=mask_out, other=0).to(tl.int32)
+                p1 = tl.load(src_ptr + base + 1, mask=mask_out, other=0).to(tl.int32)
+                p2 = tl.load(src_ptr + base + 2, mask=mask_out, other=0).to(tl.int32)
+                wx_2d = wx[None, :]
+                hacc_0 += p0 * wx_2d
+                hacc_1 += p1 * wx_2d
+                hacc_2 += p2 * wx_2d
+
+            # Horizontal uint8 quantization (byte-exact to PIL's intermediate).
+            hacc_0 = (hacc_0 + HALF_C) >> PRECISION_BITS_C
+            hacc_1 = (hacc_1 + HALF_C) >> PRECISION_BITS_C
+            hacc_2 = (hacc_2 + HALF_C) >> PRECISION_BITS_C
+            hacc_0 = tl.minimum(tl.maximum(hacc_0, 0), 255)
+            hacc_1 = tl.minimum(tl.maximum(hacc_1, 0), 255)
+            hacc_2 = tl.minimum(tl.maximum(hacc_2, 0), 255)
+
+            wy_2d = wy[:, None]
+            vacc_0 += hacc_0 * wy_2d
+            vacc_1 += hacc_1 * wy_2d
+            vacc_2 += hacc_2 * wy_2d
+
+        # Vertical uint8 quantization.
+        q_0 = (vacc_0 + HALF_C) >> PRECISION_BITS_C
+        q_1 = (vacc_1 + HALF_C) >> PRECISION_BITS_C
+        q_2 = (vacc_2 + HALF_C) >> PRECISION_BITS_C
+        q_0 = tl.minimum(tl.maximum(q_0, 0), 255)
+        q_1 = tl.minimum(tl.maximum(q_1, 0), 255)
+        q_2 = tl.minimum(tl.maximum(q_2, 0), 255)
+
+        # Source-to-output channel remap (triton requires constexpr branches).
+        if CH_R == 0:
+            q_r = q_0
+        elif CH_R == 1:
+            q_r = q_1
+        else:
+            q_r = q_2
+        if CH_G == 0:
+            q_g = q_0
+        elif CH_G == 1:
+            q_g = q_1
+        else:
+            q_g = q_2
+        if CH_B == 0:
+            q_b = q_0
+        elif CH_B == 1:
+            q_b = q_1
+        else:
+            q_b = q_2
+
+        # (pixel/255 - mean)/std  ==  pixel * (1/(255*std)) + (-mean/std)
+        out_r = q_r.to(tl.float32) * inv_std_255_r + offset_r
+        out_g = q_g.to(tl.float32) * inv_std_255_g + offset_g
+        out_b = q_b.to(tl.float32) * inv_std_255_b + offset_b
+
+        out_row = offs_y[:, None] * dst_stride_h + offs_x[None, :]
+        tl.store(dst_ptr + 0 * dst_stride_c + out_row, out_r, mask=mask_out)
+        tl.store(dst_ptr + 1 * dst_stride_c + out_row, out_g, mask=mask_out)
+        tl.store(dst_ptr + 2 * dst_stride_c + out_row, out_b, mask=mask_out)
+
+
+class _ResampleTables:
+    """Cache of per-axis PIL-int32 weight tables for one (src, dst) pair."""
+
+    __slots__ = (
+        "ymin_gpu",
+        "xmin_gpu",
+        "wy_gpu",
+        "wx_gpu",
+        "ksize_y",
+        "ksize_x",
+    )
+
+    def __init__(
+        self,
+        ymin_gpu: torch.Tensor,
+        xmin_gpu: torch.Tensor,
+        wy_gpu: torch.Tensor,
+        wx_gpu: torch.Tensor,
+        ksize_y: int,
+        ksize_x: int,
+    ) -> None:
+        self.ymin_gpu = ymin_gpu
+        self.xmin_gpu = xmin_gpu
+        self.wy_gpu = wy_gpu
+        self.wx_gpu = wx_gpu
+        self.ksize_y = ksize_y
+        self.ksize_x = ksize_x
+
+
+def build_resample_tables(
+    src_h: int,
+    src_w: int,
+    target_h: int,
+    target_w: int,
+    device: torch.device,
+) -> _ResampleTables:
+    ymin, wy, ksize_y = _bilinear_antialias_weights_1d_int(src_h, target_h)
+    xmin, wx, ksize_x = _bilinear_antialias_weights_1d_int(src_w, target_w)
+    return _ResampleTables(
+        ymin_gpu=torch.from_numpy(ymin).to(device=device, non_blocking=True),
+        xmin_gpu=torch.from_numpy(xmin).to(device=device, non_blocking=True),
+        wy_gpu=torch.from_numpy(wy.ravel()).to(device=device, non_blocking=True),
+        wx_gpu=torch.from_numpy(wx.ravel()).to(device=device, non_blocking=True),
+        ksize_y=ksize_y,
+        ksize_x=ksize_x,
+    )
+
+
+def triton_preprocess_rfdetr_stretch(
+    src: torch.Tensor,
+    tables: _ResampleTables,
+    target_h: int,
+    target_w: int,
+    means: Tuple[float, float, float] = (0.485, 0.456, 0.406),
+    stds: Tuple[float, float, float] = (0.229, 0.224, 0.225),
+    swap_rb: bool = True,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Fused PIL-exact resize + color swap + normalize.
+
+    Args:
+        src: uint8 CUDA tensor, shape (H, W, 3), HWC layout.
+        tables: precomputed int32 resample tables from `build_resample_tables`.
+        target_h, target_w: output spatial dims.
+        means, stds: normalization in output channel order (R, G, B for
+            network_input.color_mode == 'rgb').
+        swap_rb: if True, source channel 0 → output B (BGR input, RGB network).
+        out: optional preallocated fp32 (1, 3, H, W) CUDA tensor.
+
+    Returns:
+        fp32 (1, 3, target_h, target_w) on the same device as `src`.
+    """
+    if not TRITON_AVAILABLE:
+        raise RuntimeError("triton is not installed")
+    if not src.is_cuda:
+        raise ValueError(f"expected CUDA src tensor, got device={src.device}")
+    if src.dtype != torch.uint8:
+        raise ValueError(f"expected uint8 src, got {src.dtype}")
+    if src.ndim != 3 or src.shape[2] != 3:
+        raise ValueError(f"expected HWC 3-channel, got shape={tuple(src.shape)}")
+
+    src = src.contiguous()
+    src_h, src_w = int(src.shape[0]), int(src.shape[1])
+    src_stride_h = int(src.stride(0))
+    src_stride_w = int(src.stride(1))
+
+    if out is None:
+        out = torch.empty(
+            (1, 3, target_h, target_w), dtype=torch.float32, device=src.device
+        )
+    else:
+        if tuple(out.shape) != (1, 3, target_h, target_w):
+            raise ValueError(
+                f"out has shape {tuple(out.shape)}, expected "
+                f"(1, 3, {target_h}, {target_w})"
+            )
+        if out.dtype != torch.float32 or not out.is_cuda:
+            raise ValueError("out must be fp32 CUDA tensor")
+
+    dst_stride_c = target_h * target_w
+    dst_stride_h = target_w
+
+    if swap_rb:
+        ch_r, ch_g, ch_b = 2, 1, 0
+    else:
+        ch_r, ch_g, ch_b = 0, 1, 2
+
+    inv_std_255_r = 1.0 / (255.0 * stds[0])
+    inv_std_255_g = 1.0 / (255.0 * stds[1])
+    inv_std_255_b = 1.0 / (255.0 * stds[2])
+    offset_r = -means[0] / stds[0]
+    offset_g = -means[1] / stds[1]
+    offset_b = -means[2] / stds[2]
+
+    BLOCK_H = 16
+    BLOCK_W = 16
+    grid = (
+        (target_h + BLOCK_H - 1) // BLOCK_H,
+        (target_w + BLOCK_W - 1) // BLOCK_W,
+    )
+    _fused_resize_normalize_kernel[grid](
+        src,
+        out,
+        tables.ymin_gpu,
+        tables.xmin_gpu,
+        tables.wy_gpu,
+        tables.wx_gpu,
+        src_h,
+        src_w,
+        src_stride_h,
+        src_stride_w,
+        dst_stride_c,
+        dst_stride_h,
+        target_h,
+        target_w,
+        float(inv_std_255_r),
+        float(inv_std_255_g),
+        float(inv_std_255_b),
+        float(offset_r),
+        float(offset_g),
+        float(offset_b),
+        CH_R=ch_r,
+        CH_G=ch_g,
+        CH_B=ch_b,
+        KSIZE_Y=tables.ksize_y,
+        KSIZE_X=tables.ksize_x,
+        PRECISION_BITS_C=PRECISION_BITS,
+        HALF_C=_HALF,
+        BLOCK_H=BLOCK_H,
+        BLOCK_W=BLOCK_W,
+    )
+    return out

--- a/temp/coco_map.py
+++ b/temp/coco_map.py
@@ -1,0 +1,150 @@
+"""Compute coco detection + segm mAP for rfdetr-seg-nano on coco/val2017.
+
+A single process runs one pass with the path selected by the
+INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED env var. Run it twice
+(true, false) and compare — mAP should be identical to 4 decimals.
+
+Usage:
+  INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=true  python temp/coco_map.py
+  INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false python temp/coco_map.py
+
+Also prints the Triton kernel call count: it must equal the image count
+when the env is true and be 0 when it is false.
+"""
+import os
+import time
+from pathlib import Path
+
+os.environ.setdefault(
+    "DISABLED_INFERENCE_MODELS_BACKENDS",
+    "torch,torch-script,onnx,hugging-face,ultralytics,mediapipe,custom",
+)
+
+import cv2
+import numpy as np
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+from pycocotools import mask as coco_mask
+
+from inference_models import AutoModel
+import inference_models.models.rfdetr.rfdetr_instance_segmentation_trt as trt_mod
+
+COCO_DIR = Path("/home/ubuntu/inference/coco")
+ANN = COCO_DIR / "annotations" / "instances_val2017.json"
+IMG_DIR = COCO_DIR / "val2017"
+CONF = 0.05  # coco-eval convention: submit low-confidence detections too
+
+
+def build_id_maps(model_class_names, coco):
+    name_to_cat_id = {coco.loadCats([c])[0]['name']: c for c in coco.getCatIds()}
+    return {
+        idx: name_to_cat_id[name]
+        for idx, name in enumerate(model_class_names)
+        if name in name_to_cat_id
+    }
+
+
+def encode_rle(mask_bool):
+    arr = np.asfortranarray(mask_bool.cpu().numpy().astype(np.uint8))
+    rle = coco_mask.encode(arr)
+    rle['counts'] = rle['counts'].decode('ascii')
+    return rle
+
+
+def predictions_for_image(model, img_bgr, image_id, cat_map):
+    pre, meta = model.pre_process(img_bgr)
+    out = model.forward(pre)
+    det = model.post_process(out, meta, confidence=CONF)[0]
+    n = int(det.class_id.numel())
+    if n == 0:
+        return [], []
+    xyxy = det.xyxy.cpu().numpy()
+    scores = det.confidence.cpu().numpy()
+    class_ids = det.class_id.cpu().numpy()
+    masks = det.mask
+
+    bbox_preds, segm_preds = [], []
+    for i in range(n):
+        cid = int(class_ids[i])
+        if cid not in cat_map:
+            continue
+        x1, y1, x2, y2 = [float(v) for v in xyxy[i]]
+        bbox_preds.append({
+            "image_id": image_id,
+            "category_id": cat_map[cid],
+            "bbox": [x1, y1, x2 - x1, y2 - y1],
+            "score": float(scores[i]),
+        })
+        if masks is not None:
+            segm_preds.append({
+                "image_id": image_id,
+                "category_id": cat_map[cid],
+                "segmentation": encode_rle(masks[i]),
+                "score": float(scores[i]),
+            })
+    return bbox_preds, segm_preds
+
+
+def run_pass(model, coco, cat_map, tag):
+    bbox, segm = [], []
+    ids = sorted(coco.getImgIds())
+    t0 = time.perf_counter()
+    for n, image_id in enumerate(ids):
+        info = coco.loadImgs([image_id])[0]
+        img = cv2.imread(str(IMG_DIR / info['file_name']), cv2.IMREAD_COLOR)
+        if img is None:
+            continue
+        b, s = predictions_for_image(model, img, image_id, cat_map)
+        bbox.extend(b)
+        segm.extend(s)
+        if (n + 1) % 500 == 0:
+            print(f"  [{tag}] {n+1}/{len(ids)} ({time.perf_counter()-t0:.0f}s)", flush=True)
+    return bbox, segm
+
+
+def eval_and_print(coco_gt, results, iou_type):
+    if not results:
+        return None
+    ev = COCOeval(coco_gt, coco_gt.loadRes(results), iou_type)
+    ev.evaluate()
+    ev.accumulate()
+    ev.summarize()
+    return ev.stats.tolist()
+
+
+def main():
+    env_flag = os.environ.get("INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED", "true")
+    tag = f"env={env_flag}"
+
+    triton_calls = {"count": 0}
+    original = trt_mod.triton_preprocess_rfdetr_stretch
+    if original is not None:
+        def counting(*a, **kw):
+            triton_calls["count"] += 1
+            return original(*a, **kw)
+        trt_mod.triton_preprocess_rfdetr_stretch = counting
+
+    print(f"INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED={env_flag}")
+    print(f"_FAST_PATH_ENABLED={trt_mod._FAST_PATH_ENABLED}  "
+          f"_TRITON_AVAILABLE={trt_mod._TRITON_AVAILABLE}")
+
+    coco = COCO(str(ANN))
+    model = AutoModel.from_pretrained('rfdetr-seg-nano')
+    cat_map = build_id_maps(model.class_names, coco)
+
+    bbox, segm = run_pass(model, coco, cat_map, tag)
+    print(f"\n  Triton kernel calls: {triton_calls['count']}")
+
+    print(f"\n== bbox mAP ({tag}) ==")
+    stats_bbox = eval_and_print(coco, bbox, 'bbox')
+    print(f"\n== segm mAP ({tag}) ==")
+    stats_segm = eval_and_print(coco, segm, 'segm')
+
+    if stats_bbox:
+        print(f"\n  bbox : AP={stats_bbox[0]:.4f}  AP50={stats_bbox[1]:.4f}  AP75={stats_bbox[2]:.4f}")
+    if stats_segm:
+        print(f"  segm : AP={stats_segm[0]:.4f}  AP50={stats_segm[1]:.4f}  AP75={stats_segm[2]:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/temp/detection_parity_full.py
+++ b/temp/detection_parity_full.py
@@ -1,0 +1,193 @@
+"""Full coco/val2017 detection + mask parity: Triton fast path vs PIL.
+
+Driven by INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED. Because the env
+var is read once at import time, we run two subprocesses (true, false),
+dump per-image detections to pickle, then compare.
+
+Usage:
+  python temp/detection_parity_full.py           # driver: runs both passes
+  python temp/detection_parity_full.py --mode run --env true  --out /tmp/full_on.pkl
+  python temp/detection_parity_full.py --mode compare --on /tmp/full_on.pkl --off /tmp/full_off.pkl
+"""
+import argparse
+import os
+import pickle
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+COCO = Path("/home/ubuntu/inference/coco/val2017")
+CONFIDENCE = 0.4
+PY = sys.executable
+SELF = Path(__file__).resolve()
+OUT_ON = "/tmp/det_parity_full_on.pkl"
+OUT_OFF = "/tmp/det_parity_full_off.pkl"
+
+
+def do_run(out_path):
+    os.environ.setdefault(
+        "DISABLED_INFERENCE_MODELS_BACKENDS",
+        "torch,torch-script,onnx,hugging-face,ultralytics,mediapipe,custom",
+    )
+    import cv2
+    import numpy as np
+    import torch
+
+    from inference_models import AutoModel
+    import inference_models.models.rfdetr.rfdetr_instance_segmentation_trt as trt_mod
+
+    triton_calls = {"count": 0}
+    original = trt_mod.triton_preprocess_rfdetr_stretch
+    if original is not None:
+        def counting(*a, **kw):
+            triton_calls["count"] += 1
+            return original(*a, **kw)
+        trt_mod.triton_preprocess_rfdetr_stretch = counting
+
+    env_flag = os.environ.get("INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED", "<unset>")
+    print(f"[run] env={env_flag}  _FAST_PATH_ENABLED={trt_mod._FAST_PATH_ENABLED}")
+
+    paths = sorted(COCO.glob("*.jpg"))
+    model = AutoModel.from_pretrained("rfdetr-seg-nano")
+
+    records = []
+    t0 = time.perf_counter()
+    for idx, p in enumerate(paths):
+        im = cv2.imread(str(p), cv2.IMREAD_COLOR)
+        if im is None:
+            continue
+        pre, meta = model.pre_process(im)
+        out = model.forward(pre)
+        det = model.post_process(out, meta, confidence=CONFIDENCE)[0]
+        n = int(det.class_id.numel())
+        records.append({
+            "path": str(p),
+            "xyxy": det.xyxy.cpu().numpy() if n else None,
+            "conf": det.confidence.cpu().numpy() if n else None,
+            "cls":  det.class_id.cpu().numpy() if n else None,
+            "mask": det.mask.cpu().to(torch.bool).numpy() if (n and det.mask is not None) else None,
+        })
+        if (idx + 1) % 500 == 0:
+            print(f"  [{env_flag}] {idx+1}/{len(paths)}  ({time.perf_counter()-t0:.0f}s)", flush=True)
+
+    with open(out_path, "wb") as f:
+        pickle.dump({"records": records, "triton_calls": triton_calls["count"]}, f)
+    print(f"[run] triton_kernel_calls={triton_calls['count']}  saved -> {out_path}")
+
+
+def iou_box(a, b):
+    x0 = max(a[0], b[0]); y0 = max(a[1], b[1])
+    x1 = min(a[2], b[2]); y1 = min(a[3], b[3])
+    iw = max(0, x1 - x0); ih = max(0, y1 - y0)
+    inter = iw * ih
+    area_a = max(0, a[2] - a[0]) * max(0, a[3] - a[1])
+    area_b = max(0, b[2] - b[0]) * max(0, b[3] - b[1])
+    u = area_a + area_b - inter
+    return inter / u if u > 0 else 0.0
+
+
+def do_compare(on_path, off_path):
+    import numpy as np
+    with open(on_path, "rb") as f:
+        on = pickle.load(f)
+    with open(off_path, "rb") as f:
+        off = pickle.load(f)
+
+    assert len(on["records"]) == len(off["records"])
+    n_imgs = len(on["records"])
+
+    tot_on = tot_off = matched = class_disagree = count_mm = pixel_identical = 0
+    ious, dscores, mask_iou = [], [], []
+
+    for r_on, r_off in zip(on["records"], off["records"]):
+        assert r_on["path"] == r_off["path"]
+        nf = 0 if r_on["xyxy"] is None else len(r_on["xyxy"])
+        nr = 0 if r_off["xyxy"] is None else len(r_off["xyxy"])
+        tot_on += nf; tot_off += nr
+        if nf != nr:
+            count_mm += 1
+        if nf == 0 and nr == 0:
+            continue
+        bf = r_on["xyxy"] if nf else np.zeros((0, 4))
+        br = r_off["xyxy"] if nr else np.zeros((0, 4))
+        sf = r_on["conf"] if nf else np.zeros(0)
+        sr = r_off["conf"] if nr else np.zeros(0)
+        cf = r_on["cls"] if nf else np.zeros(0, dtype=int)
+        cr = r_off["cls"] if nr else np.zeros(0, dtype=int)
+        mf, mr_m = r_on["mask"], r_off["mask"]
+
+        used = set()
+        for j in range(nr):
+            best_i, best_iou = -1, 0.5
+            for i in range(nf):
+                if i in used:
+                    continue
+                iou = iou_box(bf[i], br[j])
+                if iou > best_iou:
+                    best_iou, best_i = iou, i
+            if best_i >= 0:
+                used.add(best_i)
+                matched += 1
+                ious.append(best_iou)
+                dscores.append(abs(float(sf[best_i]) - float(sr[j])))
+                if int(cf[best_i]) != int(cr[j]):
+                    class_disagree += 1
+                if mf is not None and mr_m is not None:
+                    a = mf[best_i]; b = mr_m[j]
+                    inter = np.logical_and(a, b).sum()
+                    u = np.logical_or(a, b).sum()
+                    mask_iou.append(float(inter) / float(u) if u else 0.0)
+                    if np.array_equal(a, b):
+                        pixel_identical += 1
+
+    print()
+    print(f"==== full coco/val2017 parity: env=true vs env=false ({n_imgs} images) ====")
+    print(f"  triton calls (env=true)      : {on['triton_calls']}")
+    print(f"  triton calls (env=false)     : {off['triton_calls']}")
+    print(f"  dets env=true / env=false    : {tot_on} / {tot_off}")
+    print(f"  matched (IoU>0.5)            : {matched} ({100*matched/max(1,tot_off):.2f}% of env=false)")
+    print(f"  count-mismatch images        : {count_mm}")
+    print(f"  class-id disagreements       : {class_disagree}")
+    if ious:
+        print(f"  mean box IoU                 : {np.mean(ious):.6f}")
+    if dscores:
+        print(f"  mean / max |Δscore|          : {np.mean(dscores):.3e} / {np.max(dscores):.3e}")
+    if mask_iou:
+        a = np.array(mask_iou)
+        print(f"  mean / min mask IoU          : {a.mean():.6f} / {a.min():.6f}")
+        print(f"  pixel-identical masks        : {pixel_identical}/{len(mask_iou)}")
+    print()
+    expected = n_imgs
+    ok_on  = "[PASS]" if on["triton_calls"]  == expected else "[FAIL]"
+    ok_off = "[PASS]" if off["triton_calls"] == 0 else "[FAIL]"
+    print(f"  {ok_on} env=true  -> Triton fired {on['triton_calls']}/{expected}")
+    print(f"  {ok_off} env=false -> Triton fired {off['triton_calls']} (expected 0)")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=("driver", "run", "compare"), default="driver")
+    ap.add_argument("--out")
+    ap.add_argument("--on")
+    ap.add_argument("--off")
+    args = ap.parse_args()
+
+    if args.mode == "run":
+        do_run(args.out)
+        return
+    if args.mode == "compare":
+        do_compare(args.on, args.off)
+        return
+
+    for env_value, out in (("true", OUT_ON), ("false", OUT_OFF)):
+        env = os.environ.copy()
+        env["INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED"] = env_value
+        print(f"\n---- child: env={env_value} out={out} ----", flush=True)
+        subprocess.run([PY, str(SELF), "--mode", "run", "--out", out], check=True, env=env)
+
+    do_compare(OUT_ON, OUT_OFF)
+
+
+if __name__ == "__main__":
+    main()

--- a/temp/parity_env_var.py
+++ b/temp/parity_env_var.py
@@ -1,0 +1,211 @@
+"""Parity sanity + kill-switch verification on perf/rfdetr-seg-triton-preproc.
+
+Two modes:
+  --mode run   : run N_IMAGES through the model in *this* process (env var
+                 controls fast path); save predictions + Triton kernel call
+                 count to --out.
+  --mode compare : load two prediction files and report per-detection parity.
+
+Driver: first invokes mode=run twice (env=true, env=false) via subprocess so
+each import sees a fresh env-var read, then invokes mode=compare.
+"""
+import argparse
+import os
+import pickle
+import random
+import subprocess
+import sys
+from pathlib import Path
+
+
+COCO = Path("/home/ubuntu/inference/coco/val2017")
+N_IMAGES = 100
+CONFIDENCE = 0.4
+SEED = 0
+PY = "/home/ubuntu/inference/.venv/bin/python"
+SELF = Path(__file__).resolve()
+OUT_ON = "/tmp/parity_env_on.pkl"
+OUT_OFF = "/tmp/parity_env_off.pkl"
+
+
+def do_run(out_path: str):
+    os.environ.setdefault(
+        "DISABLED_INFERENCE_MODELS_BACKENDS",
+        "torch,torch-script,onnx,hugging-face,ultralytics,mediapipe,custom",
+    )
+    import cv2
+    import torch
+    from inference_models import AutoModel
+    import inference_models.models.rfdetr.rfdetr_instance_segmentation_trt as trt_mod
+
+    triton_calls = {"count": 0}
+    original = trt_mod.triton_preprocess_rfdetr_stretch
+    if original is not None:
+        def counting(*args, **kwargs):
+            triton_calls["count"] += 1
+            return original(*args, **kwargs)
+        trt_mod.triton_preprocess_rfdetr_stretch = counting
+
+    random.seed(SEED)
+    all_paths = sorted(COCO.glob("*.jpg"))
+    paths = random.sample(all_paths, N_IMAGES)
+
+    model = AutoModel.from_pretrained("rfdetr-seg-nano")
+    print(f"[child] env={os.environ.get('INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED','<unset>')}  "
+          f"_FAST_PATH_ENABLED={trt_mod._FAST_PATH_ENABLED}  _TRITON_AVAILABLE={trt_mod._TRITON_AVAILABLE}",
+          flush=True)
+
+    records = []
+    for p in paths:
+        im = cv2.imread(str(p), cv2.IMREAD_COLOR)
+        if im is None:
+            continue
+        pre, meta = model.pre_process(im)
+        out = model.forward(pre)
+        det = model.post_process(out, meta, confidence=CONFIDENCE)[0]
+        n = int(det.class_id.numel())
+        records.append({
+            "path": str(p),
+            "xyxy": det.xyxy.cpu().numpy() if n else None,
+            "conf": det.confidence.cpu().numpy() if n else None,
+            "cls":  det.class_id.cpu().numpy() if n else None,
+            "mask": det.mask.cpu().to(torch.bool).numpy() if (n and det.mask is not None) else None,
+        })
+
+    with open(out_path, "wb") as f:
+        pickle.dump({"records": records, "triton_calls": triton_calls["count"]}, f)
+    print(f"[child] triton_kernel_calls = {triton_calls['count']}  saved -> {out_path}", flush=True)
+
+
+def iou_box(a, b):
+    import numpy as np
+    x0 = max(a[0], b[0]); y0 = max(a[1], b[1])
+    x1 = min(a[2], b[2]); y1 = min(a[3], b[3])
+    iw = max(0, x1 - x0); ih = max(0, y1 - y0)
+    inter = iw * ih
+    area_a = max(0, a[2] - a[0]) * max(0, a[3] - a[1])
+    area_b = max(0, b[2] - b[0]) * max(0, b[3] - b[1])
+    u = area_a + area_b - inter
+    return inter / u if u > 0 else 0.0
+
+
+def do_compare(on_path: str, off_path: str):
+    import numpy as np
+    with open(on_path, "rb") as f:
+        on = pickle.load(f)
+    with open(off_path, "rb") as f:
+        off = pickle.load(f)
+
+    assert len(on["records"]) == len(off["records"])
+    n_imgs = len(on["records"])
+
+    tot_on = tot_off = matched = 0
+    ious = []
+    dscores = []
+    mask_iou = []
+    pixel_identical = 0
+    count_mm_images = 0
+    class_disagree = 0
+
+    for r_on, r_off in zip(on["records"], off["records"]):
+        assert r_on["path"] == r_off["path"]
+        nf = 0 if r_on["xyxy"] is None else len(r_on["xyxy"])
+        nr = 0 if r_off["xyxy"] is None else len(r_off["xyxy"])
+        tot_on += nf; tot_off += nr
+        if nf != nr:
+            count_mm_images += 1
+        if nf == 0 and nr == 0:
+            continue
+        bf = r_on["xyxy"] if nf else np.zeros((0, 4))
+        br = r_off["xyxy"] if nr else np.zeros((0, 4))
+        sf = r_on["conf"] if nf else np.zeros(0)
+        sr = r_off["conf"] if nr else np.zeros(0)
+        cf = r_on["cls"] if nf else np.zeros(0, dtype=int)
+        cr = r_off["cls"] if nr else np.zeros(0, dtype=int)
+        mf = r_on["mask"]; mr_m = r_off["mask"]
+
+        used = set()
+        for j in range(nr):
+            best_i, best_iou = -1, 0.5
+            for i in range(nf):
+                if i in used:
+                    continue
+                iou = iou_box(bf[i], br[j])
+                if iou > best_iou:
+                    best_iou, best_i = iou, i
+            if best_i >= 0:
+                used.add(best_i)
+                matched += 1
+                ious.append(best_iou)
+                dscores.append(abs(float(sf[best_i]) - float(sr[j])))
+                if int(cf[best_i]) != int(cr[j]):
+                    class_disagree += 1
+                if mf is not None and mr_m is not None:
+                    a = mf[best_i]; b = mr_m[j]
+                    inter = np.logical_and(a, b).sum()
+                    u = np.logical_or(a, b).sum()
+                    mask_iou.append(float(inter) / float(u) if u else 0.0)
+                    if np.array_equal(a, b):
+                        pixel_identical += 1
+
+    print()
+    print(f"==== parity: env=true vs env=false  ({n_imgs} images) ====")
+    print(f"  triton calls (env=true)       : {on['triton_calls']}")
+    print(f"  triton calls (env=false)      : {off['triton_calls']}")
+    print(f"  dets env=true                 : {tot_on}")
+    print(f"  dets env=false                : {tot_off}")
+    print(f"  matched (IoU>0.5)             : {matched} "
+          f"({100*matched/max(1,tot_off):.2f}% of env=false)")
+    print(f"  count-mismatch images         : {count_mm_images}")
+    print(f"  class-id disagreements        : {class_disagree}")
+    if ious:
+        print(f"  mean box IoU                  : {np.mean(ious):.6f}")
+    if dscores:
+        print(f"  mean / max |Δscore|           : {np.mean(dscores):.3e} / {np.max(dscores):.3e}")
+    if mask_iou:
+        a = np.array(mask_iou)
+        print(f"  mean / min mask IoU           : {a.mean():.6f} / {a.min():.6f}")
+        print(f"  pixel-identical masks         : {pixel_identical}/{len(mask_iou)}")
+
+    print()
+    expected_calls_on = n_imgs  # 1 kernel launch per image (single-item batch)
+    if on["triton_calls"] == expected_calls_on:
+        print(f"  [PASS] env=true  -> Triton kernel fired {on['triton_calls']}/{expected_calls_on} times")
+    else:
+        print(f"  [FAIL] env=true  -> Triton kernel fired {on['triton_calls']} times "
+              f"(expected {expected_calls_on})")
+    if off["triton_calls"] == 0:
+        print(f"  [PASS] env=false -> Triton kernel never fired")
+    else:
+        print(f"  [FAIL] env=false -> Triton kernel fired {off['triton_calls']} times (expected 0)")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=("driver", "run", "compare"), default="driver")
+    ap.add_argument("--out")
+    args = ap.parse_args()
+
+    if args.mode == "run":
+        do_run(args.out)
+        return
+    if args.mode == "compare":
+        do_compare(OUT_ON, OUT_OFF)
+        return
+
+    for env_value, out in (("true", OUT_ON), ("false", OUT_OFF)):
+        env = os.environ.copy()
+        env["INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED"] = env_value
+        print(f"\n---- running child: env={env_value} out={out} ----", flush=True)
+        subprocess.run(
+            [PY, str(SELF), "--mode", "run", "--out", out],
+            check=True,
+            cwd="/tmp",
+            env=env,
+        )
+    print("\n---- comparing ----", flush=True)
+    do_compare(OUT_ON, OUT_OFF)
+
+
+if __name__ == "__main__":
+    main()

--- a/temp/parity_triton_vs_pil.py
+++ b/temp/parity_triton_vs_pil.py
@@ -1,0 +1,93 @@
+"""Compare Triton PIL-antialias-bilinear kernel against the production PIL path
+on a handful of COCO val2017 images at 3 target sizes.
+
+Prod path reference: inference_models/models/rfdetr/pre_processing.py:_pre_process_numpy
+(BGR uint8 -> RGB -> PIL.Image.fromarray -> TF.resize antialias -> TF.to_tensor -> TF.normalize).
+
+Triton path: build_resample_tables -> triton_preprocess_rfdetr_stretch with swap_rb=True.
+"""
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+import torchvision.transforms.functional as TF
+from PIL import Image
+
+from inference_models.models.rfdetr.triton_preprocess import (
+    build_resample_tables,
+    triton_preprocess_rfdetr_stretch,
+)
+
+COCO_DIR = Path("/home/ubuntu/inference/coco/val2017")
+MEANS = (0.485, 0.456, 0.406)
+STDS = (0.229, 0.224, 0.225)
+TARGETS = [(312, 312), (640, 640), (512, 384)]
+N_IMAGES = 20
+DEVICE = torch.device("cuda:0")
+
+
+def pil_reference(bgr_uint8: np.ndarray, th: int, tw: int) -> torch.Tensor:
+    rgb = bgr_uint8[:, :, ::-1]
+    pil = Image.fromarray(np.ascontiguousarray(rgb))
+    resized = TF.resize(pil, (th, tw), antialias=True)
+    tensor = TF.to_tensor(resized)
+    tensor = TF.normalize(tensor, mean=list(MEANS), std=list(STDS))
+    return tensor
+
+
+def main() -> None:
+    paths = sorted(COCO_DIR.glob("*.jpg"))[:N_IMAGES]
+    assert paths, f"no images in {COCO_DIR}"
+
+    print(f"{'target':>11}  {'n':>3}  {'max|Δ|':>10}  {'mean|Δ|':>10}  {'≈|Δ|<1e-3':>11}")
+    for th, tw in TARGETS:
+        max_abs = 0.0
+        sum_abs = 0.0
+        count = 0
+        near = 0
+        tables = None
+        last_src_hw = None
+        for p in paths:
+            bgr = cv2.imread(str(p), cv2.IMREAD_COLOR)
+            if bgr is None:
+                continue
+            # Reference
+            ref = pil_reference(bgr, th, tw).unsqueeze(0).to(DEVICE)
+            # Triton
+            src_gpu = torch.from_numpy(bgr).to(DEVICE)
+            if tables is None or last_src_hw != (bgr.shape[0], bgr.shape[1]):
+                tables = build_resample_tables(
+                    src_h=bgr.shape[0],
+                    src_w=bgr.shape[1],
+                    target_h=th,
+                    target_w=tw,
+                    device=DEVICE,
+                )
+                last_src_hw = (bgr.shape[0], bgr.shape[1])
+            out = triton_preprocess_rfdetr_stretch(
+                src=src_gpu,
+                tables=tables,
+                target_h=th,
+                target_w=tw,
+                means=MEANS,
+                stds=STDS,
+                swap_rb=True,
+            )
+            torch.cuda.synchronize()
+            diff = (out - ref).abs()
+            cur_max = float(diff.max().item())
+            max_abs = max(max_abs, cur_max)
+            sum_abs += float(diff.sum().item())
+            count += diff.numel()
+            if cur_max < 1e-3:
+                near += 1
+        mean_abs = sum_abs / count
+        print(
+            f"  {th:>4}x{tw:<4}  {len(paths):>3}  {max_abs:>10.3e}  "
+            f"{mean_abs:>10.3e}  {near:>5}/{len(paths):<4}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/temp/preproc_microbench.py
+++ b/temp/preproc_microbench.py
@@ -1,0 +1,60 @@
+"""Isolate pre_process() timing. Path selected by
+INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED. Reports the Triton
+kernel call count so the reviewer can see which path ran.
+
+Usage (run twice and compare):
+  INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=true  python temp/preproc_microbench.py
+  INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false python temp/preproc_microbench.py
+"""
+import os
+import time
+
+os.environ.setdefault(
+    "DISABLED_INFERENCE_MODELS_BACKENDS",
+    "torch,torch-script,onnx,hugging-face,ultralytics,mediapipe,custom",
+)
+
+import numpy as np
+import torch
+from inference_models import AutoModel
+import inference_models.models.rfdetr.rfdetr_instance_segmentation_trt as trt_mod
+
+
+def bench(label, fn, n=200):
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(n):
+        fn()
+    torch.cuda.synchronize()
+    dt = (time.perf_counter() - t0) / n * 1000
+    print(f"{label:>18s}: {dt:7.3f} ms/frame  ({1000/dt:6.1f} fps)")
+
+
+def main():
+    env_flag = os.environ.get("INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED", "<unset>")
+
+    triton_calls = {"count": 0}
+    original = trt_mod.triton_preprocess_rfdetr_stretch
+    if original is not None:
+        def counting(*a, **kw):
+            triton_calls["count"] += 1
+            return original(*a, **kw)
+        trt_mod.triton_preprocess_rfdetr_stretch = counting
+
+    print(f"INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED={env_flag}")
+    print(f"_FAST_PATH_ENABLED={trt_mod._FAST_PATH_ENABLED}")
+
+    m = AutoModel.from_pretrained("rfdetr-seg-nano")
+    for src_h, src_w in [(312, 312), (720, 1280), (1080, 1920)]:
+        img = np.random.randint(0, 255, (src_h, src_w, 3), dtype=np.uint8)
+        print(f"\nsrc {src_h}x{src_w} -> 312x312:")
+        bench("pre_process", lambda img=img: m.pre_process(img))
+
+    print(f"\n  Triton kernel calls: {triton_calls['count']} "
+          f"(expected {'>0' if env_flag.lower() in ('true','1') else '0'})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Replaces the per-frame PIL-bilinear-antialias + `to_tensor` + `normalize` chain in `RFDetrForInstanceSegmentationTRT` with a single Triton kernel that resizes, swaps BGR↔RGB, scales, and applies ImageNet normalization, writing straight into the preallocated TRT input buffer.

- Byte-exact port of PIL's separable bilinear-antialias resize (`PRECISION_BITS=22`, int32 fixed-point, uint8 quantization between horizontal and vertical passes). The horizontal uint8 intermediate lives in registers.
- Falls back to the existing `pre_process_network_input` whenever any precondition isn't met.
- **Kill switch**: set `INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false` to force the PIL reference path for every call (default `true`).

## Correctness

All repro scripts live in `temp/`. They are driven by `INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED` and each one verifies the Triton kernel fires exactly when the env is `true` and never fires when it is `false` (via an instrumented counter on `triton_preprocess_rfdetr_stretch`).

Requires `coco/val2017` + `coco/annotations/instances_val2017.json` under `/home/ubuntu/inference/coco/` (paths are hardcoded at the top of each script).

### 1. Kernel vs PIL, fp32 ULP only

```
python temp/parity_triton_vs_pil.py
```

Bypasses the model stack; calls the kernel directly and compares to PIL `TF.resize(antialias=True) → to_tensor → normalize` on 20 COCO images at 312² / 640² / 512×384.

Result: **max abs error 4.77e-7** (fp32 ULP). The uint8 resize intermediate is byte-identical to PIL.

### 2. Full-dataset detection + mask parity (5000 images)

```
python temp/detection_parity_full.py
```

Driver script: spawns two subprocesses (`env=true`, `env=false`) so each sees a fresh env-var read, pickles per-image detections, then compares.

| | Triton fast path (env=true) | PIL reference (env=false) |
|---|---|---|
| Triton kernel calls | **5000 / 5000** | **0** |
| Detections | 26,721 | 26,721 |
| Matched at IoU>0.5 | **26,721 (100%)** | — |
| Mean box IoU | **1.000000** | — |
| Mean \|Δscore\| | **0.000e+00** | — |
| Class-id disagreements | **0** | — |
| Pixel-identical masks | **26,721 / 26,721** | — |

(100-image quick sanity: `python temp/parity_env_var.py` — same shape, 1 min total.)

### 3. coco/val2017 mAP (bbox + segm, pycocotools)

Run the script twice in sequence:

```
INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=true  python temp/coco_map.py
INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false python temp/coco_map.py
```

Each run prints its Triton kernel call count (5000 vs 0) and bbox/segm mAP.

| | Triton (env=true) | PIL (env=false) | Δ |
|---|---|---|---|
| bbox AP / AP50 / AP75 | 0.4907 / 0.6810 / 0.5313 | 0.4907 / 0.6810 / 0.5313 | **0.000000** |
| segm AP / AP50 / AP75 | 0.4038 / 0.6328 / 0.4252 | 0.4038 / 0.6328 / 0.4252 | **0.000000** |

## Performance

### End-to-end, InferencePipeline + workflow

The benchmark driver is committed at `development/stream_interface/rfdetr_nano_seg_trt_workflow.py`. Run it twice:

```
INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=true  \
  python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
  --video_reference vehicles_312px.mp4

INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false \
  python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
  --video_reference vehicles_312px.mp4
```

vehicles_312px.mp4 (538 frames, src 312×176):

| | fps | ms/frame |
|---|---|---|
| PIL reference (env=false) | 76.25 | 13.11 |
| Triton fast path (env=true) | **99.83** | 10.02 |
| Δ | **+31%** | −3.09 ms |

vehicles_1080p.mp4 (538 frames, src 1920×1080 — preproc has real resize work):

| | fps | elapsed |
|---|---|---|
| PIL reference (env=false) | 14.05 | 38.29 s |
| Triton fast path (env=true) | **21.34** | 25.21 s |
| Δ | **+52%** | −13.1 s |

### Preproc microbench (isolated `pre_process()`)

```
INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=true  python temp/preproc_microbench.py
INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false python temp/preproc_microbench.py
```

| src → 312² | PIL (env=false) | Triton (env=true) |
|---|---|---|
| 312×312 | 1.81 ms | 0.19 ms (9.5×) |
| 720×1280 | 13.13 ms | 1.56 ms (8.4×) |
| 1080×1920 | 27.03 ms | 2.69 ms (10.0×) |

GPU-only nsys profile (traces not committed; saved locally in `temp/nsys/{fused_on,pil_baseline}.nsys-rep`): total kernel time 2690 ms vs 2995 ms; HtoD memcpy 29 ms vs 117 ms (the PIL path was uploading a 1.17 MB fp32 tensor per frame; Triton uploads the 164 KB raw uint8 frame instead).

## Fast-path scope

Gated on *all* of:
- `INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED` unset or `true`
- `image_size` kwarg unset
- `image_pre_processing` has no `static_crop` / `grayscale` / `contrast` enabled
- `dataset_version_resize_dimensions` is `None`
- 3-channel input, `scaling_factor` in `{None, 255}`, `normalization` set
- `resize_mode` in `{stretch, letterbox, center-crop, letterbox-reflect-edges}` (all four collapse to a single PIL stretch when `dataset_version_resize_dimensions is None` — verified with a synthetic-package test, byte-identical output across modes)
- Input is a single-item `list[np.ndarray]` or a raw `np.ndarray`, HWC `uint8`

Anything else transparently falls back to `pre_process_network_input`.

## Files

- `inference_models/models/rfdetr/triton_preprocess.py` (new) — `_fused_resize_normalize_kernel` + `_ResampleTables` weight precompute + `triton_preprocess_rfdetr_stretch` API.
- `inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py` — adds `_FastPathState` (cached pinned-host buffer, GPU src buffer, fp32 output buffer, resample tables), `_try_fast_preprocess` in `pre_process`, and the `INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED` kill switch.
- `development/stream_interface/rfdetr_nano_seg_trt_workflow.py` (new, from `optimize-rfdetr-seg`) — benchmark driver used to produce the fps numbers above.
- `temp/parity_triton_vs_pil.py`, `temp/detection_parity_full.py`, `temp/parity_env_var.py`, `temp/coco_map.py`, `temp/preproc_microbench.py` — repro scripts for every correctness + performance number above.

## Test plan

- [x] Preproc parity vs PIL on 20 coco images at 312²/640²/512×384 (max 4.77e-7)
- [x] Full coco/val2017 detection parity, 5000 images, Triton vs forced-PIL (100% match, pixel-identical masks)
- [x] coco/val2017 mAP (bbox+segm) — identical to 4 decimals between Triton and PIL paths
- [x] vehicles_312px.mp4 end-to-end benchmark with and without the fast path (+31%)
- [x] vehicles_1080p.mp4 end-to-end benchmark (+52% — preproc bottleneck is relieved more on larger sources)
- [x] Fast-path predicate verified under `InferencePipeline` (fires on all 538 frames)
- [x] Synthetic check that all 4 accepted resize modes produce identical output to stretch when `dataset_version_resize_dimensions is None`
- [x] Kill-switch verified: instrumented `triton_preprocess_rfdetr_stretch` shows kernel fires on every eligible call when env=true and never when env=false, across all four repro scripts.
