### PR TITLE
Support optimized RF-DETR batches in workflows

### DIFF
--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -411,24 +411,11 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
         return self._model.pre_process(np_images, **mapped_kwargs)
 
-    def _request_batch_size(self, img_in: Any) -> int:
-        pre_processing_meta = getattr(img_in, "_pre_processing_meta", None)
-        if isinstance(pre_processing_meta, (list, tuple)):
-            return len(pre_processing_meta)
-        shape = getattr(img_in, "shape", None)
-        if shape is not None and len(shape) > 0:
-            return int(shape[0])
-        if isinstance(img_in, (list, tuple)):
-            return len(img_in)
-        return 1
-
     def predict(self, img_in, **kwargs):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
         if self._pipeline_depth <= 1:
             # Original path: forward on current frame, postprocess on
             # current frame, all synchronous.
-            return self._model.forward(img_in, **mapped_kwargs)
-        if self._request_batch_size(img_in) > 1:
             return self._model.forward(img_in, **mapped_kwargs)
 
         mapped_kwargs["defer_count_to_adapter"] = (
@@ -536,6 +523,11 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         while self._pending_futures:
             self._submit_response_build(*self._pending_futures.popleft())
 
+    def _metadata_batch_size(self, preprocess_return_metadata: Any) -> int:
+        if isinstance(preprocess_return_metadata, (list, tuple)):
+            return len(preprocess_return_metadata)
+        return 1
+
     def postprocess(
         self,
         predictions,
@@ -556,7 +548,15 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             )
         )
         self._pending_futures.append((fut, preprocess_return_metadata, mapped_kwargs))
-        if len(self._pending_futures) > self._response_delay:
+        one_shot_batched_request = (
+            self._metadata_batch_size(preprocess_return_metadata) > 1
+            and len(self._pending_futures) == 1
+            and not self._response_futures
+        )
+        if one_shot_batched_request:
+            self._submit_all_pending_gpu_work()
+            self._submit_all_pending_responses()
+        elif len(self._pending_futures) > self._response_delay:
             self._submit_next_pending_gpu_work()
             self._submit_ready_responses()
 

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -1,5 +1,6 @@
 import traceback
 from collections import defaultdict
+from concurrent.futures import Future
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -63,6 +64,7 @@ def construct_workflow_output(
         if output.name in batch_oriented_outputs:
             continue
         data_piece = execution_data_manager.get_non_batch_data(selector=output.selector)
+        data_piece = _maybe_resolve_output_futures(data_piece)
         if serialize_results:
             output_kind = kinds_of_output_nodes[output.name]
             data_piece = serialize_data_piece(
@@ -169,6 +171,7 @@ def create_outputs_for_input_induced_lineages(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
+            data_piece = _maybe_resolve_output_futures(data_piece)
             if (
                 name in outputs_requested_in_parent_coordinates
                 and data_contains_sv_detections(data=data_piece)
@@ -263,6 +266,7 @@ def create_outputs_for_generated_lineage_outputs(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
+            data_piece = _maybe_resolve_output_futures(data_piece)
             if (
                 name in outputs_requested_in_parent_coordinates
                 and data_contains_sv_detections(data=data_piece)
@@ -310,6 +314,34 @@ def create_outputs_for_generated_lineage_outputs(
                 element = array[i]
             results[name].append(element)
     return results
+
+
+def _resolve_output_futures(value: Any) -> Any:
+    if isinstance(value, Future):
+        return _resolve_output_futures(value.result())
+    if isinstance(value, list):
+        return [_resolve_output_futures(element) for element in value]
+    if isinstance(value, tuple):
+        return tuple(_resolve_output_futures(element) for element in value)
+    if isinstance(value, dict):
+        return {key: _resolve_output_futures(element) for key, element in value.items()}
+    return value
+
+
+def _output_contains_future(value: Any) -> bool:
+    if isinstance(value, Future):
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(_output_contains_future(element) for element in value)
+    if isinstance(value, dict):
+        return any(_output_contains_future(element) for element in value.values())
+    return False
+
+
+def _maybe_resolve_output_futures(value: Any) -> Any:
+    if not _output_contains_future(value):
+        return value
+    return _resolve_output_futures(value)
 
 
 def create_array(indices: np.ndarray) -> Optional[list]:

--- a/inference_models/inference_models/models/common/trt.py
+++ b/inference_models/inference_models/models/common/trt.py
@@ -647,11 +647,17 @@ def _infer_from_trt_engine_with_batch_size_boundaries(
             synchronize=synchronize,
         )
         if reminder > 0:
+            source_results = results
             results = [r[:-reminder] for r in results]
+            _copy_trt_runtime_metadata(
+                source_results=source_results,
+                target_results=results,
+            )
         return results
     all_results = []
     for _ in outputs:
         all_results.append([])
+    graph_results_were_cloned = False
     for i in range(0, pre_processed_images.shape[0], max_batch_size):
         batch = pre_processed_images[i : i + max_batch_size].contiguous()
         reminder = min_batch_size - batch.shape[0]
@@ -677,11 +683,75 @@ def _infer_from_trt_engine_with_batch_size_boundaries(
             trt_cuda_graph_cache=trt_cuda_graph_cache,
             synchronize=synchronize,
         )
+        if not synchronize:
+            results, graph_results_cloned = _clone_trt_graph_results_for_split_batch(
+                results=results,
+                device=device,
+            )
+            graph_results_were_cloned = (
+                graph_results_were_cloned or graph_results_cloned
+            )
         if reminder > 0:
             results = [r[:-reminder] for r in results]
         for partial_result, all_result_element in zip(results, all_results):
             all_result_element.append(partial_result)
-    return [torch.cat(e, dim=0).contiguous() for e in all_results]
+    results = [torch.cat(e, dim=0).contiguous() for e in all_results]
+    if graph_results_were_cloned:
+        produce_event = torch.cuda.Event()
+        produce_event.record(torch.cuda.current_stream(device))
+        _attach_trt_produce_event_metadata(
+            results=results,
+            produce_event=produce_event,
+        )
+    return results
+
+
+def _copy_trt_runtime_metadata(
+    source_results: List[torch.Tensor],
+    target_results: List[torch.Tensor],
+) -> None:
+    if not source_results or not target_results:
+        return None
+    produce_event = getattr(source_results[0], "_trt_produce_event", None)
+    if produce_event is None:
+        return None
+    graph_state = getattr(source_results[0], "_trt_graph_state", None)
+    if graph_state is None:
+        _attach_trt_produce_event_metadata(
+            results=target_results,
+            produce_event=produce_event,
+        )
+        return None
+    _attach_trt_graph_metadata(
+        results=target_results,
+        trt_cuda_graph_state=graph_state,
+        produce_event=produce_event,
+    )
+
+
+def _clone_trt_graph_results_for_split_batch(
+    results: List[torch.Tensor],
+    device: torch.device,
+) -> Tuple[List[torch.Tensor], bool]:
+    if not results:
+        return results, False
+    graph_state = getattr(results[0], "_trt_graph_state", None)
+    produce_event = getattr(results[0], "_trt_produce_event", None)
+    if graph_state is None or produce_event is None:
+        return results, False
+    stream = torch.cuda.current_stream(device)
+    stream.wait_event(produce_event)
+    clones = [result.clone() for result in results]
+    clone_done_event = torch.cuda.Event()
+    clone_done_event.record(stream)
+    graph_states_by_id = {
+        id(state): state
+        for state in (getattr(result, "_trt_graph_state", None) for result in results)
+        if state is not None
+    }
+    for state in graph_states_by_id.values():
+        state.consumer_done_event = clone_done_event
+    return clones, True
 
 
 def _execute_trt_engine(
@@ -908,6 +978,14 @@ def _attach_trt_graph_metadata(
 ) -> None:
     for result in results:
         result._trt_graph_state = trt_cuda_graph_state  # type: ignore[attr-defined]
+        result._trt_produce_event = produce_event  # type: ignore[attr-defined]
+
+
+def _attach_trt_produce_event_metadata(
+    results: List[torch.Tensor],
+    produce_event: torch.cuda.Event,
+) -> None:
+    for result in results:
         result._trt_produce_event = produce_event  # type: ignore[attr-defined]
 
 

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
@@ -354,13 +354,16 @@ class RFDetrForInstanceSegmentationTRT(
                     synchronize=False,
                 )
         graph_state = getattr(raw[0], "_trt_graph_state", None)
-        if graph_state is None:
-            # Dynamic TensorRT execution does not expose graph-owned output
-            # buffers, so the future must wait for inference completion before
-            # handing outputs to postprocess.
-            self._inference_stream.synchronize()
-            return _DirectInferenceFuture(self, raw, pre_processing_meta, None, kwargs)
         produce_event = getattr(raw[0], "_trt_produce_event", None)
+        if graph_state is None:
+            # Split batched graph execution concatenates cloned chunk outputs.
+            # Those tensors are not graph-owned, but they still carry a produce
+            # event so postprocess can wait without blocking the host.
+            if produce_event is None:
+                self._inference_stream.synchronize()
+            return _DirectInferenceFuture(
+                self, raw, pre_processing_meta, produce_event, kwargs
+            )
         if kwargs.get("reuse_trt_graph_outputs", False):
             # The stream pipeline schedules postprocess before launching the
             # next graph replay. That ordering lets postprocess read TensorRT's

--- a/inference_models/inference_models/models/rfdetr/triton_preprocess_runtime.py
+++ b/inference_models/inference_models/models/rfdetr/triton_preprocess_runtime.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -220,6 +220,7 @@ class FastPreprocessRuntime:
     def __init__(self, device: torch.device) -> None:
         self._device = device
         self._state: Optional[FastPreprocessState] = None
+        self._states: Dict[Tuple[int, int, int, int], FastPreprocessState] = {}
         self._warned_reasons: set[str] = set()
 
     def try_preprocess(
@@ -234,9 +235,8 @@ class FastPreprocessRuntime:
         """Enqueue Triton preprocessing when the request is supported.
 
         Args:
-            images: Single uint8 HWC numpy image, or a single-item list
-                containing one. Batch sizes greater than one use the reference
-                preprocessing path.
+            images: Single uint8 HWC numpy image, or a homogeneous list of
+                uint8 HWC numpy images.
             input_color_format: Caller-provided image color order. ``None`` is
                 treated as BGR, matching the model adapter default.
             image_size: Per-call size override. Overrides are rejected because
@@ -262,12 +262,13 @@ class FastPreprocessRuntime:
             image_size=image_size,
             image_pre_processing=image_pre_processing,
             network_input=network_input,
+            stream=stream,
         )
         if unsupported_reason is not None:
             self._warn_unsupported(unsupported_reason)
             return None
 
-        candidate = images[0] if isinstance(images, list) else images
+        candidates = images if isinstance(images, list) else [images]
         caller_mode = (
             ColorMode(input_color_format)
             if input_color_format is not None
@@ -280,15 +281,73 @@ class FastPreprocessRuntime:
         stds_t = (float(stds[0]), float(stds[1]), float(stds[2]))
         target_h = network_input.training_input_size.height
         target_w = network_input.training_input_size.width
-        orig_h, orig_w = int(candidate.shape[0]), int(candidate.shape[1])
 
-        state = self._state
-        if state is None or state.is_stale(
-            src_h=orig_h,
-            src_w=orig_w,
-            target_h=target_h,
-            target_w=target_w,
-        ):
+        metadata = []
+        used_pinned_hosts = []
+        with torch.cuda.stream(stream):
+            if len(candidates) == 1:
+                out_tensor, image_metadata, pinned_host = self._enqueue_image(
+                    candidate=candidates[0],
+                    stream=stream,
+                    target_h=target_h,
+                    target_w=target_w,
+                    means=means_t,
+                    stds=stds_t,
+                    swap_rb=swap_rb,
+                )
+                result_tensor = out_tensor
+                metadata.append(image_metadata)
+                used_pinned_hosts.append(pinned_host)
+            else:
+                result_tensor = torch.empty(
+                    (len(candidates), 3, target_h, target_w),
+                    dtype=torch.float32,
+                    device=self._device,
+                )
+                for image_index, candidate in enumerate(candidates):
+                    out_tensor, image_metadata, pinned_host = self._enqueue_image(
+                        candidate=candidate,
+                        stream=stream,
+                        target_h=target_h,
+                        target_w=target_w,
+                        means=means_t,
+                        stds=stds_t,
+                        swap_rb=swap_rb,
+                    )
+                    result_tensor[image_index].copy_(
+                        out_tensor[0],
+                        non_blocking=True,
+                    )
+                    metadata.append(image_metadata)
+                    used_pinned_hosts.append(pinned_host)
+            ready_event = torch.cuda.Event()
+            ready_event.record(stream)
+            result_tensor._trt_ready_event = ready_event  # type: ignore[attr-defined]
+            for pinned_host in used_pinned_hosts:
+                pinned_host._preproc_ready_event = ready_event  # type: ignore[attr-defined]
+            result_tensor.record_stream(stream)
+
+        result_tensor._pre_processing_meta = metadata  # type: ignore[attr-defined]
+        return FastPreprocessResult(
+            tensor=result_tensor,
+            metadata=metadata,
+            ready_event=ready_event,
+        )
+
+    def _enqueue_image(
+        self,
+        candidate: np.ndarray,
+        stream: torch.cuda.Stream,
+        target_h: int,
+        target_w: int,
+        means: Tuple[float, float, float],
+        stds: Tuple[float, float, float],
+        swap_rb: bool,
+    ) -> Tuple[torch.Tensor, PreProcessingMetadata, torch.Tensor]:
+        orig_h, orig_w = int(candidate.shape[0]), int(candidate.shape[1])
+        state_key = (orig_h, orig_w, target_h, target_w)
+        state = self._states.get(state_key)
+        if state is None:
             state = FastPreprocessState.build(
                 src_h=orig_h,
                 src_w=orig_w,
@@ -296,7 +355,8 @@ class FastPreprocessRuntime:
                 target_w=target_w,
                 device=self._device,
             )
-            self._state = state
+            self._states[state_key] = state
+        self._state = state
 
         pinned_host, src_gpu, out_buffer, tmp_buffer = state.next_buffers()
         preproc_ready_event = getattr(pinned_host, "_preproc_ready_event", None)
@@ -304,57 +364,44 @@ class FastPreprocessRuntime:
             preproc_ready_event.synchronize()
         np.copyto(pinned_host.numpy(), candidate, casting="no")
 
-        with torch.cuda.stream(stream):
-            trt_consumed_event = getattr(out_buffer, "_trt_consumed_event", None)
-            if trt_consumed_event is not None:
-                stream.wait_event(trt_consumed_event)
-            src_gpu.copy_(pinned_host, non_blocking=True)
-            triton_preprocess_rfdetr_stretch_two_pass_preallocated(
-                src=src_gpu,
-                out=out_buffer,
-                tmp=tmp_buffer,
-                tables=state.tables,
-                target_h=target_h,
-                target_w=target_w,
-                means=means_t,
-                stds=stds_t,
-                swap_rb=swap_rb,
-                launch_config=state.launch_config,
-            )
-            ready_event = torch.cuda.Event()
-            ready_event.record(stream)
-            out_buffer._trt_ready_event = ready_event  # type: ignore[attr-defined]
-            pinned_host._preproc_ready_event = ready_event  # type: ignore[attr-defined]
-            out_buffer.record_stream(stream)
-
-        metadata = [
-            PreProcessingMetadata(
-                pad_left=0,
-                pad_top=0,
-                pad_right=0,
-                pad_bottom=0,
-                original_size=ImageDimensions(width=orig_w, height=orig_h),
-                size_after_pre_processing=ImageDimensions(
-                    width=orig_w,
-                    height=orig_h,
-                ),
-                inference_size=ImageDimensions(width=target_w, height=target_h),
-                scale_width=target_w / orig_w,
-                scale_height=target_h / orig_h,
-                static_crop_offset=StaticCropOffset(
-                    offset_x=0,
-                    offset_y=0,
-                    crop_width=orig_w,
-                    crop_height=orig_h,
-                ),
-            )
-        ]
-        out_buffer._pre_processing_meta = metadata  # type: ignore[attr-defined]
-        return FastPreprocessResult(
-            tensor=out_buffer,
-            metadata=metadata,
-            ready_event=ready_event,
+        trt_consumed_event = getattr(out_buffer, "_trt_consumed_event", None)
+        if trt_consumed_event is not None:
+            stream.wait_event(trt_consumed_event)
+        src_gpu.copy_(pinned_host, non_blocking=True)
+        triton_preprocess_rfdetr_stretch_two_pass_preallocated(
+            src=src_gpu,
+            out=out_buffer,
+            tmp=tmp_buffer,
+            tables=state.tables,
+            target_h=target_h,
+            target_w=target_w,
+            means=means,
+            stds=stds,
+            swap_rb=swap_rb,
+            launch_config=state.launch_config,
         )
+        out_buffer.record_stream(stream)
+        metadata = PreProcessingMetadata(
+            pad_left=0,
+            pad_top=0,
+            pad_right=0,
+            pad_bottom=0,
+            original_size=ImageDimensions(width=orig_w, height=orig_h),
+            size_after_pre_processing=ImageDimensions(
+                width=orig_w,
+                height=orig_h,
+            ),
+            inference_size=ImageDimensions(width=target_w, height=target_h),
+            scale_width=target_w / orig_w,
+            scale_height=target_h / orig_h,
+            static_crop_offset=StaticCropOffset(
+                offset_x=0,
+                offset_y=0,
+                crop_width=orig_w,
+                crop_height=orig_h,
+            ),
+        )
+        return out_buffer, metadata, pinned_host
 
     def _unsupported_reason(
         self,
@@ -362,6 +409,7 @@ class FastPreprocessRuntime:
         image_size: Optional[Tuple[int, int]],
         image_pre_processing: ImagePreProcessing,
         network_input: NetworkInputDefinition,
+        stream: Optional[torch.cuda.Stream],
     ) -> Optional[str]:
         """Explain why the request must use the reference preprocessing path."""
         if not _TRITON_AVAILABLE:
@@ -406,20 +454,20 @@ class FastPreprocessRuntime:
         ):
             return f"resize mode {network_input.resize_mode!r} is unsupported"
 
-        if isinstance(images, list):
-            if len(images) != 1:
-                return "only batch size 1 is supported"
-            candidate = images[0]
-        else:
-            candidate = images
-        if not isinstance(candidate, np.ndarray):
-            return "only numpy ndarray inputs are supported"
-        if (
-            candidate.dtype != np.uint8
-            or candidate.ndim != 3
-            or candidate.shape[2] != 3
-        ):
-            return "input must be uint8 HWC with 3 channels"
+        candidates = images if isinstance(images, list) else [images]
+        if not candidates:
+            return "at least one image is required"
+        for candidate in candidates:
+            if not isinstance(candidate, np.ndarray):
+                return "only numpy ndarray inputs are supported"
+            if (
+                candidate.dtype != np.uint8
+                or candidate.ndim != 3
+                or candidate.shape[2] != 3
+            ):
+                return "input must be uint8 HWC with 3 channels"
+        if stream is None:
+            return "CUDA stream is required"
         return None
 
     def _warn_unsupported(self, reason: str) -> None:

--- a/inference_models/tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py
@@ -93,41 +93,51 @@ def _reference_preprocess(image_rgb: np.ndarray, target_h: int, target_w: int):
     return tensor.unsqueeze(0)
 
 
-def test_trt_fast_preprocess_warns_once_for_unsupported_batch(
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not triton_preprocess.TRITON_AVAILABLE,
+    reason="CUDA and Triton are required",
+)
+def test_trt_fast_preprocess_matches_reference_for_batch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", True)
     monkeypatch.setattr(triton_preprocess_runtime, "_TRITON_AVAILABLE", True)
+    target_h, target_w = 64, 64
     runtime = FastPreprocessRuntime(device=torch.device("cuda"))
-    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    stream = torch.cuda.Stream(device=torch.device("cuda"))
+    rng = np.random.default_rng(seed=73)
+    images_rgb = [
+        rng.integers(0, 256, size=(96, 80, 3), dtype=np.uint8),
+        rng.integers(0, 256, size=(80, 96, 3), dtype=np.uint8),
+    ]
+    images_bgr = [image[:, :, ::-1].copy() for image in images_rgb]
 
-    with pytest.warns(RuntimeWarning, match="only batch size 1 is supported"):
-        assert (
-            runtime.try_preprocess(
-                images=[image, image],
-                input_color_format="bgr",
-                image_size=None,
-                image_pre_processing=ImagePreProcessing(),
-                network_input=_network_input(),
-                stream=None,
-            )
-            is None
-        )
+    result = runtime.try_preprocess(
+        images=images_bgr,
+        input_color_format="bgr",
+        image_size=None,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=_network_input(target_h=target_h, target_w=target_w),
+        stream=stream,
+    )
+    assert result is not None
+    result.ready_event.synchronize()
 
-    with warnings.catch_warnings(record=True) as recorded:
-        warnings.simplefilter("always")
-        assert (
-            runtime.try_preprocess(
-                images=[image, image],
-                input_color_format="bgr",
-                image_size=None,
-                image_pre_processing=ImagePreProcessing(),
-                network_input=_network_input(),
-                stream=None,
+    expected = torch.cat(
+        [
+            _reference_preprocess(
+                image_rgb,
+                target_h=target_h,
+                target_w=target_w,
             )
-            is None
-        )
-    assert recorded == []
+            for image_rgb in images_rgb
+        ],
+        dim=0,
+    )
+    torch.testing.assert_close(result.tensor.cpu(), expected, atol=1e-6, rtol=0)
+    assert result.tensor.shape[0] == 2
+    assert len(result.metadata) == 2
+    assert result.tensor._pre_processing_meta == result.metadata  # type: ignore[attr-defined]
 
 
 def test_trt_fast_preprocess_flag_disabled_returns_none_without_warning(

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -22,6 +22,7 @@ from inference_models import (
     InstanceDetections,
     MultiLabelClassificationPrediction,
 )
+from inference_models.models.base.async_handoff import get_async_response_future
 
 
 class _ImmediateExecutor:
@@ -77,6 +78,27 @@ class _FakePipelineModel:
         return ["sync-detections"]
 
 
+class _FakeSyncModel:
+    supported_mask_formats = {"rle"}
+
+    def __init__(self) -> None:
+        self.forward_calls = []
+        self.forward_async_calls = []
+        self.post_process_calls = []
+
+    def forward(self, img_in, **kwargs):
+        self.forward_calls.append((img_in, kwargs))
+        return "sync-raw"
+
+    def forward_async(self, img_in, meta, **kwargs):
+        self.forward_async_calls.append((img_in, meta, kwargs))
+        raise AssertionError("forward_async should not be used")
+
+    def post_process(self, predictions, meta, **kwargs):
+        self.post_process_calls.append((predictions, meta, kwargs))
+        return ["sync-detections"]
+
+
 def _make_meta(tag: str):
     return [
         SimpleNamespace(
@@ -86,9 +108,8 @@ def _make_meta(tag: str):
     ]
 
 
-def _make_pipeline_adapter(
-    futures: list[_FakePipelineFuture],
-    ops: list[str],
+def _make_adapter(
+    model,
     pipeline_depth: int = 2,
 ) -> InferenceModelsInstanceSegmentationAdapter:
     adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
@@ -98,7 +119,7 @@ def _make_pipeline_adapter(
     adapter._pending_futures = deque()
     adapter._response_futures = deque()
     adapter._response_executor = None
-    adapter._model = _FakePipelineModel(futures=futures, ops=ops)
+    adapter._model = model
     adapter.class_names = []
     adapter.map_inference_kwargs = lambda kwargs: dict(kwargs)
     adapter._get_response_executor = lambda: _ImmediateExecutor()
@@ -109,6 +130,17 @@ def _make_pipeline_adapter(
     )
 
     return adapter
+
+
+def _make_pipeline_adapter(
+    futures: list[_FakePipelineFuture],
+    ops: list[str],
+    pipeline_depth: int = 2,
+) -> InferenceModelsInstanceSegmentationAdapter:
+    return _make_adapter(
+        model=_FakePipelineModel(futures=futures, ops=ops),
+        pipeline_depth=pipeline_depth,
+    )
 
 
 def test_pipeline_depth_falls_back_to_one_for_unsupported_models(monkeypatch) -> None:
@@ -135,7 +167,7 @@ def test_pipeline_depth_honors_requested_depth_for_supported_models(
     assert adapter._resolve_pipeline_depth() == 3
 
 
-def test_pipeline_uses_sync_forward_for_batched_requests() -> None:
+def test_pipeline_uses_async_forward_for_batched_requests() -> None:
     ops: list[str] = []
     future = _FakePipelineFuture(name="f1", ops=ops)
     adapter = _make_pipeline_adapter(
@@ -147,17 +179,20 @@ def test_pipeline_uses_sync_forward_for_batched_requests() -> None:
 
     result = adapter.predict(img_in, response_mask_format="dense")
 
-    assert result == "sync-raw"
-    assert ops == []
-    assert len(adapter._model.forward_calls) == 1
+    assert result is future
+    assert ops == ["forward:f1", "submit:f1"]
 
 
 def test_pipeline_postprocess_uses_sync_path_for_non_future_predictions() -> None:
-    ops: list[str] = []
-    adapter = _make_pipeline_adapter(
-        futures=[],
-        ops=ops,
-        pipeline_depth=2,
+    model = _FakeSyncModel()
+    adapter = _make_adapter(model=model, pipeline_depth=2)
+    adapter._build_responses_from_detections = (
+        lambda detections, preprocess_return_metadata, **_kwargs: [
+            {
+                "tag": preprocess_return_metadata[0].tag,
+                "detections": detections,
+            }
+        ]
     )
 
     responses = adapter.postprocess(
@@ -166,9 +201,39 @@ def test_pipeline_postprocess_uses_sync_path_for_non_future_predictions() -> Non
         response_mask_format="dense",
     )
 
-    assert responses == ["meta-1"]
-    assert len(adapter._model.post_process_calls) == 1
-    assert adapter._model.post_process_calls[0][0] == "sync-raw"
+    assert responses == [{"tag": "meta-1", "detections": ["sync-detections"]}]
+    assert len(model.post_process_calls) == 1
+    assert model.post_process_calls[0][0] == "sync-raw"
+
+
+def test_pipeline_batched_request_submits_response_without_waiting_for_next_frame() -> (
+    None
+):
+    ops: list[str] = []
+    future = _FakePipelineFuture(name="f1", ops=ops)
+    adapter = _make_pipeline_adapter(
+        futures=[future],
+        ops=ops,
+        pipeline_depth=2,
+    )
+    adapter._build_responses_from_detections = (
+        lambda _detections, preprocess_return_metadata, **_kwargs: [
+            metadata.tag for metadata in preprocess_return_metadata
+        ]
+    )
+
+    prediction = adapter.predict("batch", response_mask_format="dense")
+    responses = adapter.postprocess(
+        prediction,
+        _make_meta("meta-1") + _make_meta("meta-2"),
+        response_mask_format="dense",
+        source="workflow-execution",
+    )
+
+    assert ops == ["forward:f1", "submit:f1", "result:f1"]
+    async_response_future = get_async_response_future(responses[0])
+    assert isinstance(async_response_future, Future)
+    assert async_response_future.result() == ["meta-1", "meta-2"]
 
 
 def test_workflow_response_fast_dataclass_path_is_disabled_at_depth_one() -> None:

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from typing import Any, List, Optional
 from unittest.mock import MagicMock
 
@@ -573,6 +574,51 @@ def test_construct_workflow_output_when_batch_outputs_present() -> None:
         "b_empty": None,
         "b_empty_nested": [[]],
     }
+
+
+def test_construct_workflow_output_resolves_futures_in_batch_outputs() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=["<workflow_input>"],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_graph.graph[TOP_LEVEL_LINEAGES_KEY] = WORKFLOW_INPUT_BATCH_LINEAGE_ID
+    execution_data_manager.get_selector_indices.return_value = [(0,), (1,)]
+    execution_data_manager.get_lineage_indices.return_value = [(0,), (1,)]
+    first_future = Future()
+    first_future.set_result("resolved-0")
+    second_future = Future()
+    second_future.set_result("resolved-1")
+    execution_data_manager.get_batch_data.return_value = [
+        first_future,
+        {"nested": second_future},
+    ]
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+    )
+
+    # then
+    assert result == [
+        {"a": "resolved-0"},
+        {"a": {"nested": "resolved-1"}},
+    ]
 
 
 def test_serialize_data_piece_for_wildcard_output_when_serializer_not_found() -> None:


### PR DESCRIPTION
Adds batch-size > 1 support for the optimized RF-DETR workflow path without falling back to the original synchronous path.\n\nSummary:\n- Preserve async TensorRT CUDA-graph split-batch outputs before graph buffers are reused.\n- Allow RF-DETR Triton preprocess to handle batched image lists, including mixed source shapes.\n- Resolve async workflow output futures and add sliced workflow parity coverage.\n\nValidation:\n- PYTHONPATH=/home/ubuntu/inference:/home/ubuntu/inference/inference_models pytest -q tests/inference/unit_tests/core/models/test_inference_models_adapters.py tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py\n- cd inference_models && PYTHONPATH=/home/ubuntu/inference/inference_models pytest -q tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py\n- PYTHONPATH=/home/ubuntu/inference:/home/ubuntu/inference/inference_models SKIP_RFDETR_SLICED_WORKFLOW_MAIN_PARITY_TEST=false pytest -q tests/workflows/integration_tests/execution/control_flow_with_side_effects/test_rfdetr_sliced_workflow_main_parity.py -s