### PR TITLE
Fix RF-DETR stream pipeline correctness

### DIFF
--- a/development/stream_interface/codeflash-optimization-compare-multistep-workflow.py
+++ b/development/stream_interface/codeflash-optimization-compare-multistep-workflow.py
@@ -1,0 +1,91 @@
+"""Benchmark RF-DETR depth-2 behavior inside a multi-step workflow.
+
+This variant reuses ``codeflash-optimization-compare.py`` for all benchmark
+plumbing, but replaces the single-block workflow with:
+
+    image -> relative static crop -> RF-DETR instance segmentation -> confidence filter
+
+The purpose is to stress the risky alignment path discussed during review:
+RF-DETR may return Future-backed predictions at depth=2, and a downstream
+workflow block must receive the resolved detections for the same cropped frame.
+"""
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_THIS_FILE = Path(__file__).resolve()
+_BASE_SCRIPT = _THIS_FILE.with_name("codeflash-optimization-compare.py")
+
+
+def _load_base_module():
+    spec = importlib.util.spec_from_file_location(
+        "codeflash_optimization_compare_base",
+        _BASE_SCRIPT,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load base benchmark script: {_BASE_SCRIPT}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_workflow(model_id: str, confidence: float) -> dict:
+    """Build a crop -> RF-DETR -> filter workflow for stream-pipeline testing."""
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/relative_statoic_crop@v1",
+                "name": "center_crop",
+                "images": "$inputs.image",
+                "x_center": 0.5,
+                "y_center": 0.5,
+                "width": 0.8,
+                "height": 0.8,
+            },
+            {
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+                "name": "segmentation",
+                "images": "$steps.center_crop.crops",
+                "model_id": model_id,
+                "confidence_mode": "custom",
+                "custom_confidence": confidence,
+                "enforce_dense_masks_in_inference_models": False,
+            },
+            {
+                "type": "roboflow_core/per_class_confidence_filter@v1",
+                "name": "confidence_filter",
+                "predictions": "$steps.segmentation.predictions",
+                "class_thresholds": {},
+                "default_threshold": 0.0,
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.confidence_filter.predictions",
+            },
+            {
+                "type": "JsonField",
+                "name": "raw_predictions",
+                "selector": "$steps.segmentation.predictions",
+            },
+        ],
+    }
+
+
+def main() -> None:
+    base_module = _load_base_module()
+    base_module._SELF = _THIS_FILE
+    base_module.build_workflow = build_workflow
+    base_module.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/codeflash-optimization-compare-percentiles.py
+++ b/development/stream_interface/codeflash-optimization-compare-percentiles.py
@@ -91,7 +91,13 @@ def _summarize_frame_intervals(intervals: list[float]) -> tuple[dict, dict]:
     return latency_percentiles_ms, fps_percentiles
 
 
-def _emit_benchmark_result(
+def _write_json(path: str, payload: dict) -> None:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2))
+
+
+def _build_benchmark_result(
     *,
     profile: str,
     frame_count: int,
@@ -99,8 +105,8 @@ def _emit_benchmark_result(
     aggregate_fps: float,
     latency_percentiles_ms: dict[str, float | None],
     fps_percentiles: dict[str, float | None],
-    result_out: str | None,
-) -> None:
+    latency_reads_ms: list[float],
+) -> dict:
     result = {
         "profile": profile,
         "frames": frame_count,
@@ -109,26 +115,40 @@ def _emit_benchmark_result(
         "fps": aggregate_fps,
         "latency_ms": latency_percentiles_ms,
         "fps_percentiles": fps_percentiles,
+        "latency_reads_ms": latency_reads_ms,
         "flags": {
             key: _benchmark.os.environ.get(key)
             for key in _benchmark._OPTIMIZATION_FLAG_KEYS
         },
     }
+
+    return result
+
+
+def _emit_benchmark_result(
+    *,
+    result: dict,
+    result_out: str | None,
+) -> None:
     print(
-        f"[benchmark] profile={profile} frames={frame_count} "
-        f"elapsed={elapsed:.2f}s aggregate_fps={aggregate_fps:.2f}",
+        f"[benchmark] profile={result['profile']} frames={result['frames']} "
+        f"elapsed={result['elapsed']:.2f}s aggregate_fps={result['aggregate_fps']:.2f}",
         flush=True,
     )
     print(
-        f"[benchmark] latency_ms {_format_percentiles(latency_percentiles_ms)}",
+        f"[benchmark] latency_ms {_format_percentiles(result['latency_ms'])}",
         flush=True,
     )
     print(
-        f"[benchmark] fps_percentiles {_format_percentiles(fps_percentiles)}",
+        f"[benchmark] fps_percentiles {_format_percentiles(result['fps_percentiles'])}",
+        flush=True,
+    )
+    print(
+        f"[benchmark] latency_reads_ms count={len(result['latency_reads_ms'])}",
         flush=True,
     )
     if result_out is not None:
-        Path(result_out).write_text(json.dumps(result, indent=2))
+        _write_json(path=result_out, payload=result)
 
 
 def sink(predictions, _video_frames) -> None:
@@ -220,24 +240,20 @@ def do_run(
     latency_percentiles_ms, fps_percentiles = _summarize_frame_intervals(
         intervals=_benchmark.FRAME_INTERVALS,
     )
-    _emit_benchmark_result(
+    latency_reads_ms = [interval * 1000.0 for interval in _benchmark.FRAME_INTERVALS]
+    result = _build_benchmark_result(
         profile=benchmark_profile,
         frame_count=_benchmark.FRAME_COUNT,
         elapsed=elapsed,
         aggregate_fps=aggregate_fps,
         latency_percentiles_ms=latency_percentiles_ms,
         fps_percentiles=fps_percentiles,
+        latency_reads_ms=latency_reads_ms,
+    )
+    _emit_benchmark_result(
+        result=result,
         result_out=result_out,
     )
-    result = {
-        "profile": benchmark_profile,
-        "frames": _benchmark.FRAME_COUNT,
-        "elapsed": elapsed,
-        "aggregate_fps": aggregate_fps,
-        "fps": aggregate_fps,
-        "latency_ms": latency_percentiles_ms,
-        "fps_percentiles": fps_percentiles,
-    }
 
     return result
 
@@ -275,6 +291,7 @@ def do_compare(
     backend: str,
     model_package_id: str | None,
     local_package: str | None,
+    result_out: str | None = None,
 ) -> None:
     resolved_video_reference = _benchmark._resolve_video_reference(video_reference)
     with _benchmark.tempfile.TemporaryDirectory(
@@ -315,11 +332,97 @@ def do_compare(
     _print_compare_result(profile="optimized", result=optimized)
     print(f"  p50_fps_speedup {p50_speedup:.2f}x", flush=True)
 
+    if result_out is not None:
+        compare_result = {
+            "mode": "compare",
+            "baseline": baseline,
+            "optimized": optimized,
+            "p50_fps_speedup": p50_speedup,
+        }
+        _write_json(path=result_out, payload=compare_result)
+        print(f"[benchmark] wrote compare result: {result_out}", flush=True)
+
+
+def main() -> None:
+    parser = _benchmark.argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("run", "compare"),
+        default="run",
+        help=(
+            "run: single benchmark in this process. "
+            "compare: baseline then optimized, each in a fresh child process."
+        ),
+    )
+    parser.add_argument("--video_reference", required=True)
+    parser.add_argument("--model_id", default=_benchmark._DEFAULT_MODEL_ID)
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument(
+        "--backend",
+        choices=("trt", "onnx", "torch"),
+        default="trt",
+        help="inference-models backend.",
+    )
+    parser.add_argument(
+        "--local_package",
+        default=None,
+        help=(
+            "Path to an on-disk model package directory (must contain "
+            "model_config.json). Skips registry fetch and cwd TRT discovery."
+        ),
+    )
+    parser.add_argument(
+        "--model_package_id",
+        default=None,
+        help=(
+            "Registry package id to download and pin (via inference-models cache). "
+            "Overrides auto-negotiation and any cwd TRT package discovery."
+        ),
+    )
+    parser.add_argument(
+        "--benchmark-profile",
+        default="run",
+        help="Label for a single run (compare mode sets baseline/optimized in children).",
+    )
+    parser.add_argument(
+        "--result-out",
+        default=None,
+        help="Optional JSON path for the benchmark result.",
+    )
+    args = parser.parse_args()
+
+    if args.local_package is not None and args.model_package_id is not None:
+        parser.error("--local_package and --model_package_id are mutually exclusive")
+
+    if args.mode == "compare":
+        do_compare(
+            video_reference=args.video_reference,
+            model_id=args.model_id,
+            confidence=args.confidence,
+            backend=args.backend,
+            model_package_id=args.model_package_id,
+            local_package=args.local_package,
+            result_out=args.result_out,
+        )
+        return
+
+    do_run(
+        video_reference=args.video_reference,
+        model_id=args.model_id,
+        confidence=args.confidence,
+        backend=args.backend,
+        model_package_id=args.model_package_id,
+        local_package=args.local_package,
+        benchmark_profile=args.benchmark_profile,
+        result_out=args.result_out,
+    )
+
 
 _benchmark.sink = sink
 _benchmark.do_run = do_run
 _benchmark.do_compare = do_compare
+_benchmark.main = main
 
 
 if __name__ == "__main__":
-    _benchmark.main()
+    main()

--- a/development/stream_interface/codeflash-optimization-compare-percentiles.py
+++ b/development/stream_interface/codeflash-optimization-compare-percentiles.py
@@ -1,0 +1,325 @@
+"""Benchmark RF-DETR stream optimization with frame percentile reporting.
+
+This script intentionally leaves ``codeflash-optimization-compare.py`` intact.
+It imports that baseline benchmark and patches only the timing/reporting pieces
+needed to include p50/p95/p99 latency and FPS percentiles.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from time import perf_counter
+
+_BASE_SCRIPT = Path(__file__).with_name("codeflash-optimization-compare.py")
+
+
+def _load_base_benchmark():
+    spec = importlib.util.spec_from_file_location(
+        "codeflash_optimization_compare_base",
+        _BASE_SCRIPT,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load base benchmark script: {_BASE_SCRIPT}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    return module
+
+
+_benchmark = _load_base_benchmark()
+_benchmark._SELF = Path(__file__).resolve()
+_benchmark.LAST_PREDICTION_TIME = None
+_benchmark.FRAME_INTERVALS = []
+
+
+def _format_optional_float(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+
+    return f"{value:.2f}"
+
+
+def _format_percentiles(percentiles: dict[str, float | None]) -> str:
+    rendered_percentiles = (
+        f"p50={_format_optional_float(percentiles['p_50'])} "
+        f"p95={_format_optional_float(percentiles['p_95'])} "
+        f"p99={_format_optional_float(percentiles['p_99'])}"
+    )
+
+    return rendered_percentiles
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+
+    ordered_values = sorted(values)
+    if len(ordered_values) == 1:
+        return ordered_values[0]
+
+    position = (len(ordered_values) - 1) * percentile
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, len(ordered_values) - 1)
+    fraction = position - lower_index
+    interpolated_value = (
+        ordered_values[lower_index] * (1.0 - fraction)
+        + ordered_values[upper_index] * fraction
+    )
+
+    return interpolated_value
+
+
+def _percentiles(values: list[float]) -> dict[str, float | None]:
+    percentiles = {
+        "p_50": _percentile(values, 0.50),
+        "p_95": _percentile(values, 0.95),
+        "p_99": _percentile(values, 0.99),
+    }
+
+    return percentiles
+
+
+def _summarize_frame_intervals(intervals: list[float]) -> tuple[dict, dict]:
+    latency_percentiles_ms = _percentiles([interval * 1000.0 for interval in intervals])
+    fps_percentiles = _percentiles(
+        [1.0 / interval for interval in intervals if interval > 0]
+    )
+
+    return latency_percentiles_ms, fps_percentiles
+
+
+def _emit_benchmark_result(
+    *,
+    profile: str,
+    frame_count: int,
+    elapsed: float,
+    aggregate_fps: float,
+    latency_percentiles_ms: dict[str, float | None],
+    fps_percentiles: dict[str, float | None],
+    result_out: str | None,
+) -> None:
+    result = {
+        "profile": profile,
+        "frames": frame_count,
+        "elapsed": elapsed,
+        "aggregate_fps": aggregate_fps,
+        "fps": aggregate_fps,
+        "latency_ms": latency_percentiles_ms,
+        "fps_percentiles": fps_percentiles,
+        "flags": {
+            key: _benchmark.os.environ.get(key)
+            for key in _benchmark._OPTIMIZATION_FLAG_KEYS
+        },
+    }
+    print(
+        f"[benchmark] profile={profile} frames={frame_count} "
+        f"elapsed={elapsed:.2f}s aggregate_fps={aggregate_fps:.2f}",
+        flush=True,
+    )
+    print(
+        f"[benchmark] latency_ms {_format_percentiles(latency_percentiles_ms)}",
+        flush=True,
+    )
+    print(
+        f"[benchmark] fps_percentiles {_format_percentiles(fps_percentiles)}",
+        flush=True,
+    )
+    if result_out is not None:
+        Path(result_out).write_text(json.dumps(result, indent=2))
+
+
+def sink(predictions, _video_frames) -> None:
+    del _video_frames
+    if not isinstance(predictions, list):
+        predictions = [predictions]
+
+    current_time = perf_counter()
+    frame_count = sum(p is not None for p in predictions)
+    if frame_count == 0:
+        return None
+
+    if _benchmark.START_TIME is None:
+        _benchmark.START_TIME = current_time
+
+    previous_time = (
+        _benchmark.LAST_PREDICTION_TIME
+        if _benchmark.LAST_PREDICTION_TIME is not None
+        else _benchmark.START_TIME
+    )
+    interval = (current_time - previous_time) / frame_count
+    _benchmark.FRAME_INTERVALS.extend([interval] * frame_count)
+    _benchmark.LAST_PREDICTION_TIME = current_time
+    _benchmark.FRAME_COUNT += frame_count
+
+    if _benchmark.FRAME_COUNT % _benchmark.PROGRESS_EVERY == 0:
+        fps = _benchmark.FRAME_COUNT / (perf_counter() - _benchmark.START_TIME)
+        print(f"[progress] frames={_benchmark.FRAME_COUNT} fps={fps:.2f}", flush=True)
+
+
+def do_run(
+    *,
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+    benchmark_profile: str,
+    result_out: str | None,
+) -> dict:
+    _benchmark.FRAME_COUNT = 0
+    _benchmark.FRAME_INTERVALS = []
+    _benchmark.LAST_PREDICTION_TIME = None
+    _benchmark.START_TIME = None
+
+    print(f"[benchmark] profile={benchmark_profile}", flush=True)
+    print(f"[benchmark] flags: {_benchmark._format_optimization_flags()}", flush=True)
+    _benchmark._log_compute_environment()
+
+    resolved_local_package = _benchmark._resolve_local_package(
+        backend=backend,
+        model_id=model_id,
+        model_package_id=model_package_id,
+        local_package=local_package,
+    )
+    if resolved_local_package is not None:
+        _benchmark.os.environ.setdefault(
+            "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES",
+            "True",
+        )
+
+    workflow_model_id = _benchmark._resolve_model_id(
+        model_id=model_id,
+        local_package=resolved_local_package,
+    )
+    if resolved_local_package is not None:
+        _benchmark._prepare_local_workflow_model_bundle(
+            workflow_model_id=workflow_model_id,
+            local_package=resolved_local_package,
+        )
+        print(
+            f"[model] using package via workflow model id: {workflow_model_id}",
+            flush=True,
+        )
+
+    inference_pipeline = _benchmark._load_inference_pipeline(backend=backend)
+    pipeline = inference_pipeline.init_with_workflow(
+        video_reference=_benchmark._resolve_video_reference(video_reference),
+        workflow_specification=_benchmark.build_workflow(workflow_model_id, confidence),
+        on_prediction=sink,
+    )
+    _benchmark.START_TIME = perf_counter()
+    pipeline.start()
+    pipeline.join()
+
+    elapsed = perf_counter() - _benchmark.START_TIME if _benchmark.START_TIME else 0.0
+    aggregate_fps = _benchmark.FRAME_COUNT / elapsed if elapsed > 0 else 0.0
+    latency_percentiles_ms, fps_percentiles = _summarize_frame_intervals(
+        intervals=_benchmark.FRAME_INTERVALS,
+    )
+    _emit_benchmark_result(
+        profile=benchmark_profile,
+        frame_count=_benchmark.FRAME_COUNT,
+        elapsed=elapsed,
+        aggregate_fps=aggregate_fps,
+        latency_percentiles_ms=latency_percentiles_ms,
+        fps_percentiles=fps_percentiles,
+        result_out=result_out,
+    )
+    result = {
+        "profile": benchmark_profile,
+        "frames": _benchmark.FRAME_COUNT,
+        "elapsed": elapsed,
+        "aggregate_fps": aggregate_fps,
+        "fps": aggregate_fps,
+        "latency_ms": latency_percentiles_ms,
+        "fps_percentiles": fps_percentiles,
+    }
+
+    return result
+
+
+def _result_p50_fps(result: dict) -> float:
+    p50_fps = result.get("fps_percentiles", {}).get("p_50")
+    if p50_fps is None:
+        return 0.0
+
+    return p50_fps
+
+
+def _print_compare_result(profile: str, result: dict) -> None:
+    print(
+        f"  {profile:<9} frames={result['frames']} "
+        f"elapsed={result['elapsed']:.2f}s "
+        f"aggregate_fps={result['aggregate_fps']:.2f}",
+        flush=True,
+    )
+    print(
+        f"    latency_ms     {_format_percentiles(result['latency_ms'])}",
+        flush=True,
+    )
+    print(
+        f"    fps_percentile {_format_percentiles(result['fps_percentiles'])}",
+        flush=True,
+    )
+
+
+def do_compare(
+    *,
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+) -> None:
+    resolved_video_reference = _benchmark._resolve_video_reference(video_reference)
+    with _benchmark.tempfile.TemporaryDirectory(
+        prefix="rfdetr-nano-seg-benchmark-"
+    ) as tmp_dir:
+        baseline_result_path = str(Path(tmp_dir) / "baseline.json")
+        optimized_result_path = str(Path(tmp_dir) / "optimized.json")
+        baseline = _benchmark._run_child_benchmark(
+            benchmark_profile="baseline",
+            flags=_benchmark._BASELINE_FLAGS,
+            video_reference=resolved_video_reference,
+            model_id=model_id,
+            confidence=confidence,
+            backend=backend,
+            model_package_id=model_package_id,
+            local_package=local_package,
+            result_out=baseline_result_path,
+        )
+        optimized = _benchmark._run_child_benchmark(
+            benchmark_profile="optimized",
+            flags=_benchmark._OPTIMIZED_FLAGS,
+            video_reference=resolved_video_reference,
+            model_id=model_id,
+            confidence=confidence,
+            backend=backend,
+            model_package_id=model_package_id,
+            local_package=local_package,
+            result_out=optimized_result_path,
+        )
+
+    baseline_p50_fps = _result_p50_fps(baseline)
+    optimized_p50_fps = _result_p50_fps(optimized)
+    p50_speedup = (
+        optimized_p50_fps / baseline_p50_fps if baseline_p50_fps > 0 else 0.0
+    )
+    print("\n---- compare ----", flush=True)
+    _print_compare_result(profile="baseline", result=baseline)
+    _print_compare_result(profile="optimized", result=optimized)
+    print(f"  p50_fps_speedup {p50_speedup:.2f}x", flush=True)
+
+
+_benchmark.sink = sink
+_benchmark.do_run = do_run
+_benchmark.do_compare = do_compare
+
+
+if __name__ == "__main__":
+    _benchmark.main()

--- a/development/stream_interface/codeflash-optimization-compare-sliced-workflow.py
+++ b/development/stream_interface/codeflash-optimization-compare-sliced-workflow.py
@@ -1,0 +1,80 @@
+"""Benchmark RF-DETR depth-2 behavior on multiple slices per video frame.
+
+This variant reuses ``codeflash-optimization-compare.py`` for all benchmark
+plumbing, but replaces the single-block workflow with:
+
+    image -> image_slicer@v2 -> RF-DETR instance segmentation
+
+The purpose is to stress batch-order alignment when one input frame fans out
+into multiple cropped images before RF-DETR runs. At depth=2, the delayed
+RF-DETR response must remain paired with the correct source frame and slice
+batch order, including the final flushed frame.
+"""
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+_THIS_FILE = Path(__file__).resolve()
+_BASE_SCRIPT = _THIS_FILE.with_name("codeflash-optimization-compare.py")
+
+
+def _load_base_module():
+    spec = importlib.util.spec_from_file_location(
+        "codeflash_optimization_compare_base",
+        _BASE_SCRIPT,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load base benchmark script: {_BASE_SCRIPT}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_workflow(model_id: str, confidence: float) -> dict:
+    """Build an image-slicer -> RF-DETR workflow for stream-pipeline testing."""
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/image_slicer@v2",
+                "name": "image_slicer",
+                "image": "$inputs.image",
+                "slice_width": 640,
+                "slice_height": 640,
+                "overlap_ratio_width": 0.0,
+                "overlap_ratio_height": 0.0,
+            },
+            {
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+                "name": "segmentation",
+                "images": "$steps.image_slicer.slices",
+                "model_id": model_id,
+                "confidence_mode": "custom",
+                "custom_confidence": confidence,
+                "enforce_dense_masks_in_inference_models": False,
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.segmentation.predictions",
+            },
+        ],
+    }
+
+
+def main() -> None:
+    base_module = _load_base_module()
+    base_module._SELF = _THIS_FILE
+    base_module.build_workflow = build_workflow
+    base_module.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/codeflash-optimization-compare-visualization-parity.py
+++ b/development/stream_interface/codeflash-optimization-compare-visualization-parity.py
@@ -1,0 +1,708 @@
+"""Compare RF-DETR depth-2 predictions through a visualization workflow.
+
+This script reuses the package-loading and benchmark setup helpers from
+``codeflash-optimization-compare.py``, but runs a workflow shaped as:
+
+    image -> relative static crop -> RF-DETR instance segmentation
+          -> polygon visualization
+
+It stops after a small number of dispatched frame results, saves visualization
+artifacts for manual inspection, and compares baseline vs optimized prediction
+values with an absolute tolerance.
+"""
+
+import argparse
+import base64
+import dataclasses
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from threading import Lock
+from time import perf_counter
+from typing import Any
+
+import numpy as np
+
+
+_THIS_FILE = Path(__file__).resolve()
+_BASE_SCRIPT = _THIS_FILE.with_name("codeflash-optimization-compare.py")
+_DEFAULT_ARTIFACTS_DIR = (
+    _THIS_FILE.parent / "codeflash-visualization-parity-artifacts"
+)
+_IGNORE_COMPARISON_KEYS = {
+    "detection_id",
+    "inference_id",
+    "parent_id",
+    "time",
+    "visualization",
+}
+
+
+def _load_base_module():
+    spec = importlib.util.spec_from_file_location(
+        "codeflash_optimization_compare_base",
+        _BASE_SCRIPT,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load base benchmark script: {_BASE_SCRIPT}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_workflow(model_id: str, confidence: float) -> dict:
+    """Build a crop -> RF-DETR -> polygon visualization workflow."""
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/relative_statoic_crop@v1",
+                "name": "center_crop",
+                "images": "$inputs.image",
+                "x_center": 0.5,
+                "y_center": 0.5,
+                "width": 0.8,
+                "height": 0.8,
+            },
+            {
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+                "name": "segmentation",
+                "images": "$steps.center_crop.crops",
+                "model_id": model_id,
+                "confidence_mode": "custom",
+                "custom_confidence": confidence,
+                "enforce_dense_masks_in_inference_models": False,
+            },
+            {
+                "type": "roboflow_core/polygon_visualization@v1",
+                "name": "polygon_visualization",
+                "image": "$steps.center_crop.crops",
+                "predictions": "$steps.segmentation.predictions",
+                "copy_image": True,
+                "thickness": 2,
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.segmentation.predictions",
+            },
+            {
+                "type": "JsonField",
+                "name": "visualization",
+                "selector": "$steps.polygon_visualization.image",
+            },
+        ],
+    }
+
+
+def _normalise_prediction_value(value: Any) -> Any:
+    if _is_supervision_detections(value):
+        return _normalise_supervision_detections(value)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _normalise_prediction_value(dataclasses.asdict(value))
+    if isinstance(value, dict):
+        return {
+            str(key): _normalise_prediction_value(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+            if key not in _IGNORE_COMPARISON_KEYS
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalise_prediction_value(item) for item in value]
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if hasattr(value, "detach") and callable(value.detach):
+        return _normalise_prediction_value(value.detach().cpu().numpy())
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return str(value)
+        return value
+    if isinstance(value, (str, int, bool)) or value is None:
+        return value
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        return _normalise_prediction_value(
+            value.model_dump(by_alias=True, exclude_none=True)
+        )
+    return repr(value)
+
+
+def _is_supervision_detections(value: Any) -> bool:
+    return (
+        hasattr(value, "xyxy")
+        and hasattr(value, "confidence")
+        and hasattr(value, "class_id")
+        and hasattr(value, "data")
+    )
+
+
+def _normalise_supervision_detections(detections: Any) -> list[dict]:
+    xyxy = np.asarray(detections.xyxy).tolist()
+    confidence = (
+        np.asarray(detections.confidence).tolist()
+        if detections.confidence is not None
+        else [None] * len(detections)
+    )
+    class_id = (
+        np.asarray(detections.class_id).tolist()
+        if detections.class_id is not None
+        else [None] * len(detections)
+    )
+    class_names = detections.data.get("class_name", [])
+    class_names = np.asarray(class_names).tolist() if len(class_names) else []
+
+    rows = []
+    for index, box in enumerate(xyxy):
+        row = {
+            "xyxy": box,
+            "confidence": confidence[index] if index < len(confidence) else None,
+            "class_id": class_id[index] if index < len(class_id) else None,
+        }
+        if index < len(class_names):
+            row["class_name"] = class_names[index]
+        rows.append(_normalise_prediction_value(row))
+    return rows
+
+
+def _extract_visualization_image(value: Any) -> np.ndarray | None:
+    if value is None:
+        return None
+    if isinstance(value, np.ndarray):
+        return value
+    if isinstance(value, (list, tuple)):
+        for element in value:
+            image = _extract_visualization_image(element)
+            if image is not None:
+                return image
+        return None
+    if hasattr(value, "numpy_image"):
+        return _extract_visualization_image(value.numpy_image)
+    if isinstance(value, dict):
+        if "numpy_image" in value:
+            return _extract_visualization_image(value["numpy_image"])
+        if value.get("type") == "numpy_object" and "value" in value:
+            return _extract_visualization_image(value["value"])
+        for key in ("image", "value", "data"):
+            if key in value:
+                image = _extract_visualization_image(value[key])
+                if image is not None:
+                    return image
+        return None
+    if isinstance(value, str):
+        try:
+            from PIL import Image
+            from io import BytesIO
+
+            decoded = base64.b64decode(value, validate=True)
+            image = Image.open(BytesIO(decoded))
+            return np.asarray(image)
+        except Exception:
+            return None
+    return None
+
+
+def _save_visualization(
+    *,
+    value: Any,
+    artifacts_dir: Path,
+    frame_id: int,
+    profile: str,
+) -> tuple[str | None, bool]:
+    image = _extract_visualization_image(value)
+    if image is None:
+        return None, True
+
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    output_path = artifacts_dir / f"{profile}_frame_{frame_id:06d}.png"
+    try:
+        import cv2
+
+        cv2.imwrite(str(output_path), image)
+    except Exception:
+        from PIL import Image
+
+        Image.fromarray(image).save(output_path)
+    return str(output_path), False
+
+
+def _make_sink(
+    *,
+    profile: str,
+    max_frames: int,
+    artifacts_dir: Path,
+    records: list[dict],
+    pipeline_holder: dict[str, Any],
+):
+    records_lock = Lock()
+
+    def sink(prediction, video_frame) -> None:
+        with records_lock:
+            if len(records) >= max_frames:
+                pipeline = pipeline_holder.get("pipeline")
+                if pipeline is not None:
+                    pipeline.terminate()
+                return
+
+            frame_id = getattr(video_frame, "frame_id", len(records) + 1)
+            prediction_payload = prediction if isinstance(prediction, dict) else {}
+            visual_value = prediction_payload.get("visualization")
+            visualization_path, missing_visualization = _save_visualization(
+                value=visual_value,
+                artifacts_dir=artifacts_dir,
+                frame_id=int(frame_id),
+                profile=profile,
+            )
+            records.append(
+                {
+                    "frame_id": int(frame_id),
+                    "predictions": _normalise_prediction_value(
+                        prediction_payload.get("predictions", prediction)
+                    ),
+                    "visualization_path": visualization_path,
+                    "missing_visualization": missing_visualization,
+                    "output_keys": (
+                        sorted(prediction_payload.keys())
+                        if isinstance(prediction_payload, dict)
+                        else []
+                    ),
+                }
+            )
+            should_terminate = len(records) >= max_frames
+
+        if should_terminate:
+            pipeline = pipeline_holder.get("pipeline")
+            if pipeline is not None:
+                pipeline.terminate()
+
+    return sink
+
+
+def _write_result(
+    *,
+    result_out: str | None,
+    result: dict,
+) -> None:
+    if result_out is None:
+        return
+    Path(result_out).write_text(json.dumps(result, indent=2))
+
+
+def do_run(
+    *,
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+    benchmark_profile: str,
+    result_out: str | None,
+    max_frames: int,
+    artifacts_dir: Path,
+) -> dict:
+    base = _load_base_module()
+    records: list[dict] = []
+    pipeline_holder: dict[str, Any] = {}
+    start_time = None
+
+    print(f"[benchmark] profile={benchmark_profile}", flush=True)
+    print(f"[benchmark] flags: {base._format_optimization_flags()}", flush=True)
+    base._log_compute_environment()
+
+    resolved_local_package = base._resolve_local_package(
+        backend=backend,
+        model_id=model_id,
+        model_package_id=model_package_id,
+        local_package=local_package,
+    )
+    if resolved_local_package is not None:
+        os.environ.setdefault(
+            "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES",
+            "True",
+        )
+
+    workflow_model_id = base._resolve_model_id(
+        model_id=model_id,
+        local_package=resolved_local_package,
+    )
+    if resolved_local_package is not None:
+        base._prepare_local_workflow_model_bundle(
+            workflow_model_id=workflow_model_id,
+            local_package=resolved_local_package,
+        )
+        print(
+            f"[model] using package via workflow model id: {workflow_model_id}",
+            flush=True,
+        )
+
+    inference_pipeline = base._load_inference_pipeline(backend=backend)
+    pipeline = inference_pipeline.init_with_workflow(
+        video_reference=base._resolve_video_reference(video_reference),
+        workflow_specification=build_workflow(workflow_model_id, confidence),
+        on_prediction=_make_sink(
+            profile=benchmark_profile,
+            max_frames=max_frames,
+            artifacts_dir=artifacts_dir,
+            records=records,
+            pipeline_holder=pipeline_holder,
+        ),
+    )
+    pipeline_holder["pipeline"] = pipeline
+    start_time = perf_counter()
+    pipeline.start()
+    pipeline.join()
+
+    records = records[:max_frames]
+    elapsed = perf_counter() - start_time if start_time is not None else 0.0
+    fps = len(records) / elapsed if elapsed > 0 else 0.0
+    result = {
+        "profile": benchmark_profile,
+        "frames": len(records),
+        "elapsed": elapsed,
+        "fps": fps,
+        "flags": {key: os.environ.get(key) for key in base._OPTIMIZATION_FLAG_KEYS},
+        "records": records,
+    }
+    print(
+        f"[benchmark] profile={benchmark_profile} frames={len(records)} "
+        f"elapsed={elapsed:.2f}s fps={fps:.2f}",
+        flush=True,
+    )
+    _write_result(result_out=result_out, result=result)
+    return result
+
+
+def _compare_values(
+    *,
+    baseline: Any,
+    optimized: Any,
+    path: str,
+    abs_tol: float,
+    errors: list[str],
+) -> None:
+    if isinstance(baseline, (int, float)) and isinstance(optimized, (int, float)):
+        if abs(float(baseline) - float(optimized)) > abs_tol:
+            errors.append(f"{path}: {baseline!r} != {optimized!r}")
+        return
+    if isinstance(baseline, list) and isinstance(optimized, list):
+        if len(baseline) != len(optimized):
+            errors.append(f"{path}: list length {len(baseline)} != {len(optimized)}")
+            return
+        for index, (left, right) in enumerate(zip(baseline, optimized)):
+            _compare_values(
+                baseline=left,
+                optimized=right,
+                path=f"{path}[{index}]",
+                abs_tol=abs_tol,
+                errors=errors,
+            )
+        return
+    if isinstance(baseline, dict) and isinstance(optimized, dict):
+        if set(baseline) != set(optimized):
+            errors.append(
+                f"{path}: dict keys {sorted(baseline)} != {sorted(optimized)}"
+            )
+            return
+        for key in sorted(baseline):
+            _compare_values(
+                baseline=baseline[key],
+                optimized=optimized[key],
+                path=f"{path}.{key}",
+                abs_tol=abs_tol,
+                errors=errors,
+            )
+        return
+    if baseline != optimized:
+        errors.append(f"{path}: {baseline!r} != {optimized!r}")
+
+
+def _compare_results(
+    *,
+    baseline: dict,
+    optimized: dict,
+    abs_tol: float,
+) -> list[str]:
+    errors: list[str] = []
+    baseline_records = baseline.get("records", [])
+    optimized_records = optimized.get("records", [])
+    if len(baseline_records) != len(optimized_records):
+        errors.append(
+            f"record count {len(baseline_records)} != {len(optimized_records)}"
+        )
+        return errors
+    for index, (baseline_record, optimized_record) in enumerate(
+        zip(baseline_records, optimized_records)
+    ):
+        record_path = f"records[{index}]"
+        if baseline_record.get("frame_id") != optimized_record.get("frame_id"):
+            errors.append(
+                f"{record_path}.frame_id: {baseline_record.get('frame_id')} != "
+                f"{optimized_record.get('frame_id')}"
+            )
+        if optimized_record.get("missing_visualization"):
+            errors.append(
+                f"{record_path}: optimized frame is missing visualization output"
+            )
+        if baseline_record.get("missing_visualization"):
+            errors.append(
+                f"{record_path}: baseline frame is missing visualization output"
+            )
+        _compare_values(
+            baseline=baseline_record.get("predictions"),
+            optimized=optimized_record.get("predictions"),
+            path=f"{record_path}.predictions",
+            abs_tol=abs_tol,
+            errors=errors,
+        )
+    return errors
+
+
+def _build_child_command(
+    *,
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+    benchmark_profile: str,
+    result_out: str,
+    max_frames: int,
+    artifacts_dir: Path,
+    abs_tol: float,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(_THIS_FILE),
+        "--mode",
+        "run",
+        "--video_reference",
+        video_reference,
+        "--model_id",
+        model_id,
+        "--confidence",
+        str(confidence),
+        "--backend",
+        backend,
+        "--benchmark-profile",
+        benchmark_profile,
+        "--result-out",
+        result_out,
+        "--max-frames",
+        str(max_frames),
+        "--artifacts-dir",
+        str(artifacts_dir),
+        "--abs-tol",
+        str(abs_tol),
+    ]
+    if model_package_id is not None:
+        command.extend(["--model_package_id", model_package_id])
+    if local_package is not None:
+        command.extend(["--local_package", local_package])
+    return command
+
+
+def _run_child_benchmark(
+    *,
+    benchmark_profile: str,
+    flags: dict[str, str],
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+    result_out: str,
+    max_frames: int,
+    artifacts_dir: Path,
+    abs_tol: float,
+) -> dict:
+    base = _load_base_module()
+    env = os.environ.copy()
+    env.update(flags)
+    env["PYTHONPATH"] = base._child_pythonpath(env.get("PYTHONPATH"))
+    command = _build_child_command(
+        video_reference=video_reference,
+        model_id=model_id,
+        confidence=confidence,
+        backend=backend,
+        model_package_id=model_package_id,
+        local_package=local_package,
+        benchmark_profile=benchmark_profile,
+        result_out=result_out,
+        max_frames=max_frames,
+        artifacts_dir=artifacts_dir,
+        abs_tol=abs_tol,
+    )
+    print(
+        "\n---- child ----\n"
+        f"  profile={benchmark_profile}\n"
+        f"  flags={flags}\n"
+        f"  result_out={result_out}\n"
+        f"  artifacts_dir={artifacts_dir}",
+        flush=True,
+    )
+    subprocess.run(
+        command,
+        cwd=str(base._REPO_ROOT),
+        env=env,
+        check=True,
+    )
+    return json.loads(Path(result_out).read_text())
+
+
+def do_compare(
+    *,
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+    max_frames: int,
+    artifacts_dir: Path,
+    abs_tol: float,
+) -> None:
+    base = _load_base_module()
+    resolved_video_reference = base._resolve_video_reference(video_reference)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="rfdetr-visualization-parity-") as tmp_dir:
+        baseline_result_path = str(Path(tmp_dir) / "baseline.json")
+        optimized_result_path = str(Path(tmp_dir) / "optimized.json")
+        baseline = _run_child_benchmark(
+            benchmark_profile="baseline",
+            flags=base._BASELINE_FLAGS,
+            video_reference=resolved_video_reference,
+            model_id=model_id,
+            confidence=confidence,
+            backend=backend,
+            model_package_id=model_package_id,
+            local_package=local_package,
+            result_out=baseline_result_path,
+            max_frames=max_frames,
+            artifacts_dir=artifacts_dir / "baseline",
+            abs_tol=abs_tol,
+        )
+        optimized = _run_child_benchmark(
+            benchmark_profile="optimized",
+            flags=base._OPTIMIZED_FLAGS,
+            video_reference=resolved_video_reference,
+            model_id=model_id,
+            confidence=confidence,
+            backend=backend,
+            model_package_id=model_package_id,
+            local_package=local_package,
+            result_out=optimized_result_path,
+            max_frames=max_frames,
+            artifacts_dir=artifacts_dir / "optimized",
+            abs_tol=abs_tol,
+        )
+
+    errors = _compare_results(
+        baseline=baseline,
+        optimized=optimized,
+        abs_tol=abs_tol,
+    )
+    baseline_fps = baseline["fps"]
+    optimized_fps = optimized["fps"]
+    speedup = optimized_fps / baseline_fps if baseline_fps > 0 else 0.0
+    print("\n---- compare ----", flush=True)
+    print(
+        f"  baseline   frames={baseline['frames']} "
+        f"elapsed={baseline['elapsed']:.2f}s fps={baseline_fps:.2f}",
+        flush=True,
+    )
+    print(
+        f"  optimized  frames={optimized['frames']} "
+        f"elapsed={optimized['elapsed']:.2f}s fps={optimized_fps:.2f}",
+        flush=True,
+    )
+    print(f"  speedup    {speedup:.2f}x", flush=True)
+    print(f"  artifacts  {artifacts_dir}", flush=True)
+    if errors:
+        print("\n---- parity failures ----", flush=True)
+        for error in errors[:50]:
+            print(f"  - {error}", flush=True)
+        if len(errors) > 50:
+            print(f"  ... {len(errors) - 50} more", flush=True)
+        raise SystemExit(1)
+    print("  parity     ok", flush=True)
+
+
+def main() -> None:
+    base = _load_base_module()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("run", "compare"),
+        default="run",
+    )
+    parser.add_argument("--video_reference", required=True)
+    parser.add_argument("--model_id", default=base._DEFAULT_MODEL_ID)
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument(
+        "--backend",
+        choices=("trt", "onnx", "torch"),
+        default="trt",
+    )
+    parser.add_argument("--local_package", default=None)
+    parser.add_argument("--model_package_id", default=None)
+    parser.add_argument("--benchmark-profile", default="run")
+    parser.add_argument("--result-out", default=None)
+    parser.add_argument("--max-frames", type=int, default=4)
+    parser.add_argument("--abs-tol", type=float, default=1e-5)
+    parser.add_argument(
+        "--artifacts-dir",
+        default=str(_DEFAULT_ARTIFACTS_DIR),
+    )
+    args = parser.parse_args()
+
+    if args.local_package is not None and args.model_package_id is not None:
+        parser.error("--local_package and --model_package_id are mutually exclusive")
+    if args.max_frames < 1:
+        parser.error("--max-frames must be >= 1")
+
+    artifacts_dir = Path(args.artifacts_dir)
+    if not artifacts_dir.is_absolute():
+        artifacts_dir = base._REPO_ROOT / artifacts_dir
+
+    if args.mode == "compare":
+        do_compare(
+            video_reference=args.video_reference,
+            model_id=args.model_id,
+            confidence=args.confidence,
+            backend=args.backend,
+            model_package_id=args.model_package_id,
+            local_package=args.local_package,
+            max_frames=args.max_frames,
+            artifacts_dir=artifacts_dir,
+            abs_tol=args.abs_tol,
+        )
+        return
+
+    do_run(
+        video_reference=args.video_reference,
+        model_id=args.model_id,
+        confidence=args.confidence,
+        backend=args.backend,
+        model_package_id=args.model_package_id,
+        local_package=args.local_package,
+        benchmark_profile=args.benchmark_profile,
+        result_out=args.result_out,
+        max_frames=args.max_frames,
+        artifacts_dir=artifacts_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/codeflash-optimization-compare.md
+++ b/development/stream_interface/codeflash-optimization-compare.md
@@ -1,0 +1,222 @@
+# RF-DETR Nano Segmentation TRT Workflow Benchmark
+
+Minimal throughput benchmark for `rfdetr-seg-nano` instance segmentation via
+`InferencePipeline` and a single-workflow-block setup. The script counts frames
+and reports FPS — no visualization, no prediction export.
+
+Script: [`rfdetr_nano_seg_trt_workflow.py`](rfdetr_nano_seg_trt_workflow.py)
+
+## Single run
+
+Runs one benchmark in the current process. Respects optimization-related
+environment variables you set in the shell (see [Manual flag overrides](#manual-flag-overrides)).
+
+```bash
+PYTHONPATH=<repo>:<repo>/inference_models \
+  python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
+    --video_reference <video> \
+    --backend trt
+```
+
+With a pinned registry package:
+
+```bash
+PYTHONPATH=<repo>:<repo>/inference_models \
+  python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
+    --video_reference <video> \
+    --backend trt \
+    --model_package_id <your-package-id>
+```
+
+With a local on-disk package (no registry fetch):
+
+```bash
+PYTHONPATH=<repo>:<repo>/inference_models \
+  python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
+    --video_reference <video> \
+    --backend trt \
+    --local_package /path/to/trt-package
+```
+
+Relative paths are resolved against the repo root when present there.
+
+## Compare baseline vs optimized
+
+Use `--mode compare` to run **baseline first**, then **optimized**, each in a
+fresh child process. The parent never loads inference or touches the GPU, so the
+two runs do not interleave and are not warmed up by a parent process.
+
+```bash
+PYTHONPATH=<repo>:<repo>/inference_models \
+  python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
+    --mode compare \
+    --video_reference <video> \
+    --backend trt
+```
+
+With a pinned package:
+
+```bash
+python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
+  --mode compare \
+  --video_reference <video> \
+  --backend trt \
+  --model_package_id <your-package-id>
+```
+
+With a local package:
+
+```bash
+python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
+  --mode compare \
+  --video_reference <video> \
+  --backend trt \
+  --local_package /path/to/trt-package
+```
+
+### Profiles and flags
+
+| Profile | Flags |
+|---------|-------|
+| **baseline** | `ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND=false`, `INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false`, `INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED=false`, `RFDETR_PIPELINE_DEPTH=1` |
+| **optimized** | `ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND=true`, `INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=true`, `INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED=true`, `RFDETR_PIPELINE_DEPTH=2` |
+
+### Manual flag overrides
+
+For a single run (`--mode run`, the default), set flags yourself instead of using
+compare mode:
+
+**Baseline (optimizations off):**
+
+```bash
+ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND=false \
+  INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false \
+  INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED=false \
+  RFDETR_PIPELINE_DEPTH=1 \
+  PYTHONPATH=<repo>:<repo>/inference_models \
+  python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
+    --video_reference <video> \
+    --backend trt
+```
+
+**Optimized (optimizations on):**
+
+```bash
+ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND=true \
+  INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=true \
+  INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED=true \
+  RFDETR_PIPELINE_DEPTH=2 \
+  PYTHONPATH=<repo>:<repo>/inference_models \
+  python development/stream_interface/rfdetr_nano_seg_trt_workflow.py \
+    --video_reference <video> \
+    --backend trt
+```
+
+## Output
+
+Each child run prints its active flags, a compute-environment summary from
+`AutoModel.describe_compute_environment()`, progress every 50 frames, then a
+final line:
+
+```
+[benchmark] profile=baseline
+[benchmark] flags: ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND=false, ...
+[benchmark] compute environment:
+                         Compute environment details
+...
+[benchmark] profile=baseline frames=1200 elapsed=27.85s fps=43.09
+```
+
+In compare mode, the driver prints a summary:
+
+```
+---- compare ----
+  baseline   frames=1200 elapsed=27.85s fps=43.09
+  optimized  frames=1200 elapsed=20.12s fps=59.64
+  speedup    1.39x
+```
+
+## CLI reference
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--mode` | `run` | `run`: single benchmark. `compare`: baseline then optimized in separate processes. |
+| `--video_reference` | *(required)* | Video file path, RTSP/HTTP URL, or camera device index. |
+| `--model_id` | `rfdetr-seg-nano` | Model alias or full Roboflow model id. |
+| `--confidence` | `0.4` | Detection confidence threshold. |
+| `--backend` | `trt` | `trt`, `onnx`, or `torch` — pins the inference-models backend. |
+| `--local_package` | — | Path to an on-disk package directory (`model_config.json` required). Skips registry fetch. Mutually exclusive with `--model_package_id`. |
+| `--model_package_id` | — | Registry package id to download and pin. Overrides cwd TRT discovery and auto-negotiation. |
+| `--benchmark-profile` | `run` | Label for a single run (compare mode sets `baseline` / `optimized` in children). |
+| `--result-out` | — | Optional JSON path for the final benchmark result. |
+
+## Model package resolution
+
+Priority order:
+
+1. **`--local_package`** — use the given directory as-is (must contain `model_config.json`). No registry access.
+2. **`--model_package_id`** — download and pin that registry package (cached under `$INFERENCE_HOME/models-cache/`, default `/tmp/cache`), or reuse if already cached.
+3. **Local TRT directory in cwd** — `rfdetr-seg-nano-orin-trt-package/`, or any single valid TRT package folder (TRT backend only, when neither flag above is set).
+4. **Autoresolve** — registry download and negotiation on first inference.
+
+To list available packages on the target device:
+
+```python
+from inference_models import AutoModel
+
+AutoModel.describe_model("rfdetr-seg-nano")
+```
+
+## Setup notes
+
+- Run from the inference repo with dependencies installed (CUDA/TRT as needed for `--backend trt`).
+- Set `PYTHONPATH` to `<repo>:<repo>/inference_models`, or run from the repo root (the script also prepends those paths).
+- TRT engines are hardware-specific — download and benchmark on the target device (e.g. Jetson Orin).
+- Use a persistent `INFERENCE_HOME` if you do not want the default `/tmp/cache` cleared on reboot.
+- `ROBOFLOW_API_KEY` is only required for private models; `rfdetr-seg-nano` is public.
+
+## Troubleshooting
+
+### `CorruptedModelPackageError: Could not find model config while attempting to load model from local directory`
+
+This can happen in `--mode compare` when the **baseline** child succeeds and the **optimized**
+child fails before inference starts.
+
+**Cause:** the baseline run materializes `rfdetr-seg-nano/1` (a symlink to the downloaded TRT
+package). That leaves a `rfdetr-seg-nano/` directory in the repo root. The optimized child then
+calls `AutoModel.from_pretrained("rfdetr-seg-nano", ...)` to fetch the same
+`--model_package_id`. Because `rfdetr-seg-nano/` already exists on disk, the loader treats it as
+a local package directory, looks for `rfdetr-seg-nano/model_config.json` (which is only under
+`rfdetr-seg-nano/1/`), and fails.
+
+**Fix:** use a current version of the script (it reuses the materialized package / cache path
+instead of re-fetching through the colliding alias). As a one-off workaround:
+
+```bash
+rm -rf rfdetr-seg-nano
+```
+
+Then re-run compare mode.
+
+### `FileExistsError` when creating `rfdetr-seg-nano/1` symlink
+
+**Cause:** `AutoModel.from_pretrained` may already create `rfdetr-seg-nano/1` in the cwd
+(often as a symlink into the package cache). The script used `Path.exists()`, which returns
+`False` for a **broken** symlink even though the path is present, so `symlink_to()` raises
+`FileExistsError`.
+
+**Fix:** use a current version of the script (it uses `os.path.lexists()` / `is_symlink()` and
+replaces stale or broken links). As a one-off workaround:
+
+```bash
+rm -f rfdetr-seg-nano/1
+# or
+rm -rf rfdetr-seg-nano
+```
+
+### `Using an engine plan file across different models of devices is not supported`
+
+The pinned TRT package was built for a specific GPU (e.g. `nvidia-l4` in the registry
+metadata). Running it on a different device may work slowly or unreliably. Pick a
+`--model_package_id` that matches your hardware, or use `AutoModel.describe_model("rfdetr-seg-nano")`
+on the target machine to see compatible packages.

--- a/development/stream_interface/codeflash-optimization-compare.py
+++ b/development/stream_interface/codeflash-optimization-compare.py
@@ -1,0 +1,700 @@
+"""Minimal benchmark: RF-DETR instance segmentation through inference-models,
+run via InferencePipeline on a single video source.
+
+Workflow has exactly one block — the segmentation model. No annotators, no
+buffer strategies, no rate limiting.
+
+The `--backend` flag (trt | onnx | torch) pins the auto-loader by setting
+`DISABLED_INFERENCE_MODELS_BACKENDS` to every backend except the chosen one,
+so the benchmark numbers correspond unambiguously to a single execution path.
+
+Pass `--local_package` to benchmark against an on-disk package directory (no
+registry fetch). Pass `--model_package_id` to download a specific registry
+package (cached under `$INFERENCE_HOME/models-cache/`) instead of auto-negotiation.
+A TRT package directory in the cwd is still used when neither flag is set.
+
+Use `--mode compare` to run baseline and optimized configurations sequentially
+in separate child processes (no interleaving, no parent GPU warmup).
+
+Defaults: rfdetr-seg-nano @ confidence 0.4 on the native TRT backend.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from time import perf_counter
+
+_ALL_BACKENDS = {
+    "torch",
+    "torch-script",
+    "onnx",
+    "trt",
+    "hugging-face",
+    "ultralytics",
+    "custom",
+}
+_DEFAULT_MODEL_ID = "rfdetr-seg-nano"
+_PREFERRED_LOCAL_TRT_PACKAGE = "rfdetr-seg-nano-orin-trt-package"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFERENCE_MODELS_ROOT = _REPO_ROOT / "inference_models"
+_SELF = Path(__file__).resolve()
+_PY = sys.executable
+
+_BASELINE_FLAGS = {
+    "ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND": "false",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED": "false",
+    "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED": "false",
+    "RFDETR_PIPELINE_DEPTH": "1",
+}
+_OPTIMIZED_FLAGS = {
+    "ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND": "true",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED": "true",
+    "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED": "true",
+    "RFDETR_PIPELINE_DEPTH": "2",
+}
+_OPTIMIZATION_FLAG_KEYS = sorted(
+    {*_BASELINE_FLAGS.keys(), *_OPTIMIZED_FLAGS.keys()}
+)
+
+FRAME_COUNT = 0
+START_TIME = None
+PROGRESS_EVERY = 50
+
+
+def _is_local_trt_package(path: Path) -> bool:
+    if not path.is_dir():
+        return False
+    required_files = ("engine.plan", "model_config.json", "inference_config.json")
+    if not all((path / f).is_file() for f in required_files):
+        return False
+    try:
+        model_config = json.loads((path / "model_config.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return model_config.get("backend_type") == "trt"
+
+
+def _find_local_trt_package() -> str | None:
+    preferred = Path.cwd() / _PREFERRED_LOCAL_TRT_PACKAGE
+    if _is_local_trt_package(preferred):
+        return str(preferred.resolve())
+
+    candidates = sorted(
+        path.resolve() for path in Path.cwd().iterdir() if _is_local_trt_package(path)
+    )
+    if len(candidates) == 1:
+        return str(candidates[0])
+    return None
+
+
+def _configure_backend(backend: str) -> None:
+    os.environ.setdefault(
+        "ONNXRUNTIME_EXECUTION_PROVIDERS",
+        "[TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider]",
+    )
+    os.environ["DISABLED_INFERENCE_MODELS_BACKENDS"] = ",".join(
+        sorted(_ALL_BACKENDS - {backend})
+    )
+
+
+def _prioritize_repo_imports() -> None:
+    for path in (str(_INFERENCE_MODELS_ROOT), str(_REPO_ROOT)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+    for module_name in list(sys.modules):
+        if module_name == "inference" or module_name.startswith("inference."):
+            del sys.modules[module_name]
+        if module_name == "inference_models" or module_name.startswith(
+            "inference_models."
+        ):
+            del sys.modules[module_name]
+
+
+def _load_inference_pipeline(*, backend: str):
+    _configure_backend(backend=backend)
+    _prioritize_repo_imports()
+    spec = importlib.util.spec_from_file_location(
+        "inference",
+        _REPO_ROOT / "inference" / "__init__.py",
+        submodule_search_locations=[str(_REPO_ROOT / "inference")],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load local inference package")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["inference"] = module
+    spec.loader.exec_module(module)
+    return module.InferencePipeline
+
+
+def _is_valid_package_dir(package_dir: Path) -> bool:
+    return package_dir.is_dir() and (package_dir / "model_config.json").is_file()
+
+
+def _resolve_package_dir_candidate(candidate: Path) -> Path | None:
+    if not os.path.lexists(candidate):
+        return None
+    if candidate.is_symlink():
+        try:
+            return candidate.resolve()
+        except OSError:
+            return None
+    if candidate.is_dir():
+        return candidate.resolve()
+    return None
+
+
+def _try_reuse_materialized_package(model_id: str, package_id: str) -> str | None:
+    from inference_models.models.auto_loaders.core import (
+        generate_model_package_cache_path,
+    )
+
+    candidates = (
+        Path(model_id) / "1",
+        Path(
+            generate_model_package_cache_path(
+                model_id=model_id,
+                package_id=package_id,
+            )
+        ),
+    )
+    for candidate in candidates:
+        package_dir = _resolve_package_dir_candidate(candidate)
+        if package_dir is not None and _is_valid_package_dir(package_dir):
+            return str(package_dir)
+    return None
+
+
+def _ensure_workflow_model_symlink(model_dir: Path, target_dir: Path) -> None:
+    """Create or refresh ``model_dir`` as a symlink to ``target_dir`` when needed."""
+    resolved_target = target_dir.resolve()
+    if model_dir.is_symlink():
+        try:
+            if model_dir.resolve() == resolved_target:
+                return
+        except OSError:
+            pass
+        model_dir.unlink()
+    elif model_dir.exists():
+        if (
+            model_dir.is_dir()
+            and _is_valid_package_dir(model_dir)
+            and model_dir.resolve() == resolved_target
+        ):
+            return
+        raise RuntimeError(
+            f"Workflow model path {model_dir} already exists and is not a symlink "
+            f"to {resolved_target}"
+        )
+    model_dir.symlink_to(resolved_target, target_is_directory=True)
+
+
+def _registry_model_id_for_fetch(model_id: str) -> str:
+    model_dir = Path(model_id)
+    if model_dir.is_dir() and not (model_dir / "model_config.json").is_file():
+        from inference.models.aliases import resolve_roboflow_model_alias
+
+        return resolve_roboflow_model_alias(model_id=model_id)
+    return model_id
+
+
+def _fetch_model_package(model_id: str, package_id: str, backend: str) -> str:
+    from inference_models import AutoModel
+    from inference_models.models.auto_loaders.core import (
+        generate_model_package_cache_path,
+    )
+
+    fetch_model_id = _registry_model_id_for_fetch(model_id)
+    package_dirs: list[str] = []
+
+    def capture_package_dir(path: str) -> None:
+        package_dirs.append(path)
+
+    AutoModel.from_pretrained(
+        model_id_or_path=fetch_model_id,
+        backend=backend,
+        model_package_id=package_id,
+        verbose=True,
+        point_model_directory=capture_package_dir,
+    )
+    if package_dirs:
+        return package_dirs[0]
+
+    cache_dir = Path(
+        generate_model_package_cache_path(model_id=model_id, package_id=package_id)
+    )
+    if _is_valid_package_dir(cache_dir):
+        return str(cache_dir.resolve())
+
+    raise RuntimeError(
+        f"Model package {package_id!r} for {model_id!r} did not report a cache path."
+    )
+
+
+def _resolve_local_package_path(local_package: str) -> str:
+    package_path = Path(local_package)
+    if not package_path.is_absolute():
+        candidate = _REPO_ROOT / package_path
+        if candidate.exists():
+            package_path = candidate
+    package_path = package_path.resolve()
+    if not _is_valid_package_dir(package_path):
+        raise FileNotFoundError(
+            "Local package directory does not contain model_config.json: "
+            f"{package_path}"
+        )
+    return str(package_path)
+
+
+def _resolve_local_package(
+    *,
+    backend: str,
+    model_id: str,
+    model_package_id: str | None,
+    local_package: str | None,
+) -> str | None:
+    if local_package is not None:
+        package_dir = _resolve_local_package_path(local_package)
+        print(f"[model] using local package from {package_dir}", flush=True)
+        return package_dir
+
+    if model_package_id is not None:
+        reused_package_dir = _try_reuse_materialized_package(
+            model_id=model_id,
+            package_id=model_package_id,
+        )
+        if reused_package_dir is not None:
+            print(
+                f"[model] reusing package_id={model_package_id} from {reused_package_dir}",
+                flush=True,
+            )
+            return reused_package_dir
+
+        package_dir = _fetch_model_package(
+            model_id=model_id,
+            package_id=model_package_id,
+            backend=backend,
+        )
+        print(
+            f"[model] fetched package_id={model_package_id} from {package_dir}",
+            flush=True,
+        )
+        return package_dir
+
+    if backend == "trt":
+        return _find_local_trt_package()
+
+    return None
+
+
+def _resolve_model_id(model_id: str, local_package: str | None) -> str:
+    if local_package is not None:
+        return f"{model_id}/1"
+    return model_id
+
+
+def _prepare_local_workflow_model_bundle(
+    workflow_model_id: str,
+    local_package: str,
+) -> None:
+    model_dir = Path(workflow_model_id)
+    model_dir.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_workflow_model_symlink(model_dir=model_dir, target_dir=Path(local_package))
+
+    model_cache_dir = (
+        Path(os.environ.get("MODEL_CACHE_DIR", "/tmp/cache")) / workflow_model_id
+    )
+    model_cache_dir.mkdir(parents=True, exist_ok=True)
+    model_type_path = model_cache_dir / "model_type.json"
+    model_metadata = {
+        "project_task_type": "instance-segmentation",
+        "model_type": "rfdetr-seg-nano",
+    }
+    model_type_path.write_text(json.dumps(model_metadata, indent=4))
+
+
+def build_workflow(model_id: str, confidence: float) -> dict:
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+                "name": "segmentation",
+                "images": "$inputs.image",
+                "model_id": model_id,
+                "confidence_mode": "custom",
+                "custom_confidence": confidence,
+                "enforce_dense_masks_in_inference_models": False,
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.segmentation.predictions",
+            },
+        ],
+    }
+
+
+def _format_optimization_flags() -> str:
+    rendered_flags = [
+        f"{key}={os.environ.get(key, '<unset>')}" for key in _OPTIMIZATION_FLAG_KEYS
+    ]
+    return ", ".join(rendered_flags)
+
+
+def _log_compute_environment() -> None:
+    _prioritize_repo_imports()
+    from inference_models import AutoModel
+
+    print("[benchmark] compute environment:", flush=True)
+    AutoModel.describe_compute_environment()
+    try:
+        import triton
+
+        print(f"triton {triton.__version__}", flush=True)
+    except ImportError:
+        print("triton unavailable", flush=True)
+
+
+def _emit_benchmark_result(
+    *,
+    profile: str,
+    frame_count: int,
+    elapsed: float,
+    fps: float,
+    result_out: str | None,
+) -> None:
+    result = {
+        "profile": profile,
+        "frames": frame_count,
+        "elapsed": elapsed,
+        "fps": fps,
+        "flags": {key: os.environ.get(key) for key in _OPTIMIZATION_FLAG_KEYS},
+    }
+    print(
+        f"[benchmark] profile={profile} frames={frame_count} "
+        f"elapsed={elapsed:.2f}s fps={fps:.2f}",
+        flush=True,
+    )
+    if result_out is not None:
+        Path(result_out).write_text(json.dumps(result, indent=2))
+
+
+def sink(predictions, _video_frames) -> None:
+    global FRAME_COUNT, START_TIME
+    del _video_frames
+    if not isinstance(predictions, list):
+        predictions = [predictions]
+    FRAME_COUNT += sum(p is not None for p in predictions)
+    if START_TIME is None:
+        START_TIME = perf_counter()
+    if FRAME_COUNT % PROGRESS_EVERY == 0:
+        fps = FRAME_COUNT / (perf_counter() - START_TIME)
+        print(f"[progress] frames={FRAME_COUNT} fps={fps:.2f}", flush=True)
+
+
+def _resolve_video_reference(video_reference: str) -> str:
+    video_path = Path(video_reference)
+    if video_path.is_absolute():
+        return str(video_path)
+    candidate = _REPO_ROOT / video_path
+    if candidate.exists():
+        return str(candidate.resolve())
+    return video_reference
+
+
+def _child_pythonpath(existing_pythonpath: str | None) -> str:
+    entries = [
+        str(path)
+        for path in (_REPO_ROOT, _INFERENCE_MODELS_ROOT)
+        if path.exists()
+    ]
+    if existing_pythonpath:
+        entries.append(existing_pythonpath)
+    return os.pathsep.join(entries)
+
+
+def do_run(
+    *,
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+    benchmark_profile: str,
+    result_out: str | None,
+) -> dict:
+    global FRAME_COUNT, START_TIME
+    FRAME_COUNT = 0
+    START_TIME = None
+
+    print(f"[benchmark] profile={benchmark_profile}", flush=True)
+    print(f"[benchmark] flags: {_format_optimization_flags()}", flush=True)
+    _log_compute_environment()
+
+    resolved_local_package = _resolve_local_package(
+        backend=backend,
+        model_id=model_id,
+        model_package_id=model_package_id,
+        local_package=local_package,
+    )
+    if resolved_local_package is not None:
+        os.environ.setdefault(
+            "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES",
+            "True",
+        )
+
+    workflow_model_id = _resolve_model_id(
+        model_id=model_id,
+        local_package=resolved_local_package,
+    )
+    if resolved_local_package is not None:
+        _prepare_local_workflow_model_bundle(
+            workflow_model_id=workflow_model_id,
+            local_package=resolved_local_package,
+        )
+        print(
+            f"[model] using package via workflow model id: {workflow_model_id}",
+            flush=True,
+        )
+
+    inference_pipeline = _load_inference_pipeline(backend=backend)
+    pipeline = inference_pipeline.init_with_workflow(
+        video_reference=_resolve_video_reference(video_reference),
+        workflow_specification=build_workflow(workflow_model_id, confidence),
+        on_prediction=sink,
+    )
+    pipeline.start()
+    pipeline.join()
+
+    elapsed = perf_counter() - START_TIME if START_TIME else 0.0
+    fps = FRAME_COUNT / elapsed if elapsed > 0 else 0.0
+    _emit_benchmark_result(
+        profile=benchmark_profile,
+        frame_count=FRAME_COUNT,
+        elapsed=elapsed,
+        fps=fps,
+        result_out=result_out,
+    )
+    return {
+        "profile": benchmark_profile,
+        "frames": FRAME_COUNT,
+        "elapsed": elapsed,
+        "fps": fps,
+    }
+
+
+def _build_child_command(
+    *,
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+    benchmark_profile: str,
+    result_out: str,
+) -> list[str]:
+    command = [
+        _PY,
+        str(_SELF),
+        "--mode",
+        "run",
+        "--video_reference",
+        video_reference,
+        "--model_id",
+        model_id,
+        "--confidence",
+        str(confidence),
+        "--backend",
+        backend,
+        "--benchmark-profile",
+        benchmark_profile,
+        "--result-out",
+        result_out,
+    ]
+    if model_package_id is not None:
+        command.extend(["--model_package_id", model_package_id])
+    if local_package is not None:
+        command.extend(["--local_package", local_package])
+    return command
+
+
+def _run_child_benchmark(
+    *,
+    benchmark_profile: str,
+    flags: dict[str, str],
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+    result_out: str,
+) -> dict:
+    env = os.environ.copy()
+    env.update(flags)
+    env["PYTHONPATH"] = _child_pythonpath(env.get("PYTHONPATH"))
+    command = _build_child_command(
+        video_reference=video_reference,
+        model_id=model_id,
+        confidence=confidence,
+        backend=backend,
+        model_package_id=model_package_id,
+        local_package=local_package,
+        benchmark_profile=benchmark_profile,
+        result_out=result_out,
+    )
+    print(
+        "\n---- child ----\n"
+        f"  profile={benchmark_profile}\n"
+        f"  flags={flags}\n"
+        f"  result_out={result_out}",
+        flush=True,
+    )
+    subprocess.run(
+        command,
+        cwd=str(_REPO_ROOT),
+        env=env,
+        check=True,
+    )
+    return json.loads(Path(result_out).read_text())
+
+
+def do_compare(
+    *,
+    video_reference: str,
+    model_id: str,
+    confidence: float,
+    backend: str,
+    model_package_id: str | None,
+    local_package: str | None,
+) -> None:
+    resolved_video_reference = _resolve_video_reference(video_reference)
+    with tempfile.TemporaryDirectory(prefix="rfdetr-nano-seg-benchmark-") as tmp_dir:
+        baseline_result_path = str(Path(tmp_dir) / "baseline.json")
+        optimized_result_path = str(Path(tmp_dir) / "optimized.json")
+        baseline = _run_child_benchmark(
+            benchmark_profile="baseline",
+            flags=_BASELINE_FLAGS,
+            video_reference=resolved_video_reference,
+            model_id=model_id,
+            confidence=confidence,
+            backend=backend,
+            model_package_id=model_package_id,
+            local_package=local_package,
+            result_out=baseline_result_path,
+        )
+        optimized = _run_child_benchmark(
+            benchmark_profile="optimized",
+            flags=_OPTIMIZED_FLAGS,
+            video_reference=resolved_video_reference,
+            model_id=model_id,
+            confidence=confidence,
+            backend=backend,
+            model_package_id=model_package_id,
+            local_package=local_package,
+            result_out=optimized_result_path,
+        )
+
+    baseline_fps = baseline["fps"]
+    optimized_fps = optimized["fps"]
+    speedup = optimized_fps / baseline_fps if baseline_fps > 0 else 0.0
+    print("\n---- compare ----", flush=True)
+    print(
+        f"  baseline   frames={baseline['frames']} "
+        f"elapsed={baseline['elapsed']:.2f}s fps={baseline_fps:.2f}",
+        flush=True,
+    )
+    print(
+        f"  optimized  frames={optimized['frames']} "
+        f"elapsed={optimized['elapsed']:.2f}s fps={optimized_fps:.2f}",
+        flush=True,
+    )
+    print(f"  speedup    {speedup:.2f}x", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("run", "compare"),
+        default="run",
+        help=(
+            "run: single benchmark in this process. "
+            "compare: baseline then optimized, each in a fresh child process."
+        ),
+    )
+    parser.add_argument("--video_reference", required=True)
+    parser.add_argument("--model_id", default=_DEFAULT_MODEL_ID)
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument(
+        "--backend",
+        choices=("trt", "onnx", "torch"),
+        default="trt",
+        help="inference-models backend.",
+    )
+    parser.add_argument(
+        "--local_package",
+        default=None,
+        help=(
+            "Path to an on-disk model package directory (must contain "
+            "model_config.json). Skips registry fetch and cwd TRT discovery."
+        ),
+    )
+    parser.add_argument(
+        "--model_package_id",
+        default=None,
+        help=(
+            "Registry package id to download and pin (via inference-models cache). "
+            "Overrides auto-negotiation and any cwd TRT package discovery."
+        ),
+    )
+    parser.add_argument(
+        "--benchmark-profile",
+        default="run",
+        help="Label for a single run (compare mode sets baseline/optimized in children).",
+    )
+    parser.add_argument(
+        "--result-out",
+        default=None,
+        help="Optional JSON path for the final benchmark result (used by compare mode).",
+    )
+    args = parser.parse_args()
+
+    if args.local_package is not None and args.model_package_id is not None:
+        parser.error("--local_package and --model_package_id are mutually exclusive")
+
+    if args.mode == "compare":
+        do_compare(
+            video_reference=args.video_reference,
+            model_id=args.model_id,
+            confidence=args.confidence,
+            backend=args.backend,
+            model_package_id=args.model_package_id,
+            local_package=args.local_package,
+        )
+        return
+
+    do_run(
+        video_reference=args.video_reference,
+        model_id=args.model_id,
+        confidence=args.confidence,
+        backend=args.backend,
+        model_package_id=args.model_package_id,
+        local_package=args.local_package,
+        benchmark_profile=args.benchmark_profile,
+        result_out=args.result_out,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/rfdetr_coco_same_shape_parity.py
+++ b/development/stream_interface/rfdetr_coco_same_shape_parity.py
@@ -1,0 +1,717 @@
+"""Compare RF-DETR instance-segmentation outputs on same-shape COCO images.
+
+This harness is used to reproduce the correctness table in the RF-DETR Triton
+preprocess PR. It runs a baseline git ref with all RF-DETR fast paths disabled
+and a candidate ref with Triton RLE postprocess and Triton preprocess enabled,
+then compares
+detection counts, classes, boxes, scores, and RLE masks.
+
+Example:
+
+    env PARITY_MODEL_PATH=/path/to/rfdetr-seg-nano-orin-trt-package \
+      python development/stream_interface/rfdetr_coco_same_shape_parity.py \
+        --base-ref main \
+        --candidate-ref opt-preprocess \
+        --height 480 \
+        --width 640 \
+        --image-count 1000
+"""
+
+import argparse
+import os
+import pickle
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import deque
+from pathlib import Path
+from typing import Deque, Optional
+
+import cv2
+import numpy as np
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[2]
+SELF = Path(__file__).resolve()
+PY = sys.executable
+MODEL_ID = "rfdetr-seg-nano"
+CONFIDENCE = 0.4
+DEFAULT_BASE_OUT = "/tmp/rfdetr_coco_same_shape_base.pkl"
+DEFAULT_CANDIDATE_OUT = "/tmp/rfdetr_coco_same_shape_candidate.pkl"
+
+BASE_FLAGS_OFF = {
+    "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED": "false",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED": "false",
+    "RFDETR_PIPELINE_DEPTH": "1",
+    "ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND": "false",
+    "RFDETR_NSIGHT_MARKERS": "false",
+}
+CANDIDATE_FLAGS_ON = {
+    "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED": "true",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED": "true",
+    "RFDETR_PIPELINE_DEPTH": "1",
+    "ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND": "false",
+    "RFDETR_NSIGHT_MARKERS": "false",
+}
+TRT_PACKAGE_REQUIRED_FILES = (
+    "model_config.json",
+    "class_names.txt",
+    "inference_config.json",
+    "engine.plan",
+)
+
+
+def _repo_import_roots(repo_root: Path) -> list[Path]:
+    return [repo_root, repo_root / "inference_models"]
+
+
+def _child_pythonpath(repo_root: Path, existing_pythonpath: Optional[str]) -> str:
+    entries = [str(path) for path in _repo_import_roots(repo_root) if path.exists()]
+    if existing_pythonpath:
+        entries.append(existing_pythonpath)
+    return os.pathsep.join(entries)
+
+
+def _prioritize_local_packages(repo_root: Path) -> None:
+    for search_root in reversed(_repo_import_roots(repo_root)):
+        search_root_str = str(search_root)
+        if search_root_str in sys.path:
+            sys.path.remove(search_root_str)
+        if search_root.exists():
+            sys.path.insert(0, search_root_str)
+    for module_name in list(sys.modules):
+        if module_name == "inference" or module_name.startswith("inference."):
+            sys.modules.pop(module_name, None)
+        if module_name == "inference_models" or module_name.startswith(
+            "inference_models."
+        ):
+            sys.modules.pop(module_name, None)
+
+
+def _bootstrap_repo_root(repo_root: str) -> Path:
+    repo_path = Path(repo_root).resolve()
+    os.chdir(repo_path)
+    _prioritize_local_packages(repo_path)
+    return repo_path
+
+
+def _git_output(repo_root: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=str(repo_root),
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+def _safe_git_output(repo_root: Path, *args: str, default: str = "<unknown>") -> str:
+    try:
+        return _git_output(repo_root, *args)
+    except subprocess.CalledProcessError:
+        return default
+
+
+def _remove_worktree(worktree_root: Path) -> None:
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(worktree_root)],
+        cwd=str(SCRIPT_REPO_ROOT),
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    shutil.rmtree(worktree_root, ignore_errors=True)
+
+
+def _materialize_target(ref: str) -> dict:
+    if ref.lower() in {"working-tree", "worktree", "current"}:
+        return {
+            "label": (
+                f"{_safe_git_output(SCRIPT_REPO_ROOT, 'rev-parse', '--abbrev-ref', 'HEAD')} "
+                "(working-tree)"
+            ),
+            "repo_root": SCRIPT_REPO_ROOT,
+            "cleanup": None,
+        }
+    worktree_root = Path(tempfile.mkdtemp(prefix="rfdetr-coco-parity-"))
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree_root), ref],
+        cwd=str(SCRIPT_REPO_ROOT),
+        check=True,
+    )
+    return {
+        "label": ref,
+        "repo_root": worktree_root,
+        "cleanup": lambda: _remove_worktree(worktree_root),
+    }
+
+
+def _is_trt_package(package_dir: Path) -> bool:
+    return package_dir.is_dir() and all(
+        (package_dir / filename).exists() for filename in TRT_PACKAGE_REQUIRED_FILES
+    )
+
+
+def _resolve_model_reference() -> str:
+    explicit_model_path = os.environ.get("PARITY_MODEL_PATH")
+    if explicit_model_path and _is_trt_package(Path(explicit_model_path)):
+        return str(Path(explicit_model_path).resolve())
+    for root in (SCRIPT_REPO_ROOT, Path.cwd(), Path(tempfile.gettempdir())):
+        for name in (
+            "rfdetr-seg-nano-orin-trt-package",
+            "rfdetr-seg-nano-trt-package",
+        ):
+            package = root / name
+            if _is_trt_package(package):
+                return str(package.resolve())
+    return MODEL_ID
+
+
+def _select_same_shape_images(
+    coco_dir: Path, shape: tuple[int, int], limit: int
+) -> list[str]:
+    target_h, target_w = shape
+    selected = []
+    for path in sorted(coco_dir.glob("*.jpg")):
+        image = cv2.imread(str(path), cv2.IMREAD_COLOR)
+        if image is None:
+            continue
+        h, w = image.shape[:2]
+        if (h, w) == (target_h, target_w):
+            selected.append(str(path.resolve()))
+            if len(selected) >= limit:
+                break
+    if len(selected) < limit:
+        raise RuntimeError(
+            f"Found only {len(selected)} images with shape {(target_h, target_w)}"
+        )
+    return selected
+
+
+def _normalized_rle(rle: dict) -> dict:
+    counts = rle["counts"]
+    if isinstance(counts, bytes):
+        counts = counts.decode("ascii")
+    return {"size": list(rle["size"]), "counts": counts}
+
+
+def _rle_for_coco_iou(rle: dict) -> dict:
+    counts = rle["counts"]
+    if isinstance(counts, str):
+        counts = counts.encode("ascii")
+    return {"size": list(rle["size"]), "counts": counts}
+
+
+def _rles_equal(left: dict, right: dict) -> bool:
+    left_norm = _rle_for_coco_iou(left)
+    right_norm = _rle_for_coco_iou(right)
+    return (
+        left_norm["size"] == right_norm["size"]
+        and left_norm["counts"] == right_norm["counts"]
+    )
+
+
+def _rle_iou(left: dict, right: dict) -> float:
+    from pycocotools import mask as mask_utils
+
+    return float(
+        mask_utils.iou([_rle_for_coco_iou(left)], [_rle_for_coco_iou(right)], [False])[
+            0, 0
+        ]
+    )
+
+
+def _record_from_response(image_path: str, response) -> dict:
+    predictions = response.predictions
+    if not predictions:
+        return {
+            "_kind": "rec",
+            "image_path": image_path,
+            "xyxy": None,
+            "conf": None,
+            "cls": None,
+            "rles": None,
+        }
+
+    xyxy = np.empty((len(predictions), 4), dtype=np.float32)
+    conf = np.empty((len(predictions),), dtype=np.float32)
+    cls = np.empty((len(predictions),), dtype=np.int32)
+    rles = []
+    for idx, pred in enumerate(predictions):
+        x1 = float(pred.x) - float(pred.width) / 2.0
+        y1 = float(pred.y) - float(pred.height) / 2.0
+        x2 = float(pred.x) + float(pred.width) / 2.0
+        y2 = float(pred.y) + float(pred.height) / 2.0
+        xyxy[idx] = (x1, y1, x2, y2)
+        conf[idx] = float(pred.confidence)
+        cls[idx] = int(pred.class_id)
+        rle = getattr(pred, "rle", None)
+        if rle is None:
+            raise ValueError("Expected RLE predictions; got polygon response.")
+        rles.append(_normalized_rle(rle))
+    return {
+        "_kind": "rec",
+        "image_path": image_path,
+        "xyxy": xyxy,
+        "conf": conf,
+        "cls": cls,
+        "rles": rles,
+    }
+
+
+def _run_warmup(model, frame, warmup_frames: int) -> None:
+    for _ in range(warmup_frames):
+        preprocessed, metadata = model.preprocess(
+            frame,
+            confidence=CONFIDENCE,
+            response_mask_format="rle",
+        )
+        prediction_handle = model.predict(
+            preprocessed,
+            confidence=CONFIDENCE,
+            response_mask_format="rle",
+        )
+        model.postprocess(
+            prediction_handle,
+            metadata,
+            confidence=CONFIDENCE,
+            response_mask_format="rle",
+        )
+    if hasattr(model, "flush"):
+        model.flush()
+
+
+def do_run(
+    out_path: str,
+    repo_root: str,
+    label: str,
+    image_list_path: str,
+    warmup_frames: int,
+) -> None:
+    repo_path = _bootstrap_repo_root(repo_root)
+    os.environ.setdefault(
+        "DISABLED_INFERENCE_MODELS_BACKENDS",
+        "torch,torch-script,onnx,hugging-face,ultralytics,custom",
+    )
+    os.environ.setdefault(
+        "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES", "true"
+    )
+
+    import torch
+    from inference.core.models.inference_models_adapters import (
+        InferenceModelsInstanceSegmentationAdapter,
+    )
+
+    with open(image_list_path, "rb") as f:
+        image_paths = pickle.load(f)
+
+    model_reference = _resolve_model_reference()
+    model = InferenceModelsInstanceSegmentationAdapter(model_reference)
+    pipeline_depth = int(getattr(model, "_pipeline_depth", 1))
+    response_delay = max(0, int(getattr(model, "_response_delay", 0)))
+    signature = {
+        "git_head": _safe_git_output(repo_path, "rev-parse", "--short", "HEAD"),
+        "git_describe": _safe_git_output(
+            repo_path, "describe", "--always", "--dirty", "--broken"
+        ),
+    }
+
+    first_frame = cv2.imread(image_paths[0], cv2.IMREAD_COLOR)
+    if first_frame is None:
+        raise RuntimeError(f"Could not read image: {image_paths[0]}")
+
+    print(
+        "[run] "
+        f"label={label} repo_root={repo_path} head={signature['git_head']} "
+        f"model_reference={model_reference} pipeline_depth={pipeline_depth}",
+        flush=True,
+    )
+    _run_warmup(model=model, frame=first_frame, warmup_frames=warmup_frames)
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    header = {
+        "_kind": "header",
+        "label": label,
+        "repo_root": str(repo_path),
+        "model_reference": model_reference,
+        "confidence": CONFIDENCE,
+        "git_head": signature["git_head"],
+        "git_describe": signature["git_describe"],
+        "pipeline_depth": pipeline_depth,
+        "response_delay": response_delay,
+        "image_count": len(image_paths),
+        "flags": {
+            key: os.environ.get(key)
+            for key in sorted({*BASE_FLAGS_OFF.keys(), *CANDIDATE_FLAGS_ON.keys()})
+        },
+    }
+
+    pending: Deque[str] = deque()
+    n_records = 0
+    with open(out_path, "wb") as f:
+        pickle.dump(header, f)
+        for index, image_path in enumerate(image_paths):
+            frame = cv2.imread(image_path, cv2.IMREAD_COLOR)
+            if frame is None:
+                raise RuntimeError(f"Could not read image: {image_path}")
+            preprocessed, metadata = model.preprocess(
+                frame,
+                confidence=CONFIDENCE,
+                response_mask_format="rle",
+            )
+            prediction_handle = model.predict(
+                preprocessed,
+                confidence=CONFIDENCE,
+                response_mask_format="rle",
+            )
+            responses = model.postprocess(
+                prediction_handle,
+                metadata,
+                confidence=CONFIDENCE,
+                response_mask_format="rle",
+            )
+
+            if pipeline_depth <= 1:
+                if len(responses) != 1:
+                    raise ValueError(f"image {index}: expected one response")
+                pickle.dump(_record_from_response(image_path, responses[0]), f)
+                n_records += 1
+            else:
+                pending.append(image_path)
+                if len(pending) > response_delay:
+                    if len(responses) != 1:
+                        raise ValueError(f"image {index}: expected one response")
+                    response_image_path = pending.popleft()
+                    pickle.dump(
+                        _record_from_response(response_image_path, responses[0]), f
+                    )
+                    n_records += 1
+            if (index + 1) % 25 == 0:
+                print(f"  [{label}] images={index + 1} records={n_records}", flush=True)
+
+        flush_responses = model.flush() if hasattr(model, "flush") else []
+        for response in flush_responses:
+            if not pending:
+                raise ValueError("flush returned response with no pending image")
+            response_image_path = pending.popleft()
+            pickle.dump(_record_from_response(response_image_path, response), f)
+            n_records += 1
+        if pending:
+            raise ValueError(f"pending images left after flush: {len(pending)}")
+        pickle.dump(
+            {
+                "_kind": "footer",
+                "label": label,
+                "n_records": n_records,
+            },
+            f,
+        )
+    print(f"[run] label={label} records={n_records} saved={out_path}", flush=True)
+
+
+def _iter_pickles(path: str):
+    with open(path, "rb") as f:
+        while True:
+            try:
+                yield pickle.load(f)
+            except EOFError:
+                return
+
+
+def _box_iou(left, right) -> float:
+    x0 = max(left[0], right[0])
+    y0 = max(left[1], right[1])
+    x1 = min(left[2], right[2])
+    y1 = min(left[3], right[3])
+    iw = max(0.0, float(x1 - x0))
+    ih = max(0.0, float(y1 - y0))
+    inter = iw * ih
+    left_area = max(0.0, float(left[2] - left[0])) * max(0.0, float(left[3] - left[1]))
+    right_area = max(0.0, float(right[2] - right[0])) * max(
+        0.0, float(right[3] - right[1])
+    )
+    union = left_area + right_area - inter
+    return inter / union if union > 0 else 0.0
+
+
+def do_compare(base_path: str, candidate_path: str) -> None:
+    base_iter = _iter_pickles(base_path)
+    candidate_iter = _iter_pickles(candidate_path)
+    base_header = next(base_iter)
+    candidate_header = next(candidate_iter)
+
+    n_images = 0
+    tot_base = 0
+    tot_candidate = 0
+    matched = 0
+    count_mismatch = 0
+    class_disagree = 0
+    pixel_identical = 0
+    box_ious = []
+    score_deltas = []
+    mask_ious = []
+    first_mismatches = []
+    base_footer = None
+    candidate_footer = None
+
+    for base_record, candidate_record in zip(base_iter, candidate_iter):
+        if (
+            base_record.get("_kind") == "footer"
+            or candidate_record.get("_kind") == "footer"
+        ):
+            base_footer = base_record
+            candidate_footer = candidate_record
+            break
+        if base_record["image_path"] != candidate_record["image_path"]:
+            raise AssertionError(
+                (base_record["image_path"], candidate_record["image_path"])
+            )
+        n_images += 1
+        n_base = 0 if base_record["xyxy"] is None else len(base_record["xyxy"])
+        n_candidate = (
+            0 if candidate_record["xyxy"] is None else len(candidate_record["xyxy"])
+        )
+        tot_base += n_base
+        tot_candidate += n_candidate
+        if n_base != n_candidate:
+            count_mismatch += 1
+            if len(first_mismatches) < 10:
+                first_mismatches.append(
+                    (Path(base_record["image_path"]).name, n_base, n_candidate)
+                )
+        if n_base == 0 and n_candidate == 0:
+            continue
+
+        base_boxes = base_record["xyxy"] if n_base else np.zeros((0, 4), dtype=float)
+        candidate_boxes = (
+            candidate_record["xyxy"] if n_candidate else np.zeros((0, 4), dtype=float)
+        )
+        base_scores = base_record["conf"] if n_base else np.zeros(0, dtype=float)
+        candidate_scores = (
+            candidate_record["conf"] if n_candidate else np.zeros(0, dtype=float)
+        )
+        base_classes = base_record["cls"] if n_base else np.zeros(0, dtype=np.int32)
+        candidate_classes = (
+            candidate_record["cls"] if n_candidate else np.zeros(0, dtype=np.int32)
+        )
+        base_rles = base_record["rles"] or []
+        candidate_rles = candidate_record["rles"] or []
+
+        used = set()
+        for candidate_idx in range(n_candidate):
+            best_base_idx = -1
+            best_iou = 0.5
+            for base_idx in range(n_base):
+                if base_idx in used:
+                    continue
+                if int(base_classes[base_idx]) != int(candidate_classes[candidate_idx]):
+                    continue
+                box_iou = _box_iou(base_boxes[base_idx], candidate_boxes[candidate_idx])
+                if box_iou > best_iou:
+                    best_iou = box_iou
+                    best_base_idx = base_idx
+            if best_base_idx < 0:
+                continue
+
+            used.add(best_base_idx)
+            matched += 1
+            box_ious.append(best_iou)
+            score_deltas.append(
+                abs(
+                    float(base_scores[best_base_idx])
+                    - float(candidate_scores[candidate_idx])
+                )
+            )
+            if int(base_classes[best_base_idx]) != int(
+                candidate_classes[candidate_idx]
+            ):
+                class_disagree += 1
+            if base_rles and candidate_rles:
+                base_rle = base_rles[best_base_idx]
+                candidate_rle = candidate_rles[candidate_idx]
+                mask_ious.append(_rle_iou(base_rle, candidate_rle))
+                if _rles_equal(base_rle, candidate_rle):
+                    pixel_identical += 1
+
+    if base_footer is None:
+        for obj in base_iter:
+            if obj.get("_kind") == "footer":
+                base_footer = obj
+                break
+    if candidate_footer is None:
+        for obj in candidate_iter:
+            if obj.get("_kind") == "footer":
+                candidate_footer = obj
+                break
+
+    print()
+    print(
+        f"==== COCO same-shape parity: {base_header['label']} vs "
+        f"{candidate_header['label']} ===="
+    )
+    print(f"  base repo                    : {base_header['git_describe']}")
+    print(f"  candidate repo               : {candidate_header['git_describe']}")
+    print(
+        f"  pipeline depth (base/cand)   : "
+        f"{base_header['pipeline_depth']} / {candidate_header['pipeline_depth']}"
+    )
+    print(
+        f"  images base / candidate      : "
+        f"{base_footer['n_records']} / {candidate_footer['n_records']}"
+    )
+    print(f"  detections base / candidate  : {tot_base} / {tot_candidate}")
+    print(
+        f"  matched same-class IoU>0.5   : {matched} "
+        f"({100 * matched / max(1, tot_base):.2f}% of base)"
+    )
+    print(f"  count-mismatch images        : {count_mismatch}")
+    if first_mismatches:
+        print(f"  first count mismatches       : {first_mismatches}")
+    print(f"  class-id disagreements       : {class_disagree}")
+    if box_ious:
+        print(
+            f"  mean / min box IoU           : {np.mean(box_ious):.6f} / {np.min(box_ious):.6f}"
+        )
+    if score_deltas:
+        print(
+            f"  mean / max |delta score|     : "
+            f"{np.mean(score_deltas):.3e} / {np.max(score_deltas):.3e}"
+        )
+    if mask_ious:
+        mask_iou_array = np.array(mask_ious)
+        print(
+            f"  mean / min mask IoU          : "
+            f"{mask_iou_array.mean():.6f} / {mask_iou_array.min():.6f}"
+        )
+        print(f"  pixel-identical masks        : {pixel_identical}/{len(mask_ious)}")
+
+
+def _run_child(
+    repo_root: Path,
+    label: str,
+    out_path: str,
+    image_list_path: str,
+    flags: dict,
+    warmup_frames: int,
+) -> None:
+    env = os.environ.copy()
+    env.update(flags)
+    env["MPLCONFIGDIR"] = "/tmp/mpl"
+    env["PARITY_MODEL_PATH"] = str(
+        (SCRIPT_REPO_ROOT / "rfdetr-seg-nano-orin-trt-package").resolve()
+    )
+    env["PYTHONPATH"] = _child_pythonpath(repo_root, env.get("PYTHONPATH"))
+    args = [
+        PY,
+        str(SELF),
+        "--mode",
+        "run",
+        "--repo-root",
+        str(repo_root),
+        "--label",
+        label,
+        "--out",
+        out_path,
+        "--image-list",
+        image_list_path,
+        "--warmup-frames",
+        str(warmup_frames),
+    ]
+    print(
+        "\n---- child ----\n"
+        f"  label={label}\n"
+        f"  repo_root={repo_root}\n"
+        f"  out={out_path}\n"
+        f"  flags={flags}",
+        flush=True,
+    )
+    subprocess.run(args, cwd=str(SCRIPT_REPO_ROOT), env=env, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode", choices=("driver", "run", "compare"), default="driver"
+    )
+    parser.add_argument("--repo-root")
+    parser.add_argument("--label")
+    parser.add_argument("--out")
+    parser.add_argument("--image-list")
+    parser.add_argument("--base", default=DEFAULT_BASE_OUT)
+    parser.add_argument("--candidate", default=DEFAULT_CANDIDATE_OUT)
+    parser.add_argument("--base-ref", default="main")
+    parser.add_argument("--candidate-ref", default="working-tree")
+    parser.add_argument("--coco-dir", default="coco/val2017")
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--width", type=int, default=640)
+    parser.add_argument("--image-count", type=int, default=100)
+    parser.add_argument("--warmup-frames", type=int, default=10)
+    parser.add_argument("--keep-worktrees", action="store_true")
+    args = parser.parse_args()
+
+    if args.mode == "run":
+        if not args.out or not args.image_list:
+            raise ValueError("--out and --image-list are required in run mode")
+        do_run(
+            out_path=args.out,
+            repo_root=args.repo_root or str(SCRIPT_REPO_ROOT),
+            label=args.label or "run",
+            image_list_path=args.image_list,
+            warmup_frames=args.warmup_frames,
+        )
+        return
+    if args.mode == "compare":
+        do_compare(args.base, args.candidate)
+        return
+
+    coco_dir = (SCRIPT_REPO_ROOT / args.coco_dir).resolve()
+    image_paths = _select_same_shape_images(
+        coco_dir=coco_dir,
+        shape=(args.height, args.width),
+        limit=args.image_count,
+    )
+    image_list_path = Path(
+        tempfile.mkstemp(prefix="rfdetr-coco-images-", suffix=".pkl")[1]
+    )
+    with open(image_list_path, "wb") as f:
+        pickle.dump(image_paths, f)
+    print(
+        f"[driver] selected {len(image_paths)} images with shape "
+        f"{(args.height, args.width)} from {coco_dir}",
+        flush=True,
+    )
+
+    base_target = _materialize_target(args.base_ref)
+    candidate_target = _materialize_target(args.candidate_ref)
+    cleanup_callbacks = [
+        target["cleanup"]
+        for target in (base_target, candidate_target)
+        if callable(target["cleanup"])
+    ]
+    try:
+        _run_child(
+            repo_root=Path(base_target["repo_root"]),
+            label=f"{base_target['label']} flags-off",
+            out_path=args.base,
+            image_list_path=str(image_list_path),
+            flags=BASE_FLAGS_OFF,
+            warmup_frames=args.warmup_frames,
+        )
+        _run_child(
+            repo_root=Path(candidate_target["repo_root"]),
+            label=f"{candidate_target['label']} flags-on",
+            out_path=args.candidate,
+            image_list_path=str(image_list_path),
+            flags=CANDIDATE_FLAGS_ON,
+            warmup_frames=args.warmup_frames,
+        )
+    finally:
+        image_list_path.unlink(missing_ok=True)
+        if not args.keep_worktrees:
+            for cleanup in reversed(cleanup_callbacks):
+                cleanup()
+    do_compare(args.base, args.candidate)
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
+++ b/development/stream_interface/rfdetr_nano_seg_trt_workflow.py
@@ -1,0 +1,211 @@
+"""Minimal benchmark: RF-DETR instance segmentation through inference-models,
+run via InferencePipeline on a single video source.
+
+Workflow has exactly one block — the segmentation model. No annotators, no
+buffer strategies, no rate limiting.
+
+The `--backend` flag (trt | onnx | torch) is parsed before importing
+`inference` and pins the auto-loader by setting
+`DISABLED_INFERENCE_MODELS_BACKENDS` to every backend except the chosen one,
+so the benchmark numbers correspond unambiguously to a single execution path.
+
+Defaults: rfdetr-seg-nano @ confidence 0.4 on the native TRT backend.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+_ALL_BACKENDS = {
+    "torch",
+    "torch-script",
+    "onnx",
+    "trt",
+    "hugging-face",
+    "ultralytics",
+    "custom",
+}
+_DEFAULT_MODEL_ID = "rfdetr-seg-nano"
+_PREFERRED_LOCAL_TRT_PACKAGE = "rfdetr-seg-nano-orin-trt-package"
+_LOCAL_WORKFLOW_MODEL_ID = f"{_DEFAULT_MODEL_ID}/1"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFERENCE_MODELS_ROOT = _REPO_ROOT / "inference_models"
+
+
+def _is_local_trt_package(path: Path) -> bool:
+    if not path.is_dir():
+        return False
+    required_files = ("engine.plan", "model_config.json", "inference_config.json")
+    if not all((path / f).is_file() for f in required_files):
+        return False
+    try:
+        model_config = json.loads((path / "model_config.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return model_config.get("backend_type") == "trt"
+
+
+def _find_local_trt_package() -> str | None:
+    preferred = Path.cwd() / _PREFERRED_LOCAL_TRT_PACKAGE
+    if _is_local_trt_package(preferred):
+        return str(preferred.resolve())
+
+    candidates = sorted(
+        path.resolve() for path in Path.cwd().iterdir() if _is_local_trt_package(path)
+    )
+    if len(candidates) == 1:
+        return str(candidates[0])
+    return None
+
+
+def _select_backend_from_argv() -> str:
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--backend", choices=("trt", "onnx", "torch"), default="trt")
+    args, _ = pre.parse_known_args()
+    return args.backend
+
+
+_BACKEND = _select_backend_from_argv()
+_LOCAL_TRT_PACKAGE = _find_local_trt_package() if _BACKEND == "trt" else None
+if _LOCAL_TRT_PACKAGE is not None:
+    os.environ.setdefault(
+        "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES", "True"
+    )
+os.environ.setdefault(
+    "ONNXRUNTIME_EXECUTION_PROVIDERS",
+    "[TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider]",
+)
+os.environ["DISABLED_INFERENCE_MODELS_BACKENDS"] = ",".join(
+    sorted(_ALL_BACKENDS - {_BACKEND})
+)
+for path in (str(_INFERENCE_MODELS_ROOT), str(_REPO_ROOT)):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+for module_name in list(sys.modules):
+    if module_name == "inference" or module_name.startswith("inference."):
+        del sys.modules[module_name]
+    if module_name == "inference_models" or module_name.startswith("inference_models."):
+        del sys.modules[module_name]
+
+from time import perf_counter
+
+_LOCAL_INFERENCE_SPEC = importlib.util.spec_from_file_location(
+    "inference",
+    _REPO_ROOT / "inference" / "__init__.py",
+    submodule_search_locations=[str(_REPO_ROOT / "inference")],
+)
+if _LOCAL_INFERENCE_SPEC is None or _LOCAL_INFERENCE_SPEC.loader is None:
+    raise RuntimeError("Could not load local inference package")
+_LOCAL_INFERENCE_MODULE = importlib.util.module_from_spec(_LOCAL_INFERENCE_SPEC)
+sys.modules["inference"] = _LOCAL_INFERENCE_MODULE
+_LOCAL_INFERENCE_SPEC.loader.exec_module(_LOCAL_INFERENCE_MODULE)
+InferencePipeline = _LOCAL_INFERENCE_MODULE.InferencePipeline
+
+
+def _resolve_model_id(model_id: str, backend: str) -> str:
+    if backend == "trt" and model_id == _DEFAULT_MODEL_ID and _LOCAL_TRT_PACKAGE:
+        return _LOCAL_WORKFLOW_MODEL_ID
+    return model_id
+
+
+def _prepare_local_workflow_model_bundle(model_id: str) -> None:
+    if _LOCAL_TRT_PACKAGE is None or model_id != _LOCAL_WORKFLOW_MODEL_ID:
+        return
+
+    model_dir = Path(model_id)
+    model_dir.parent.mkdir(parents=True, exist_ok=True)
+    target_dir = Path(_LOCAL_TRT_PACKAGE)
+    if not model_dir.exists():
+        model_dir.symlink_to(target_dir, target_is_directory=True)
+
+    model_cache_dir = Path(os.environ.get("MODEL_CACHE_DIR", "/tmp/cache")) / model_id
+    model_cache_dir.mkdir(parents=True, exist_ok=True)
+    model_type_path = model_cache_dir / "model_type.json"
+    model_metadata = {
+        "project_task_type": "instance-segmentation",
+        "model_type": "rfdetr-seg-nano",
+    }
+    model_type_path.write_text(json.dumps(model_metadata, indent=4))
+
+
+def build_workflow(model_id: str, confidence: float) -> dict:
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+                "name": "segmentation",
+                "images": "$inputs.image",
+                "model_id": model_id,
+                "confidence_mode": "custom",
+                "custom_confidence": confidence,
+                "enforce_dense_masks_in_inference_models": False,
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.segmentation.predictions",
+            },
+        ],
+    }
+
+
+FRAME_COUNT = 0
+START_TIME = None
+PROGRESS_EVERY = 50
+
+
+def sink(predictions, _video_frames) -> None:
+    global FRAME_COUNT, START_TIME
+    del _video_frames
+    if not isinstance(predictions, list):
+        predictions = [predictions]
+    FRAME_COUNT += sum(p is not None for p in predictions)
+    if START_TIME is None:
+        START_TIME = perf_counter()
+    if FRAME_COUNT % PROGRESS_EVERY == 0:
+        fps = FRAME_COUNT / (perf_counter() - START_TIME)
+        print(f"[progress] frames={FRAME_COUNT} fps={fps:.2f}", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--video_reference", required=True)
+    parser.add_argument("--model_id", default=_DEFAULT_MODEL_ID)
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument(
+        "--backend",
+        choices=("trt", "onnx", "torch"),
+        default="trt",
+        help="inference-models backend (consumed pre-import via env var).",
+    )
+    args = parser.parse_args()
+    model_id = _resolve_model_id(args.model_id, args.backend)
+    _prepare_local_workflow_model_bundle(model_id)
+    if model_id != args.model_id:
+        print(
+            f"[model] using local TRT package via workflow model id: {model_id}",
+            flush=True,
+        )
+
+    pipeline = InferencePipeline.init_with_workflow(
+        video_reference=args.video_reference,
+        workflow_specification=build_workflow(model_id, args.confidence),
+        on_prediction=sink,
+    )
+    pipeline.start()
+    pipeline.join()
+
+    elapsed = perf_counter() - START_TIME if START_TIME else 0.0
+    fps = FRAME_COUNT / elapsed if elapsed > 0 else 0.0
+    print(f"frames={FRAME_COUNT} elapsed={elapsed:.2f}s fps={fps:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/rfdetr_preprocess_microbenchmark.py
+++ b/development/stream_interface/rfdetr_preprocess_microbenchmark.py
@@ -1,0 +1,637 @@
+"""Capture/replay benchmark for RF-DETR reference preprocessing.
+
+Default usage captures 100 invocations of
+``inference_models.models.rfdetr.pre_processing.pre_process_network_input`` from
+the e2e workflow and immediately replays them:
+
+    python development/stream_interface/rfdetr_preprocess_microbenchmark.py \
+        --video_reference vehicles_1080p.mp4
+
+Replay-only usage:
+
+    python development/stream_interface/rfdetr_preprocess_microbenchmark.py \
+        --mode replay --cases-dir temp/rfdetr_preprocess_cases
+
+The TRT RF-DETR model has a Triton fast path that bypasses this function.
+Capture mode forces ``INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false``
+before loading the workflow so the reference preprocessing function is
+exercised. Triton replay uses the same ``FastPreprocessRuntime`` helper as the
+TRT adapter rather than duplicating eligibility, buffer, and metadata logic in
+this harness.
+"""
+
+import argparse
+import functools
+import importlib.util
+import json
+import os
+from pathlib import Path
+import pickle
+import sys
+import threading
+from time import perf_counter, time
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFERENCE_MODELS_ROOT = _REPO_ROOT / "inference_models"
+_WORKFLOW_PATH = (
+    _REPO_ROOT / "development" / "stream_interface" / "rfdetr_nano_seg_trt_workflow.py"
+)
+_TARGET_FUNCTION = "pre_process_network_input"
+_SCHEMA_VERSION = 1
+_FORCED_PREPROC_ENV = "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED"
+_TRITON_REPLAY_RUNTIMES: Dict[str, Any] = {}
+
+
+def _ensure_local_import_paths() -> None:
+    for path in (str(_INFERENCE_MODELS_ROOT), str(_REPO_ROOT)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def _load_workflow_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "rfdetr_nano_seg_trt_workflow_for_preprocess_microbenchmark",
+        _WORKFLOW_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load workflow module from {_WORKFLOW_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _tensor_to_cpu(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.detach().cpu().clone()
+
+
+def _snapshot_images(images: Any) -> Any:
+    if isinstance(images, torch.Tensor):
+        return {"kind": "tensor", "value": _tensor_to_cpu(images)}
+    if isinstance(images, np.ndarray):
+        return {"kind": "ndarray", "value": np.array(images, copy=True)}
+    if isinstance(images, list):
+        return {"kind": "list", "value": [_snapshot_images(image) for image in images]}
+    return {"kind": "raw", "value": images}
+
+
+def _materialize_images(payload: Any, device: torch.device) -> Any:
+    kind = payload["kind"]
+    value = payload["value"]
+    if kind == "tensor":
+        return value.to(device=device).clone()
+    if kind == "ndarray":
+        return np.array(value, copy=True)
+    if kind == "list":
+        return [_materialize_images(image, device=device) for image in value]
+    if kind == "raw":
+        return value
+    raise RuntimeError(f"Unknown image payload kind: {kind}")
+
+
+def _snapshot_inputs(
+    *,
+    images: Any,
+    image_pre_processing: Any,
+    network_input: Any,
+    target_device: torch.device,
+    input_color_format: Optional[Any],
+    image_size_wh: Optional[Union[int, Tuple[int, int]]],
+    pre_processing_overrides: Optional[Any],
+) -> dict:
+    return {
+        "images": _snapshot_images(images),
+        "image_pre_processing": image_pre_processing,
+        "network_input": network_input,
+        "target_device": str(target_device),
+        "input_color_format": input_color_format,
+        "image_size_wh": image_size_wh,
+        "pre_processing_overrides": pre_processing_overrides,
+    }
+
+
+def _snapshot_output(output: Tuple[torch.Tensor, List[Any]]) -> dict:
+    tensor, metadata = output
+    return {
+        "tensor": _tensor_to_cpu(tensor),
+        "metadata": list(metadata),
+    }
+
+
+def _bind_target_arguments(args: tuple, kwargs: dict) -> dict:
+    names = (
+        "images",
+        "image_pre_processing",
+        "network_input",
+        "target_device",
+        "input_color_format",
+        "image_size_wh",
+        "pre_processing_overrides",
+    )
+    bound = {
+        "input_color_format": None,
+        "image_size_wh": None,
+        "pre_processing_overrides": None,
+    }
+    bound.update(dict(zip(names, args)))
+    bound.update(kwargs)
+    missing = [
+        name
+        for name in ("images", "image_pre_processing", "network_input", "target_device")
+        if name not in bound
+    ]
+    if missing:
+        raise RuntimeError(f"Cannot capture target call; missing args: {missing}")
+    return {name: bound[name] for name in names}
+
+
+def _write_pickle(path: Path, payload: dict) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("wb") as f:
+        pickle.dump(payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+    os.replace(tmp_path, path)
+
+
+class _CaptureState:
+    def __init__(self, cases_dir: Path, limit: int) -> None:
+        self.cases_dir = cases_dir
+        self.limit = limit
+        self.count = 0
+        self.lock = threading.Lock()
+
+    def maybe_save(self, inputs: dict, output: Tuple[torch.Tensor, List[Any]]) -> None:
+        with self.lock:
+            if self.count >= self.limit:
+                return
+            case_index = self.count
+            payload = {
+                "schema_version": _SCHEMA_VERSION,
+                "case_index": case_index,
+                "inputs": _snapshot_inputs(**inputs),
+                "expected_output": _snapshot_output(output),
+            }
+            _write_pickle(self.cases_dir / f"case_{case_index:04d}.pkl", payload)
+            self.count += 1
+            if self.count == 1 or self.count % 10 == 0 or self.count == self.limit:
+                print(
+                    f"[capture] saved {self.count}/{self.limit} preprocess calls",
+                    flush=True,
+                )
+
+
+def _install_capture_hook(state: _CaptureState) -> None:
+    _ensure_local_import_paths()
+    from inference_models.models.rfdetr import pre_processing as rfdetr_pre_processing
+
+    original = getattr(rfdetr_pre_processing, _TARGET_FUNCTION)
+
+    @functools.wraps(original)
+    def wrapper(*args: Any, **kwargs: Any) -> Tuple[torch.Tensor, List[Any]]:
+        result = original(*args, **kwargs)
+        state.maybe_save(inputs=_bind_target_arguments(args, kwargs), output=result)
+        return result
+
+    setattr(rfdetr_pre_processing, _TARGET_FUNCTION, wrapper)
+    for module_name in (
+        "inference_models.models.rfdetr.rfdetr_instance_segmentation_trt",
+        "inference_models.models.rfdetr.rfdetr_instance_segmentation_onnx",
+        "inference_models.models.rfdetr.rfdetr_instance_segmentation_pytorch",
+        "inference_models.models.rfdetr.rfdetr_object_detection_trt",
+        "inference_models.models.rfdetr.rfdetr_object_detection_onnx",
+        "inference_models.models.rfdetr.rfdetr_object_detection_pytorch",
+    ):
+        module = sys.modules.get(module_name)
+        if module is not None and hasattr(module, _TARGET_FUNCTION):
+            setattr(module, _TARGET_FUNCTION, wrapper)
+
+
+def _prepare_cases_dir(cases_dir: Path, overwrite: bool) -> None:
+    cases_dir.mkdir(parents=True, exist_ok=True)
+    existing = list(cases_dir.glob("case_*.pkl"))
+    manifest_path = cases_dir / "manifest.json"
+    if not overwrite and (existing or manifest_path.exists()):
+        raise RuntimeError(
+            f"{cases_dir} already contains captured cases; pass --overwrite "
+            "or choose a different --cases-dir."
+        )
+    if overwrite:
+        for path in existing:
+            path.unlink()
+        if manifest_path.exists():
+            manifest_path.unlink()
+
+
+def _write_manifest(cases_dir: Path, payload: dict) -> None:
+    with (cases_dir / "manifest.json").open("w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def _run_capture(args: argparse.Namespace) -> int:
+    if args.force_reference_preprocess:
+        os.environ[_FORCED_PREPROC_ENV] = "false"
+
+    cases_dir = args.cases_dir.resolve()
+    _prepare_cases_dir(cases_dir=cases_dir, overwrite=args.overwrite)
+
+    workflow = _load_workflow_module()
+    model_id = workflow._resolve_model_id(args.model_id, args.backend)
+    workflow._prepare_local_workflow_model_bundle(model_id)
+    if model_id != args.model_id:
+        print(
+            f"[model] using local TRT package via workflow model id: {model_id}",
+            flush=True,
+        )
+
+    state = _CaptureState(cases_dir=cases_dir, limit=args.capture_count)
+    _install_capture_hook(state=state)
+
+    frame_count = 0
+    start_time: Optional[float] = None
+    pipeline_ref: Dict[str, Any] = {}
+
+    def sink(predictions: Any, video_frames: Any) -> None:
+        nonlocal frame_count, start_time
+        del video_frames
+        if not isinstance(predictions, list):
+            predictions = [predictions]
+        frame_count += sum(p is not None for p in predictions)
+        if start_time is None:
+            start_time = perf_counter()
+        if frame_count % args.progress_every == 0:
+            elapsed = perf_counter() - start_time
+            fps = frame_count / elapsed if elapsed > 0 else 0.0
+            print(
+                f"[progress] frames={frame_count} fps={fps:.2f} "
+                f"captures={state.count}/{state.limit}",
+                flush=True,
+            )
+        if state.count >= state.limit and "pipeline" in pipeline_ref:
+            pipeline_ref["pipeline"].terminate()
+
+    pipeline = workflow.InferencePipeline.init_with_workflow(
+        video_reference=args.video_reference,
+        workflow_specification=workflow.build_workflow(model_id, args.confidence),
+        on_prediction=sink,
+    )
+    pipeline_ref["pipeline"] = pipeline
+    pipeline.start()
+    pipeline.join()
+
+    if state.count < args.capture_count:
+        raise RuntimeError(
+            f"Captured only {state.count}/{args.capture_count} invocations. "
+            "Use a longer video or lower --capture-count."
+        )
+
+    elapsed = perf_counter() - start_time if start_time else 0.0
+    _write_manifest(
+        cases_dir=cases_dir,
+        payload={
+            "schema_version": _SCHEMA_VERSION,
+            "function": (
+                "inference_models.models.rfdetr.pre_processing."
+                "pre_process_network_input"
+            ),
+            "case_count": state.count,
+            "video_reference": args.video_reference,
+            "backend": args.backend,
+            "model_id": model_id,
+            "confidence": args.confidence,
+            "frames_seen_by_sink": frame_count,
+            "capture_elapsed_seconds": elapsed,
+            "created_at_unix": time(),
+            "forced_env": (
+                f"{_FORCED_PREPROC_ENV}=false"
+                if args.force_reference_preprocess
+                else None
+            ),
+        },
+    )
+    print(f"[capture] wrote {state.count} cases to {cases_dir}", flush=True)
+    return state.count
+
+
+def _resolve_device(device: str, captured: str) -> torch.device:
+    if device == "captured":
+        return torch.device(captured)
+    if device == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    resolved = torch.device(device)
+    if resolved.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("--device cuda requested, but CUDA is not available")
+    return resolved
+
+
+def _materialize_inputs(case: dict, device_override: str) -> dict:
+    inputs = case["inputs"]
+    target_device = _resolve_device(
+        device=device_override,
+        captured=inputs["target_device"],
+    )
+    return {
+        "images": _materialize_images(inputs["images"], device=target_device),
+        "image_pre_processing": inputs["image_pre_processing"],
+        "network_input": inputs["network_input"],
+        "target_device": target_device,
+        "input_color_format": inputs["input_color_format"],
+        "image_size_wh": inputs["image_size_wh"],
+        "pre_processing_overrides": inputs["pre_processing_overrides"],
+    }
+
+
+def _run_triton_fast_preprocess(inputs: dict) -> Tuple[torch.Tensor, List[Any]]:
+    from inference_models.models.rfdetr import triton_preprocess_runtime
+    from inference_models.models.rfdetr.triton_preprocess_runtime import (
+        FastPreprocessRuntime,
+    )
+
+    target_device = inputs["target_device"]
+    if target_device.type != "cuda":
+        raise RuntimeError(
+            f"Triton replay requires CUDA target_device, got {target_device}"
+        )
+
+    # Capture may have forced the environment flag off in this process. Replay
+    # mode is an explicit request to exercise the Triton path, so force the
+    # runtime gate on while still using the production runtime helper.
+    triton_preprocess_runtime._FAST_PATH_ENABLED = True
+
+    runtime_state = _TRITON_REPLAY_RUNTIMES.get(str(target_device))
+    if runtime_state is None:
+        runtime_state = (
+            FastPreprocessRuntime(device=target_device),
+            torch.cuda.Stream(device=target_device),
+        )
+        _TRITON_REPLAY_RUNTIMES[str(target_device)] = runtime_state
+    runtime, stream = runtime_state
+
+    result = runtime.try_preprocess(
+        images=inputs["images"],
+        input_color_format=inputs["input_color_format"],
+        image_size=inputs["image_size_wh"],
+        image_pre_processing=inputs["image_pre_processing"],
+        network_input=inputs["network_input"],
+        stream=stream,
+    )
+    if result is None:
+        raise RuntimeError(
+            "Captured preprocess case is not supported by FastPreprocessRuntime; "
+            "run replay with --replay-implementation reference to benchmark the "
+            "reference path."
+        )
+    return result.tensor, result.metadata
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _load_case(path: Path) -> dict:
+    with path.open("rb") as f:
+        payload = pickle.load(f)
+    if payload.get("schema_version") != _SCHEMA_VERSION:
+        raise RuntimeError(
+            f"{path} has schema_version={payload.get('schema_version')}; "
+            f"expected {_SCHEMA_VERSION}."
+        )
+    return payload
+
+
+def _assert_tensor_equal(
+    *,
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    label: str,
+    atol: float,
+    rtol: float,
+) -> None:
+    actual_cpu = actual.detach().cpu()
+    if torch.is_floating_point(actual_cpu) and (atol != 0.0 or rtol != 0.0):
+        equal = torch.allclose(actual_cpu, expected, atol=atol, rtol=rtol)
+    else:
+        equal = torch.equal(actual_cpu, expected)
+    if not equal:
+        max_abs = (
+            (actual_cpu - expected).abs().max().item()
+            if actual_cpu.shape == expected.shape
+            else None
+        )
+        raise AssertionError(
+            f"{label} differs: actual shape={tuple(actual_cpu.shape)} "
+            f"expected shape={tuple(expected.shape)} max_abs_diff={max_abs}"
+        )
+
+
+def _assert_outputs_equal(
+    *,
+    actual: Tuple[torch.Tensor, List[Any]],
+    expected: dict,
+    case_index: int,
+    atol: float,
+    rtol: float,
+) -> None:
+    actual_tensor, actual_metadata = actual
+    _assert_tensor_equal(
+        actual=actual_tensor,
+        expected=expected["tensor"],
+        label=f"case {case_index} tensor",
+        atol=atol,
+        rtol=rtol,
+    )
+    if list(actual_metadata) != list(expected["metadata"]):
+        raise AssertionError(f"case {case_index} metadata differs")
+
+
+def _run_one_replay_case(
+    *,
+    case_path: Path,
+    device_override: str,
+    implementation: str,
+    atol: float,
+    rtol: float,
+) -> float:
+    from inference_models.models.rfdetr.pre_processing import pre_process_network_input
+
+    case = _load_case(case_path)
+    inputs = _materialize_inputs(case=case, device_override=device_override)
+    _synchronize(inputs["target_device"])
+    start = perf_counter()
+    if implementation == "reference":
+        actual = pre_process_network_input(**inputs)
+    elif implementation == "triton":
+        actual = _run_triton_fast_preprocess(inputs)
+    else:
+        raise RuntimeError(f"Unknown replay implementation: {implementation}")
+    _synchronize(inputs["target_device"])
+    elapsed = perf_counter() - start
+    _assert_outputs_equal(
+        actual=actual,
+        expected=case["expected_output"],
+        case_index=case["case_index"],
+        atol=atol,
+        rtol=rtol,
+    )
+    return elapsed
+
+
+def _summarize_timings(timings: List[float]) -> dict:
+    sorted_timings = sorted(timings)
+    total = sum(sorted_timings)
+    count = len(sorted_timings)
+
+    def percentile(p: float) -> float:
+        if count == 0:
+            return 0.0
+        index = min(count - 1, int(round((count - 1) * p)))
+        return sorted_timings[index]
+
+    return {
+        "count": count,
+        "total_seconds": total,
+        "mean_ms": (total / count) * 1000 if count else 0.0,
+        "min_ms": sorted_timings[0] * 1000 if count else 0.0,
+        "p50_ms": percentile(0.50) * 1000,
+        "p90_ms": percentile(0.90) * 1000,
+        "p99_ms": percentile(0.99) * 1000,
+        "max_ms": sorted_timings[-1] * 1000 if count else 0.0,
+    }
+
+
+def _print_timing_summary(summary: dict) -> None:
+    print(
+        "[replay] "
+        f"calls={summary['count']} "
+        f"total={summary['total_seconds']:.3f}s "
+        f"mean={summary['mean_ms']:.3f}ms "
+        f"p50={summary['p50_ms']:.3f}ms "
+        f"p90={summary['p90_ms']:.3f}ms "
+        f"p99={summary['p99_ms']:.3f}ms "
+        f"min={summary['min_ms']:.3f}ms "
+        f"max={summary['max_ms']:.3f}ms",
+        flush=True,
+    )
+
+
+def _run_replay(args: argparse.Namespace) -> dict:
+    _ensure_local_import_paths()
+    cases_dir = args.cases_dir.resolve()
+    case_paths = sorted(cases_dir.glob("case_*.pkl"))
+    if args.max_cases is not None:
+        case_paths = case_paths[: args.max_cases]
+    if not case_paths:
+        raise RuntimeError(f"No case_*.pkl files found in {cases_dir}")
+
+    print(
+        f"[replay] cases={len(case_paths)} repeats={args.repeats} "
+        f"warmup_repeats={args.warmup_repeats} device={args.device} "
+        f"implementation={args.replay_implementation}",
+        flush=True,
+    )
+    for _ in range(args.warmup_repeats):
+        for case_path in case_paths:
+            _run_one_replay_case(
+                case_path=case_path,
+                device_override=args.device,
+                implementation=args.replay_implementation,
+                atol=args.atol,
+                rtol=args.rtol,
+            )
+
+    timings = []
+    for repeat_index in range(args.repeats):
+        for case_path in case_paths:
+            timings.append(
+                _run_one_replay_case(
+                    case_path=case_path,
+                    device_override=args.device,
+                    implementation=args.replay_implementation,
+                    atol=args.atol,
+                    rtol=args.rtol,
+                )
+            )
+        print(
+            f"[replay] completed repeat {repeat_index + 1}/{args.repeats}",
+            flush=True,
+        )
+
+    summary = _summarize_timings(timings)
+    _print_timing_summary(summary)
+    print("[replay] all outputs matched captured e2e outputs", flush=True)
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("capture", "replay", "capture-and-replay"),
+        default="capture-and-replay",
+    )
+    parser.add_argument("--video_reference", default="vehicles_1080p.mp4")
+    parser.add_argument("--model_id", default="rfdetr-seg-nano")
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument("--backend", choices=("trt", "onnx", "torch"), default="trt")
+    parser.add_argument(
+        "--cases-dir",
+        type=Path,
+        default=Path("temp/rfdetr_preprocess_cases"),
+    )
+    parser.add_argument("--capture-count", type=int, default=100)
+    parser.add_argument("--progress-every", type=int, default=50)
+    parser.add_argument(
+        "--overwrite",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument(
+        "--force-reference-preprocess",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Set INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=false before "
+            "loading the workflow so pre_process_network_input is called."
+        ),
+    )
+    parser.add_argument(
+        "--device",
+        default="captured",
+        help="'captured', 'auto', 'cpu', or a torch device string used on replay.",
+    )
+    parser.add_argument(
+        "--replay-implementation",
+        choices=("reference", "triton"),
+        default="reference",
+        help="Implementation used by replay; capture always hooks pre_process_network_input.",
+    )
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--warmup-repeats", type=int, default=0)
+    parser.add_argument("--max-cases", type=int, default=None)
+    parser.add_argument("--atol", type=float, default=0.0)
+    parser.add_argument("--rtol", type=float, default=0.0)
+    args = parser.parse_args()
+    if args.capture_count <= 0:
+        raise ValueError("--capture-count must be positive")
+    if args.repeats <= 0:
+        raise ValueError("--repeats must be positive")
+    if args.warmup_repeats < 0:
+        raise ValueError("--warmup-repeats must be non-negative")
+    if args.progress_every <= 0:
+        raise ValueError("--progress-every must be positive")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.mode in {"capture", "capture-and-replay"}:
+        _run_capture(args=args)
+    if args.mode in {"replay", "capture-and-replay"}:
+        _run_replay(args=args)
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/rfdetr_rle_postprocess_microbenchmark.py
+++ b/development/stream_interface/rfdetr_rle_postprocess_microbenchmark.py
@@ -1,0 +1,622 @@
+"""Capture/replay benchmark for RF-DETR RLE instance-segmentation postprocess.
+
+Default usage captures 100 invocations from the e2e workflow and immediately
+replays them:
+
+    python development/stream_interface/rfdetr_rle_postprocess_microbenchmark.py \
+        --video_reference vehicles_1080p.mp4
+
+Replay-only usage:
+
+    python development/stream_interface/rfdetr_rle_postprocess_microbenchmark.py \
+        --mode replay --cases-dir temp/rfdetr_rle_postprocess_cases
+"""
+
+import argparse
+import functools
+import importlib.util
+import json
+import os
+from pathlib import Path
+import pickle
+import sys
+import threading
+from time import perf_counter, time
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFERENCE_MODELS_ROOT = _REPO_ROOT / "inference_models"
+_WORKFLOW_PATH = (
+    _REPO_ROOT / "development" / "stream_interface" / "rfdetr_nano_seg_trt_workflow.py"
+)
+_TARGET_FUNCTION = "post_process_instance_segmentation_results_to_rle_masks"
+_SCHEMA_VERSION = 1
+
+
+def _ensure_local_import_paths() -> None:
+    for path in (str(_INFERENCE_MODELS_ROOT), str(_REPO_ROOT)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def _load_workflow_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "rfdetr_nano_seg_trt_workflow_for_microbenchmark",
+        _WORKFLOW_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load workflow module from {_WORKFLOW_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _tensor_to_cpu(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.detach().cpu().clone()
+
+
+def _threshold_to_cpu(
+    threshold: Union[float, torch.Tensor],
+) -> Union[float, torch.Tensor]:
+    if isinstance(threshold, torch.Tensor):
+        return _tensor_to_cpu(threshold)
+    return threshold
+
+
+def _classes_re_mapping_to_cpu(classes_re_mapping: Optional[Any]) -> Optional[dict]:
+    if classes_re_mapping is None:
+        return None
+    return {
+        "remaining_class_ids": _tensor_to_cpu(classes_re_mapping.remaining_class_ids),
+        "class_mapping": _tensor_to_cpu(classes_re_mapping.class_mapping),
+    }
+
+
+def _snapshot_inputs(
+    *,
+    bboxes: torch.Tensor,
+    logits: torch.Tensor,
+    masks: torch.Tensor,
+    pre_processing_meta: List[Any],
+    threshold: Union[float, torch.Tensor],
+    num_classes: int,
+    classes_re_mapping: Optional[Any],
+) -> dict:
+    return {
+        "bboxes": _tensor_to_cpu(bboxes),
+        "logits": _tensor_to_cpu(logits),
+        "masks": _tensor_to_cpu(masks),
+        "pre_processing_meta": pre_processing_meta,
+        "threshold": _threshold_to_cpu(threshold),
+        "num_classes": num_classes,
+        "classes_re_mapping": _classes_re_mapping_to_cpu(classes_re_mapping),
+    }
+
+
+def _snapshot_mask(mask: Any) -> dict:
+    if isinstance(mask, torch.Tensor):
+        return {"kind": "dense", "tensor": _tensor_to_cpu(mask)}
+    return {
+        "kind": "rle",
+        "image_size": tuple(mask.image_size),
+        "masks": list(mask.masks),
+    }
+
+
+def _snapshot_output(output: List[Any]) -> List[dict]:
+    return [
+        {
+            "xyxy": _tensor_to_cpu(detection.xyxy),
+            "class_id": _tensor_to_cpu(detection.class_id),
+            "confidence": _tensor_to_cpu(detection.confidence),
+            "mask": _snapshot_mask(detection.mask),
+            "image_metadata": detection.image_metadata,
+            "bboxes_metadata": detection.bboxes_metadata,
+        }
+        for detection in output
+    ]
+
+
+def _bind_target_arguments(args: tuple, kwargs: dict) -> dict:
+    names = (
+        "bboxes",
+        "logits",
+        "masks",
+        "pre_processing_meta",
+        "threshold",
+        "num_classes",
+        "classes_re_mapping",
+    )
+    bound = dict(zip(names, args))
+    bound.update(kwargs)
+    missing = [name for name in names if name not in bound]
+    if missing:
+        raise RuntimeError(f"Cannot capture target call; missing args: {missing}")
+    return {name: bound[name] for name in names}
+
+
+def _write_pickle(path: Path, payload: dict) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("wb") as f:
+        pickle.dump(payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+    os.replace(tmp_path, path)
+
+
+class _CaptureState:
+    def __init__(self, cases_dir: Path, limit: int) -> None:
+        self.cases_dir = cases_dir
+        self.limit = limit
+        self.count = 0
+        self.lock = threading.Lock()
+
+    def maybe_save(self, inputs: dict, output: List[Any]) -> None:
+        with self.lock:
+            if self.count >= self.limit:
+                return
+            case_index = self.count
+            payload = {
+                "schema_version": _SCHEMA_VERSION,
+                "case_index": case_index,
+                "inputs": _snapshot_inputs(**inputs),
+                "expected_output": _snapshot_output(output),
+            }
+            _write_pickle(
+                self.cases_dir / f"case_{case_index:04d}.pkl",
+                payload,
+            )
+            self.count += 1
+            if self.count == 1 or self.count % 10 == 0 or self.count == self.limit:
+                print(
+                    f"[capture] saved {self.count}/{self.limit} postprocess calls",
+                    flush=True,
+                )
+
+
+def _install_capture_hook(state: _CaptureState) -> None:
+    _ensure_local_import_paths()
+    from inference_models.models.rfdetr import common as rfdetr_common
+
+    original = getattr(rfdetr_common, _TARGET_FUNCTION)
+
+    @functools.wraps(original)
+    def wrapper(*args: Any, **kwargs: Any) -> List[Any]:
+        result = original(*args, **kwargs)
+        state.maybe_save(inputs=_bind_target_arguments(args, kwargs), output=result)
+        return result
+
+    setattr(rfdetr_common, _TARGET_FUNCTION, wrapper)
+    for module_name in (
+        "inference_models.models.rfdetr.rfdetr_instance_segmentation_trt",
+        "inference_models.models.rfdetr.rfdetr_instance_segmentation_onnx",
+        "inference_models.models.rfdetr.rfdetr_instance_segmentation_pytorch",
+    ):
+        module = sys.modules.get(module_name)
+        if module is not None and hasattr(module, _TARGET_FUNCTION):
+            setattr(module, _TARGET_FUNCTION, wrapper)
+
+
+def _prepare_cases_dir(cases_dir: Path, overwrite: bool) -> None:
+    cases_dir.mkdir(parents=True, exist_ok=True)
+    existing = list(cases_dir.glob("case_*.pkl"))
+    manifest_path = cases_dir / "manifest.json"
+    if not overwrite and (existing or manifest_path.exists()):
+        raise RuntimeError(
+            f"{cases_dir} already contains captured cases; pass --overwrite "
+            "or choose a different --cases-dir."
+        )
+    if overwrite:
+        for path in existing:
+            path.unlink()
+        if manifest_path.exists():
+            manifest_path.unlink()
+
+
+def _write_manifest(cases_dir: Path, payload: dict) -> None:
+    with (cases_dir / "manifest.json").open("w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def _run_capture(args: argparse.Namespace) -> int:
+    cases_dir = args.cases_dir.resolve()
+    _prepare_cases_dir(cases_dir=cases_dir, overwrite=args.overwrite)
+
+    workflow = _load_workflow_module()
+    model_id = workflow._resolve_model_id(args.model_id, args.backend)
+    workflow._prepare_local_workflow_model_bundle(model_id)
+    if model_id != args.model_id:
+        print(
+            f"[model] using local TRT package via workflow model id: {model_id}",
+            flush=True,
+        )
+
+    state = _CaptureState(cases_dir=cases_dir, limit=args.capture_count)
+    _install_capture_hook(state=state)
+
+    frame_count = 0
+    start_time: Optional[float] = None
+    pipeline_ref: Dict[str, Any] = {}
+
+    def sink(predictions: Any, video_frames: Any) -> None:
+        nonlocal frame_count, start_time
+        del video_frames
+        if not isinstance(predictions, list):
+            predictions = [predictions]
+        frame_count += sum(p is not None for p in predictions)
+        if start_time is None:
+            start_time = perf_counter()
+        if frame_count % args.progress_every == 0:
+            elapsed = perf_counter() - start_time
+            fps = frame_count / elapsed if elapsed > 0 else 0.0
+            print(
+                f"[progress] frames={frame_count} fps={fps:.2f} "
+                f"captures={state.count}/{state.limit}",
+                flush=True,
+            )
+        if state.count >= state.limit and "pipeline" in pipeline_ref:
+            pipeline_ref["pipeline"].terminate()
+
+    pipeline = workflow.InferencePipeline.init_with_workflow(
+        video_reference=args.video_reference,
+        workflow_specification=workflow.build_workflow(model_id, args.confidence),
+        on_prediction=sink,
+    )
+    pipeline_ref["pipeline"] = pipeline
+    pipeline.start()
+    pipeline.join()
+
+    if state.count < args.capture_count:
+        raise RuntimeError(
+            f"Captured only {state.count}/{args.capture_count} invocations. "
+            "Use a longer video or lower --capture-count."
+        )
+
+    elapsed = perf_counter() - start_time if start_time else 0.0
+    _write_manifest(
+        cases_dir=cases_dir,
+        payload={
+            "schema_version": _SCHEMA_VERSION,
+            "function": (
+                "inference_models.models.rfdetr.common."
+                "post_process_instance_segmentation_results_to_rle_masks"
+            ),
+            "case_count": state.count,
+            "video_reference": args.video_reference,
+            "backend": args.backend,
+            "model_id": model_id,
+            "confidence": args.confidence,
+            "frames_seen_by_sink": frame_count,
+            "capture_elapsed_seconds": elapsed,
+            "created_at_unix": time(),
+        },
+    )
+    print(f"[capture] wrote {state.count} cases to {cases_dir}", flush=True)
+    return state.count
+
+
+def _resolve_device(device: str) -> torch.device:
+    if device == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    resolved = torch.device(device)
+    if resolved.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("--device cuda requested, but CUDA is not available")
+    return resolved
+
+
+def _to_device(value: Union[float, torch.Tensor], device: torch.device) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.to(device=device).clone()
+    return value
+
+
+def _classes_re_mapping_to_device(
+    payload: Optional[dict], device: torch.device
+) -> Optional[Any]:
+    if payload is None:
+        return None
+    from inference_models.models.rfdetr.class_remapping import ClassesReMapping
+
+    return ClassesReMapping(
+        remaining_class_ids=payload["remaining_class_ids"].to(device=device).clone(),
+        class_mapping=payload["class_mapping"].to(device=device).clone(),
+    )
+
+
+def _materialize_inputs(case: dict, device: torch.device) -> dict:
+    inputs = case["inputs"]
+    return {
+        "bboxes": inputs["bboxes"].to(device=device).clone(),
+        "logits": inputs["logits"].to(device=device).clone(),
+        "masks": inputs["masks"].to(device=device).clone(),
+        "pre_processing_meta": inputs["pre_processing_meta"],
+        "threshold": _to_device(inputs["threshold"], device=device),
+        "num_classes": inputs["num_classes"],
+        "classes_re_mapping": _classes_re_mapping_to_device(
+            inputs["classes_re_mapping"],
+            device=device,
+        ),
+    }
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _load_case(path: Path) -> dict:
+    with path.open("rb") as f:
+        payload = pickle.load(f)
+    if payload.get("schema_version") != _SCHEMA_VERSION:
+        raise RuntimeError(
+            f"{path} has schema_version={payload.get('schema_version')}; "
+            f"expected {_SCHEMA_VERSION}."
+        )
+    return payload
+
+
+def _assert_tensor_equal(
+    *,
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    label: str,
+    atol: float,
+    rtol: float,
+) -> None:
+    actual_cpu = actual.detach().cpu()
+    if torch.is_floating_point(actual_cpu) and (atol != 0.0 or rtol != 0.0):
+        equal = torch.allclose(actual_cpu, expected, atol=atol, rtol=rtol)
+    else:
+        equal = torch.equal(actual_cpu, expected)
+    if not equal:
+        raise AssertionError(
+            f"{label} differs: actual shape={tuple(actual_cpu.shape)} "
+            f"expected shape={tuple(expected.shape)}"
+        )
+
+
+def _assert_mask_equal(
+    *,
+    actual: Any,
+    expected: dict,
+    label: str,
+    atol: float,
+    rtol: float,
+) -> None:
+    if expected["kind"] == "dense":
+        if not isinstance(actual, torch.Tensor):
+            raise AssertionError(f"{label} expected dense tensor mask")
+        _assert_tensor_equal(
+            actual=actual,
+            expected=expected["tensor"],
+            label=f"{label}.tensor",
+            atol=atol,
+            rtol=rtol,
+        )
+        return
+    if isinstance(actual, torch.Tensor):
+        raise AssertionError(f"{label} expected RLE mask")
+    if tuple(actual.image_size) != tuple(expected["image_size"]):
+        raise AssertionError(
+            f"{label}.image_size differs: {actual.image_size} != "
+            f"{expected['image_size']}"
+        )
+    if list(actual.masks) != list(expected["masks"]):
+        raise AssertionError(f"{label}.masks differ")
+
+
+def _assert_outputs_equal(
+    *,
+    actual: List[Any],
+    expected: List[dict],
+    case_index: int,
+    atol: float,
+    rtol: float,
+) -> None:
+    if len(actual) != len(expected):
+        raise AssertionError(
+            f"case {case_index}: output length differs: "
+            f"{len(actual)} != {len(expected)}"
+        )
+    for output_index, (actual_detection, expected_detection) in enumerate(
+        zip(actual, expected)
+    ):
+        label = f"case {case_index} output {output_index}"
+        _assert_tensor_equal(
+            actual=actual_detection.xyxy,
+            expected=expected_detection["xyxy"],
+            label=f"{label}.xyxy",
+            atol=atol,
+            rtol=rtol,
+        )
+        _assert_tensor_equal(
+            actual=actual_detection.class_id,
+            expected=expected_detection["class_id"],
+            label=f"{label}.class_id",
+            atol=atol,
+            rtol=rtol,
+        )
+        _assert_tensor_equal(
+            actual=actual_detection.confidence,
+            expected=expected_detection["confidence"],
+            label=f"{label}.confidence",
+            atol=atol,
+            rtol=rtol,
+        )
+        _assert_mask_equal(
+            actual=actual_detection.mask,
+            expected=expected_detection["mask"],
+            label=f"{label}.mask",
+            atol=atol,
+            rtol=rtol,
+        )
+        if actual_detection.image_metadata != expected_detection["image_metadata"]:
+            raise AssertionError(f"{label}.image_metadata differs")
+        if actual_detection.bboxes_metadata != expected_detection["bboxes_metadata"]:
+            raise AssertionError(f"{label}.bboxes_metadata differs")
+
+
+def _run_one_replay_case(
+    *,
+    case_path: Path,
+    device: torch.device,
+    atol: float,
+    rtol: float,
+) -> float:
+    from inference_models.models.rfdetr.common import (
+        post_process_instance_segmentation_results_to_rle_masks,
+    )
+
+    case = _load_case(case_path)
+    inputs = _materialize_inputs(case=case, device=device)
+    _synchronize(device)
+    start = perf_counter()
+    actual = post_process_instance_segmentation_results_to_rle_masks(**inputs)
+    _synchronize(device)
+    elapsed = perf_counter() - start
+    _assert_outputs_equal(
+        actual=actual,
+        expected=case["expected_output"],
+        case_index=case["case_index"],
+        atol=atol,
+        rtol=rtol,
+    )
+    return elapsed
+
+
+def _summarize_timings(timings: List[float]) -> dict:
+    sorted_timings = sorted(timings)
+    total = sum(sorted_timings)
+    count = len(sorted_timings)
+
+    def percentile(p: float) -> float:
+        if count == 0:
+            return 0.0
+        index = min(count - 1, int(round((count - 1) * p)))
+        return sorted_timings[index]
+
+    return {
+        "count": count,
+        "total_seconds": total,
+        "mean_ms": (total / count) * 1000 if count else 0.0,
+        "min_ms": sorted_timings[0] * 1000 if count else 0.0,
+        "p50_ms": percentile(0.50) * 1000,
+        "p90_ms": percentile(0.90) * 1000,
+        "p99_ms": percentile(0.99) * 1000,
+        "max_ms": sorted_timings[-1] * 1000 if count else 0.0,
+    }
+
+
+def _print_timing_summary(summary: dict) -> None:
+    print(
+        "[replay] "
+        f"calls={summary['count']} "
+        f"total={summary['total_seconds']:.3f}s "
+        f"mean={summary['mean_ms']:.3f}ms "
+        f"p50={summary['p50_ms']:.3f}ms "
+        f"p90={summary['p90_ms']:.3f}ms "
+        f"p99={summary['p99_ms']:.3f}ms "
+        f"min={summary['min_ms']:.3f}ms "
+        f"max={summary['max_ms']:.3f}ms",
+        flush=True,
+    )
+
+
+def _run_replay(args: argparse.Namespace) -> dict:
+    _ensure_local_import_paths()
+    device = _resolve_device(args.device)
+    cases_dir = args.cases_dir.resolve()
+    case_paths = sorted(cases_dir.glob("case_*.pkl"))
+    if args.max_cases is not None:
+        case_paths = case_paths[: args.max_cases]
+    if not case_paths:
+        raise RuntimeError(f"No case_*.pkl files found in {cases_dir}")
+
+    print(
+        f"[replay] cases={len(case_paths)} repeats={args.repeats} "
+        f"warmup_repeats={args.warmup_repeats} device={device}",
+        flush=True,
+    )
+    for _ in range(args.warmup_repeats):
+        for case_path in case_paths:
+            _run_one_replay_case(
+                case_path=case_path,
+                device=device,
+                atol=args.atol,
+                rtol=args.rtol,
+            )
+
+    timings = []
+    for repeat_index in range(args.repeats):
+        for case_path in case_paths:
+            timings.append(
+                _run_one_replay_case(
+                    case_path=case_path,
+                    device=device,
+                    atol=args.atol,
+                    rtol=args.rtol,
+                )
+            )
+        print(
+            f"[replay] completed repeat {repeat_index + 1}/{args.repeats}",
+            flush=True,
+        )
+
+    summary = _summarize_timings(timings)
+    _print_timing_summary(summary)
+    print("[replay] all outputs matched captured e2e outputs", flush=True)
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("capture", "replay", "capture-and-replay"),
+        default="capture-and-replay",
+    )
+    parser.add_argument("--video_reference", default="vehicles_1080p.mp4")
+    parser.add_argument("--model_id", default="rfdetr-seg-nano")
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument("--backend", choices=("trt", "onnx", "torch"), default="trt")
+    parser.add_argument(
+        "--cases-dir",
+        type=Path,
+        default=Path("temp/rfdetr_rle_postprocess_cases"),
+    )
+    parser.add_argument("--capture-count", type=int, default=100)
+    parser.add_argument("--progress-every", type=int, default=50)
+    parser.add_argument(
+        "--overwrite",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument("--device", default="auto")
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--warmup-repeats", type=int, default=0)
+    parser.add_argument("--max-cases", type=int, default=None)
+    parser.add_argument("--atol", type=float, default=0.0)
+    parser.add_argument("--rtol", type=float, default=0.0)
+    args = parser.parse_args()
+    if args.capture_count <= 0:
+        raise ValueError("--capture-count must be positive")
+    if args.repeats <= 0:
+        raise ValueError("--repeats must be positive")
+    if args.warmup_repeats < 0:
+        raise ValueError("--warmup-repeats must be non-negative")
+    if args.progress_every <= 0:
+        raise ValueError("--progress-every must be positive")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.mode in {"capture", "capture-and-replay"}:
+        _run_capture(args=args)
+    if args.mode in {"replay", "capture-and-replay"}:
+        _run_replay(args=args)
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/rfdetr_rle_to_poly_microbenchmark.py
+++ b/development/stream_interface/rfdetr_rle_to_poly_microbenchmark.py
@@ -1,0 +1,445 @@
+"""Capture/replay benchmark for RF-DETR RLE-to-polygon conversion.
+
+This targets the CPU path in
+``inference.core.utils.rle_to_polygon.rle_masks_to_polygons``:
+
+    COCO RLE counts -> sparse crop -> cv2.findContours -> polygon arrays
+
+Default usage captures 100 invocations from the 1080p workflow and immediately
+replays them with exact output checks:
+
+    python development/stream_interface/rfdetr_rle_to_poly_microbenchmark.py \
+        --video_reference vehicles_1080p.mp4
+
+Replay-only usage:
+
+    python development/stream_interface/rfdetr_rle_to_poly_microbenchmark.py \
+        --mode replay --cases-dir temp/rfdetr_rle_to_poly_cases
+"""
+
+import argparse
+import functools
+import importlib.util
+import json
+import os
+from pathlib import Path
+import pickle
+import sys
+import threading
+from time import perf_counter, time
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFERENCE_MODELS_ROOT = _REPO_ROOT / "inference_models"
+_WORKFLOW_PATH = (
+    _REPO_ROOT / "development" / "stream_interface" / "rfdetr_nano_seg_trt_workflow.py"
+)
+_TARGET_FUNCTION = "rle_masks_to_polygons"
+_SCHEMA_VERSION = 1
+
+
+def _ensure_local_import_paths() -> None:
+    for path in (str(_INFERENCE_MODELS_ROOT), str(_REPO_ROOT)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def _load_workflow_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "rfdetr_nano_seg_trt_workflow_for_rle_to_poly_microbenchmark",
+        _WORKFLOW_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load workflow module from {_WORKFLOW_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _snapshot_masks(masks: Any) -> dict:
+    snapshot = {
+        "image_size": tuple(masks.image_size),
+        "masks": list(masks.masks),
+        "mask_count": len(masks.masks),
+    }
+    counts = getattr(masks, "_rle_counts_cpu", None)
+    lengths = getattr(masks, "_rle_lengths_cpu", None)
+    if counts is not None and lengths is not None:
+        snapshot["rle_counts_cpu"] = np.array(counts, copy=True)
+        snapshot["rle_lengths_cpu"] = np.array(lengths, copy=True)
+    return snapshot
+
+
+def _snapshot_output(output: List[np.ndarray]) -> List[np.ndarray]:
+    return [np.array(poly, copy=True) for poly in output]
+
+
+def _write_pickle(path: Path, payload: dict) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("wb") as f:
+        pickle.dump(payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+    os.replace(tmp_path, path)
+
+
+class _CaptureState:
+    def __init__(self, cases_dir: Path, limit: int) -> None:
+        self.cases_dir = cases_dir
+        self.limit = limit
+        self.count = 0
+        self.total_masks = 0
+        self.lock = threading.Lock()
+
+    def maybe_save(self, masks: Any, output: List[np.ndarray]) -> None:
+        with self.lock:
+            if self.count >= self.limit:
+                return
+            case_index = self.count
+            mask_snapshot = _snapshot_masks(masks=masks)
+            payload = {
+                "schema_version": _SCHEMA_VERSION,
+                "case_index": case_index,
+                "inputs": {"masks": mask_snapshot},
+                "expected_output": _snapshot_output(output=output),
+            }
+            _write_pickle(
+                self.cases_dir / f"case_{case_index:04d}.pkl",
+                payload,
+            )
+            self.count += 1
+            self.total_masks += mask_snapshot["mask_count"]
+            if self.count == 1 or self.count % 10 == 0 or self.count == self.limit:
+                print(
+                    f"[capture] saved {self.count}/{self.limit} "
+                    f"rle-to-poly calls masks={self.total_masks}",
+                    flush=True,
+                )
+
+
+def _install_capture_hook(state: _CaptureState) -> None:
+    _ensure_local_import_paths()
+    from inference.core.models import inference_models_adapters as adapters
+    from inference.core.utils import rle_to_polygon
+
+    original = getattr(rle_to_polygon, _TARGET_FUNCTION)
+
+    @functools.wraps(original)
+    def wrapper(masks: Any) -> List[np.ndarray]:
+        result = original(masks)
+        state.maybe_save(masks=masks, output=result)
+        return result
+
+    setattr(rle_to_polygon, _TARGET_FUNCTION, wrapper)
+    # The adapter imports the function directly at module load time.
+    setattr(adapters, _TARGET_FUNCTION, wrapper)
+
+
+def _prepare_cases_dir(cases_dir: Path, overwrite: bool) -> None:
+    cases_dir.mkdir(parents=True, exist_ok=True)
+    existing = list(cases_dir.glob("case_*.pkl"))
+    manifest_path = cases_dir / "manifest.json"
+    if not overwrite and (existing or manifest_path.exists()):
+        raise RuntimeError(
+            f"{cases_dir} already contains captured cases; pass --overwrite "
+            "or choose a different --cases-dir."
+        )
+    if overwrite:
+        for path in existing:
+            path.unlink()
+        if manifest_path.exists():
+            manifest_path.unlink()
+
+
+def _write_manifest(cases_dir: Path, payload: dict) -> None:
+    with (cases_dir / "manifest.json").open("w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def _run_capture(args: argparse.Namespace) -> int:
+    cases_dir = args.cases_dir.resolve()
+    _prepare_cases_dir(cases_dir=cases_dir, overwrite=args.overwrite)
+
+    workflow = _load_workflow_module()
+    model_id = workflow._resolve_model_id(args.model_id, args.backend)
+    workflow._prepare_local_workflow_model_bundle(model_id)
+    if model_id != args.model_id:
+        print(
+            f"[model] using local TRT package via workflow model id: {model_id}",
+            flush=True,
+        )
+
+    state = _CaptureState(cases_dir=cases_dir, limit=args.capture_count)
+    _install_capture_hook(state=state)
+
+    frame_count = 0
+    start_time: Optional[float] = None
+    pipeline_ref: Dict[str, Any] = {}
+
+    def sink(predictions: Any, video_frames: Any) -> None:
+        nonlocal frame_count, start_time
+        del video_frames
+        if not isinstance(predictions, list):
+            predictions = [predictions]
+        frame_count += sum(p is not None for p in predictions)
+        if start_time is None:
+            start_time = perf_counter()
+        if frame_count % args.progress_every == 0:
+            elapsed = perf_counter() - start_time
+            fps = frame_count / elapsed if elapsed > 0 else 0.0
+            print(
+                f"[progress] frames={frame_count} fps={fps:.2f} "
+                f"captures={state.count}/{state.limit}",
+                flush=True,
+            )
+        if state.count >= state.limit and "pipeline" in pipeline_ref:
+            pipeline_ref["pipeline"].terminate()
+
+    pipeline = workflow.InferencePipeline.init_with_workflow(
+        video_reference=args.video_reference,
+        workflow_specification=workflow.build_workflow(model_id, args.confidence),
+        on_prediction=sink,
+    )
+    pipeline_ref["pipeline"] = pipeline
+    pipeline.start()
+    pipeline.join()
+
+    if state.count < args.capture_count:
+        raise RuntimeError(
+            f"Captured only {state.count}/{args.capture_count} invocations. "
+            "Use a longer video or lower --capture-count."
+        )
+
+    elapsed = perf_counter() - start_time if start_time else 0.0
+    _write_manifest(
+        cases_dir=cases_dir,
+        payload={
+            "schema_version": _SCHEMA_VERSION,
+            "function": "inference.core.utils.rle_to_polygon.rle_masks_to_polygons",
+            "case_count": state.count,
+            "total_masks": state.total_masks,
+            "video_reference": args.video_reference,
+            "backend": args.backend,
+            "model_id": model_id,
+            "confidence": args.confidence,
+            "frames_seen_by_sink": frame_count,
+            "capture_elapsed_seconds": elapsed,
+            "created_at_unix": time(),
+        },
+    )
+    print(
+        f"[capture] wrote {state.count} cases to {cases_dir} "
+        f"total_masks={state.total_masks}",
+        flush=True,
+    )
+    return state.count
+
+
+def _load_case(path: Path) -> dict:
+    with path.open("rb") as f:
+        payload = pickle.load(f)
+    if payload.get("schema_version") != _SCHEMA_VERSION:
+        raise RuntimeError(
+            f"{path} has schema_version={payload.get('schema_version')}; "
+            f"expected {_SCHEMA_VERSION}."
+        )
+    return payload
+
+
+def _materialize_masks(case: dict, use_lazy_counts: bool) -> Any:
+    _ensure_local_import_paths()
+    from inference_models.models.base.types import InstancesRLEMasks
+
+    payload = case["inputs"]["masks"]
+    masks = InstancesRLEMasks(
+        image_size=tuple(payload["image_size"]),
+        masks=list(payload["masks"]),
+    )
+    if use_lazy_counts and "rle_counts_cpu" in payload and "rle_lengths_cpu" in payload:
+        masks._rle_counts_cpu = np.array(payload["rle_counts_cpu"], copy=True)
+        masks._rle_lengths_cpu = np.array(payload["rle_lengths_cpu"], copy=True)
+    return masks
+
+
+def _assert_outputs_equal(
+    *,
+    actual: List[np.ndarray],
+    expected: List[np.ndarray],
+    case_index: int,
+) -> None:
+    if len(actual) != len(expected):
+        raise AssertionError(
+            f"case {case_index}: output length differs: "
+            f"{len(actual)} != {len(expected)}"
+        )
+    for poly_index, (actual_poly, expected_poly) in enumerate(zip(actual, expected)):
+        if actual_poly.shape != expected_poly.shape:
+            raise AssertionError(
+                f"case {case_index} polygon {poly_index}: shape differs "
+                f"{actual_poly.shape} != {expected_poly.shape}"
+            )
+        if actual_poly.dtype != expected_poly.dtype:
+            raise AssertionError(
+                f"case {case_index} polygon {poly_index}: dtype differs "
+                f"{actual_poly.dtype} != {expected_poly.dtype}"
+            )
+        if not np.array_equal(actual_poly, expected_poly):
+            raise AssertionError(
+                f"case {case_index} polygon {poly_index}: values differ"
+            )
+
+
+def _run_one_replay_case(*, case_path: Path, use_lazy_counts: bool) -> float:
+    from inference.core.utils.rle_to_polygon import rle_masks_to_polygons
+
+    case = _load_case(case_path)
+    masks = _materialize_masks(case=case, use_lazy_counts=use_lazy_counts)
+    start = perf_counter()
+    actual = rle_masks_to_polygons(masks)
+    elapsed = perf_counter() - start
+    _assert_outputs_equal(
+        actual=actual,
+        expected=case["expected_output"],
+        case_index=case["case_index"],
+    )
+    return elapsed
+
+
+def _summarize_timings(timings: List[float]) -> dict:
+    sorted_timings = sorted(timings)
+    total = sum(sorted_timings)
+    count = len(sorted_timings)
+
+    def percentile(p: float) -> float:
+        if count == 0:
+            return 0.0
+        index = min(count - 1, int(round((count - 1) * p)))
+        return sorted_timings[index]
+
+    return {
+        "count": count,
+        "total_seconds": total,
+        "mean_ms": (total / count) * 1000 if count else 0.0,
+        "min_ms": sorted_timings[0] * 1000 if count else 0.0,
+        "p50_ms": percentile(0.50) * 1000,
+        "p90_ms": percentile(0.90) * 1000,
+        "p99_ms": percentile(0.99) * 1000,
+        "max_ms": sorted_timings[-1] * 1000 if count else 0.0,
+    }
+
+
+def _print_timing_summary(summary: dict) -> None:
+    print(
+        "[replay] "
+        f"calls={summary['count']} "
+        f"total={summary['total_seconds']:.3f}s "
+        f"mean={summary['mean_ms']:.3f}ms "
+        f"p50={summary['p50_ms']:.3f}ms "
+        f"p90={summary['p90_ms']:.3f}ms "
+        f"p99={summary['p99_ms']:.3f}ms "
+        f"min={summary['min_ms']:.3f}ms "
+        f"max={summary['max_ms']:.3f}ms",
+        flush=True,
+    )
+
+
+def _run_replay(args: argparse.Namespace) -> dict:
+    _ensure_local_import_paths()
+    cases_dir = args.cases_dir.resolve()
+    case_paths = sorted(cases_dir.glob("case_*.pkl"))
+    if args.max_cases is not None:
+        case_paths = case_paths[: args.max_cases]
+    if not case_paths:
+        raise RuntimeError(f"No case_*.pkl files found in {cases_dir}")
+
+    print(
+        f"[replay] cases={len(case_paths)} repeats={args.repeats} "
+        f"warmup_repeats={args.warmup_repeats} "
+        f"use_lazy_counts={args.use_lazy_counts}",
+        flush=True,
+    )
+    for _ in range(args.warmup_repeats):
+        for case_path in case_paths:
+            _run_one_replay_case(
+                case_path=case_path,
+                use_lazy_counts=args.use_lazy_counts,
+            )
+
+    timings = []
+    for repeat_index in range(args.repeats):
+        for case_path in case_paths:
+            timings.append(
+                _run_one_replay_case(
+                    case_path=case_path,
+                    use_lazy_counts=args.use_lazy_counts,
+                )
+            )
+        print(
+            f"[replay] completed repeat {repeat_index + 1}/{args.repeats}",
+            flush=True,
+        )
+
+    summary = _summarize_timings(timings)
+    _print_timing_summary(summary)
+    print("[replay] all polygons matched captured e2e outputs", flush=True)
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("capture", "replay", "capture-and-replay"),
+        default="capture-and-replay",
+    )
+    parser.add_argument("--video_reference", default="vehicles_1080p.mp4")
+    parser.add_argument("--model_id", default="rfdetr-seg-nano")
+    parser.add_argument("--confidence", type=float, default=0.4)
+    parser.add_argument("--backend", choices=("trt", "onnx", "torch"), default="trt")
+    parser.add_argument(
+        "--cases-dir",
+        type=Path,
+        default=Path("temp/rfdetr_rle_to_poly_cases"),
+    )
+    parser.add_argument("--capture-count", type=int, default=100)
+    parser.add_argument("--progress-every", type=int, default=50)
+    parser.add_argument(
+        "--overwrite",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--warmup-repeats", type=int, default=0)
+    parser.add_argument("--max-cases", type=int, default=None)
+    parser.add_argument(
+        "--use-lazy-counts",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "When captured cases include uncompressed RLE counts, restore them "
+            "onto the replay masks."
+        ),
+    )
+    args = parser.parse_args()
+    if args.capture_count <= 0:
+        raise ValueError("--capture-count must be positive")
+    if args.repeats <= 0:
+        raise ValueError("--repeats must be positive")
+    if args.warmup_repeats < 0:
+        raise ValueError("--warmup-repeats must be non-negative")
+    if args.progress_every <= 0:
+        raise ValueError("--progress-every must be positive")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.mode in {"capture", "capture-and-replay"}:
+        _run_capture(args=args)
+    if args.mode in {"replay", "capture-and-replay"}:
+        _run_replay(args=args)
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/rfdetr_workflow_video_parity.py
+++ b/development/stream_interface/rfdetr_workflow_video_parity.py
@@ -1,0 +1,780 @@
+"""Compare RF-DETR workflow outputs on a video across two git refs.
+
+The driver mode runs the same one-block RF-DETR instance-segmentation workflow
+twice: a baseline ref with RF-DETR fast paths disabled, and a candidate ref with
+the full stack enabled. Each child run writes sink outputs keyed by video frame;
+the final compare checks that both runs emitted the same frame ids and
+semantically equivalent serialized workflow predictions.
+
+Example:
+
+    env PARITY_MODEL_PATH=/app/helloworld/inference/rfdetr-seg-nano-orin-trt-package \
+      python development/stream_interface/rfdetr_workflow_video_parity.py \
+        --video_reference vehicles_1080p.mp4 \
+        --base-ref main \
+        --candidate-ref opt-pipeline-integration
+"""
+
+import argparse
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import pickle
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Optional
+
+import numpy as np
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[2]
+SELF = Path(__file__).resolve()
+PY = sys.executable
+MODEL_ID = "rfdetr-seg-nano"
+LOCAL_WORKFLOW_MODEL_ID = f"{MODEL_ID}/1"
+CONFIDENCE = 0.4
+DEFAULT_BASE_OUT = "/tmp/rfdetr_workflow_video_base.pkl"
+DEFAULT_CANDIDATE_OUT = "/tmp/rfdetr_workflow_video_candidate.pkl"
+TRT_PACKAGE_REQUIRED_FILES = (
+    "model_config.json",
+    "class_names.txt",
+    "inference_config.json",
+    "engine.plan",
+)
+
+BASE_FLAGS_OFF = {
+    "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED": "false",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED": "false",
+    "RFDETR_PIPELINE_DEPTH": "1",
+    "ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND": "false",
+}
+CANDIDATE_FLAGS_ON = {
+    "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED": "true",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED": "true",
+    "RFDETR_PIPELINE_DEPTH": "2",
+    "ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND": "true",
+}
+ALL_BACKENDS = {
+    "torch",
+    "torch-script",
+    "onnx",
+    "trt",
+    "hugging-face",
+    "ultralytics",
+    "custom",
+}
+_SV_DETECTIONS_SERIALIZER = None
+_VOLATILE_OUTPUT_KEYS = {"detection_id"}
+
+
+def _repo_import_roots(repo_root: Path) -> list[Path]:
+    return [repo_root, repo_root / "inference_models"]
+
+
+def _child_pythonpath(repo_root: Path, existing_pythonpath: Optional[str]) -> str:
+    entries = [str(path) for path in _repo_import_roots(repo_root) if path.exists()]
+    if existing_pythonpath:
+        entries.append(existing_pythonpath)
+    return os.pathsep.join(entries)
+
+
+def _prioritize_local_packages(repo_root: Path) -> None:
+    for search_root in reversed(_repo_import_roots(repo_root)):
+        search_root_str = str(search_root)
+        if search_root_str in sys.path:
+            sys.path.remove(search_root_str)
+        if search_root.exists():
+            sys.path.insert(0, search_root_str)
+    for module_name in list(sys.modules):
+        if module_name == "inference" or module_name.startswith("inference."):
+            sys.modules.pop(module_name, None)
+        if module_name == "inference_models" or module_name.startswith(
+            "inference_models."
+        ):
+            sys.modules.pop(module_name, None)
+
+
+def _bootstrap_repo_root(repo_root: str) -> Path:
+    repo_path = Path(repo_root).resolve()
+    os.chdir(repo_path)
+    _prioritize_local_packages(repo_path)
+    return repo_path
+
+
+def _git_output(repo_root: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=str(repo_root),
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+def _safe_git_output(repo_root: Path, *args: str, default: str = "<unknown>") -> str:
+    try:
+        return _git_output(repo_root, *args)
+    except subprocess.CalledProcessError:
+        return default
+
+
+def _remove_worktree(worktree_root: Path) -> None:
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(worktree_root)],
+        cwd=str(SCRIPT_REPO_ROOT),
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    shutil.rmtree(worktree_root, ignore_errors=True)
+
+
+def _materialize_target(ref: str) -> dict:
+    if ref.lower() in {"working-tree", "worktree", "current"}:
+        return {
+            "label": (
+                f"{_safe_git_output(SCRIPT_REPO_ROOT, 'rev-parse', '--abbrev-ref', 'HEAD')} "
+                "(working-tree)"
+            ),
+            "repo_root": SCRIPT_REPO_ROOT,
+            "cleanup": None,
+        }
+    worktree_root = Path(tempfile.mkdtemp(prefix="rfdetr-video-parity-"))
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree_root), ref],
+        cwd=str(SCRIPT_REPO_ROOT),
+        check=True,
+    )
+    return {
+        "label": ref,
+        "repo_root": worktree_root,
+        "cleanup": lambda: _remove_worktree(worktree_root),
+    }
+
+
+def _is_trt_package(package_dir: Path) -> bool:
+    return package_dir.is_dir() and all(
+        (package_dir / filename).exists() for filename in TRT_PACKAGE_REQUIRED_FILES
+    )
+
+
+def _resolve_model_package() -> Optional[Path]:
+    explicit_model_path = os.environ.get("PARITY_MODEL_PATH")
+    if explicit_model_path and _is_trt_package(Path(explicit_model_path)):
+        return Path(explicit_model_path).resolve()
+    for root in (SCRIPT_REPO_ROOT, Path.cwd(), Path(tempfile.gettempdir())):
+        for name in (
+            "rfdetr-seg-nano-orin-trt-package",
+            "rfdetr-seg-nano-trt-package",
+        ):
+            package = root / name
+            if _is_trt_package(package):
+                return package.resolve()
+    return None
+
+
+def _prepare_local_workflow_model_bundle(repo_root: Path) -> str:
+    package = _resolve_model_package()
+    if package is None:
+        return MODEL_ID
+    os.environ.setdefault(
+        "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES", "true"
+    )
+    model_dir = repo_root / LOCAL_WORKFLOW_MODEL_ID
+    model_dir.parent.mkdir(parents=True, exist_ok=True)
+    if not model_dir.exists():
+        model_dir.symlink_to(package, target_is_directory=True)
+
+    model_cache_dir = (
+        Path(os.environ.get("MODEL_CACHE_DIR", "/tmp/cache")) / MODEL_ID / "1"
+    )
+    model_cache_dir.mkdir(parents=True, exist_ok=True)
+    model_type_path = model_cache_dir / "model_type.json"
+    model_metadata = {
+        "project_task_type": "instance-segmentation",
+        "model_type": "rfdetr-seg-nano",
+    }
+    model_type_path.write_text(json.dumps(model_metadata, indent=4))
+    return LOCAL_WORKFLOW_MODEL_ID
+
+
+def _load_local_inference(repo_root: Path):
+    spec = importlib.util.spec_from_file_location(
+        "inference",
+        repo_root / "inference" / "__init__.py",
+        submodule_search_locations=[str(repo_root / "inference")],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load local inference package from {repo_root}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["inference"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_workflow(model_id: str, confidence: float) -> dict:
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+                "name": "segmentation",
+                "images": "$inputs.image",
+                "model_id": model_id,
+                "confidence_mode": "custom",
+                "custom_confidence": confidence,
+                "enforce_dense_masks_in_inference_models": False,
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.segmentation.predictions",
+            },
+        ],
+    }
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _jsonable(val)
+            for key, val in sorted(value.items())
+            if str(key) not in _VOLATILE_OUTPUT_KEYS
+        }
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(element) for element in value]
+    if all(hasattr(value, attr) for attr in ("xyxy", "confidence", "class_id")):
+        if _SV_DETECTIONS_SERIALIZER is None:
+            raise RuntimeError("sv.Detections serializer was not initialized")
+        return _jsonable(_SV_DETECTIONS_SERIALIZER(value))
+    if isinstance(value, np.ndarray):
+        return _jsonable(value.tolist())
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, bytes):
+        return value.decode("ascii")
+    if hasattr(value, "model_dump"):
+        return _jsonable(value.model_dump(by_alias=True, exclude_none=True))
+    if hasattr(value, "dict"):
+        return _jsonable(value.dict())
+    return value
+
+
+def _as_list(value: Any) -> list:
+    return value if isinstance(value, list) else [value]
+
+
+def do_run(
+    out_path: str,
+    repo_root: str,
+    label: str,
+    video_reference: str,
+    backend: str,
+    confidence: float,
+) -> None:
+    global _SV_DETECTIONS_SERIALIZER
+    repo_path = _bootstrap_repo_root(repo_root)
+    os.environ.setdefault(
+        "ONNXRUNTIME_EXECUTION_PROVIDERS",
+        "[TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider]",
+    )
+    os.environ["DISABLED_INFERENCE_MODELS_BACKENDS"] = ",".join(
+        sorted(ALL_BACKENDS - {backend})
+    )
+    model_id = _prepare_local_workflow_model_bundle(repo_root=repo_path)
+    inference_module = _load_local_inference(repo_root=repo_path)
+    from inference.core.workflows.core_steps.common.serializers import (
+        serialise_sv_detections,
+    )
+
+    _SV_DETECTIONS_SERIALIZER = serialise_sv_detections
+    inference_pipeline = inference_module.InferencePipeline
+    signature = {
+        "git_head": _safe_git_output(repo_path, "rev-parse", "--short", "HEAD"),
+        "git_describe": _safe_git_output(
+            repo_path, "describe", "--always", "--dirty", "--broken"
+        ),
+    }
+    header = {
+        "_kind": "header",
+        "label": label,
+        "repo_root": str(repo_path),
+        "model_id": model_id,
+        "video_reference": video_reference,
+        "confidence": confidence,
+        "git_head": signature["git_head"],
+        "git_describe": signature["git_describe"],
+        "flags": {
+            key: os.environ.get(key)
+            for key in sorted({*BASE_FLAGS_OFF.keys(), *CANDIDATE_FLAGS_ON.keys()})
+        },
+    }
+    errors = []
+    records = 0
+    with open(out_path, "wb") as f:
+        pickle.dump(header, f)
+
+        def sink(predictions, video_frames) -> None:
+            nonlocal records
+            prediction_list = _as_list(predictions)
+            frame_list = _as_list(video_frames)
+            if len(prediction_list) != len(frame_list):
+                errors.append(
+                    f"sink length mismatch: {len(prediction_list)} predictions "
+                    f"for {len(frame_list)} frames"
+                )
+                return
+            for prediction, video_frame in zip(prediction_list, frame_list):
+                pickle.dump(
+                    {
+                        "_kind": "record",
+                        "frame_id": int(video_frame.frame_id),
+                        "source_id": video_frame.source_id,
+                        "prediction": _jsonable(prediction),
+                    },
+                    f,
+                )
+                records += 1
+
+        print(
+            "[run] "
+            f"label={label} repo_root={repo_path} head={signature['git_head']} "
+            f"model_id={model_id} video={video_reference}",
+            flush=True,
+        )
+        pipeline = inference_pipeline.init_with_workflow(
+            video_reference=video_reference,
+            workflow_specification=_build_workflow(model_id, confidence),
+            on_prediction=sink,
+            serialize_results=False,
+        )
+        pipeline.start()
+        pipeline.join()
+        if errors:
+            raise RuntimeError("; ".join(errors))
+        if records == 0:
+            raise RuntimeError("video workflow emitted no prediction records")
+        pickle.dump(
+            {
+                "_kind": "footer",
+                "label": label,
+                "n_records": records,
+            },
+            f,
+        )
+    print(f"[run] label={label} records={records} saved={out_path}", flush=True)
+
+
+def _iter_pickles(path: str):
+    with open(path, "rb") as f:
+        while True:
+            try:
+                yield pickle.load(f)
+            except EOFError:
+                return
+
+
+def _compare_values(
+    base: Any, candidate: Any, path: str, atol: float, errors: list
+) -> None:
+    if isinstance(base, dict) and isinstance(candidate, dict):
+        if set(base) != set(candidate):
+            errors.append(f"{path}: key mismatch {sorted(base)} != {sorted(candidate)}")
+            return
+        for key in sorted(base):
+            _compare_values(base[key], candidate[key], f"{path}.{key}", atol, errors)
+        return
+    if isinstance(base, list) and isinstance(candidate, list):
+        if len(base) != len(candidate):
+            errors.append(f"{path}: length mismatch {len(base)} != {len(candidate)}")
+            return
+        for index, (base_item, candidate_item) in enumerate(zip(base, candidate)):
+            _compare_values(base_item, candidate_item, f"{path}[{index}]", atol, errors)
+        return
+    if isinstance(base, (int, float)) and isinstance(candidate, (int, float)):
+        if not math.isclose(float(base), float(candidate), abs_tol=atol, rel_tol=0.0):
+            errors.append(f"{path}: numeric mismatch {base} != {candidate}")
+        return
+    if base != candidate:
+        errors.append(f"{path}: value mismatch {base!r} != {candidate!r}")
+
+
+def _extract_detection_list(prediction: Any) -> Optional[list]:
+    if not isinstance(prediction, dict) or "predictions" not in prediction:
+        return None
+    value = prediction["predictions"]
+    if isinstance(value, dict) and isinstance(value.get("predictions"), list):
+        return value["predictions"]
+    if isinstance(value, list):
+        return value
+    return None
+
+
+def _xyxy_from_detection(
+    detection: dict,
+) -> Optional[tuple[float, float, float, float]]:
+    try:
+        width = float(detection["width"])
+        height = float(detection["height"])
+        center_x = float(detection["x"])
+        center_y = float(detection["y"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    half_width = width / 2.0
+    half_height = height / 2.0
+    return (
+        center_x - half_width,
+        center_y - half_height,
+        center_x + half_width,
+        center_y + half_height,
+    )
+
+
+def _box_iou(
+    left: tuple[float, float, float, float], right: tuple[float, float, float, float]
+) -> float:
+    x0 = max(left[0], right[0])
+    y0 = max(left[1], right[1])
+    x1 = min(left[2], right[2])
+    y1 = min(left[3], right[3])
+    iw = max(0.0, x1 - x0)
+    ih = max(0.0, y1 - y0)
+    inter = iw * ih
+    left_area = max(0.0, left[2] - left[0]) * max(0.0, left[3] - left[1])
+    right_area = max(0.0, right[2] - right[0]) * max(0.0, right[3] - right[1])
+    union = left_area + right_area - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _compare_detection_lists(
+    base_detections: list,
+    candidate_detections: list,
+    frame_id: int,
+    min_box_iou: float,
+    max_score_delta: float,
+    stats: dict,
+    errors: list,
+) -> None:
+    stats["base_detections"] += len(base_detections)
+    stats["candidate_detections"] += len(candidate_detections)
+    if len(base_detections) != len(candidate_detections):
+        stats["count_mismatch_frames"] += 1
+        errors.append(
+            f"frame {frame_id}: detection count mismatch "
+            f"{len(base_detections)} != {len(candidate_detections)}"
+        )
+        return
+
+    used_base_indices = set()
+    for candidate_index, candidate_detection in enumerate(candidate_detections):
+        candidate_class = candidate_detection.get("class_id")
+        candidate_box = _xyxy_from_detection(candidate_detection)
+        if candidate_box is None:
+            errors.append(f"frame {frame_id}: candidate detection has no xyxy box")
+            continue
+        best_base_index = -1
+        best_iou = min_box_iou
+        for base_index, base_detection in enumerate(base_detections):
+            if base_index in used_base_indices:
+                continue
+            if base_detection.get("class_id") != candidate_class:
+                continue
+            base_box = _xyxy_from_detection(base_detection)
+            if base_box is None:
+                continue
+            box_iou = _box_iou(base_box, candidate_box)
+            if box_iou > best_iou:
+                best_iou = box_iou
+                best_base_index = base_index
+        if best_base_index < 0:
+            stats["unmatched_candidate_detections"] += 1
+            errors.append(
+                f"frame {frame_id}: candidate detection {candidate_index} "
+                f"class_id={candidate_class!r} has no matching base detection"
+            )
+            continue
+
+        used_base_indices.add(best_base_index)
+        stats["matched_detections"] += 1
+        stats["box_ious"].append(best_iou)
+        base_detection = base_detections[best_base_index]
+        base_score = float(base_detection.get("confidence", 0.0))
+        candidate_score = float(candidate_detection.get("confidence", 0.0))
+        score_delta = abs(base_score - candidate_score)
+        stats["score_deltas"].append(score_delta)
+        if score_delta > max_score_delta:
+            errors.append(
+                f"frame {frame_id}: score delta {score_delta:.6f} exceeds "
+                f"{max_score_delta:.6f}"
+            )
+        base_points = base_detection.get("points") or []
+        candidate_points = candidate_detection.get("points") or []
+        if len(base_points) != len(candidate_points):
+            stats["polygon_point_count_mismatches"] += 1
+
+    unmatched_base = len(base_detections) - len(used_base_indices)
+    stats["unmatched_base_detections"] += unmatched_base
+    if unmatched_base:
+        errors.append(f"frame {frame_id}: {unmatched_base} base detections unmatched")
+
+
+def do_compare(
+    base_path: str,
+    candidate_path: str,
+    atol: float,
+    min_box_iou: float,
+    max_score_delta: float,
+) -> None:
+    base_iter = _iter_pickles(base_path)
+    candidate_iter = _iter_pickles(candidate_path)
+    base_header = next(base_iter)
+    candidate_header = next(candidate_iter)
+    compared = 0
+    errors = []
+    stats = {
+        "base_detections": 0,
+        "candidate_detections": 0,
+        "matched_detections": 0,
+        "count_mismatch_frames": 0,
+        "unmatched_candidate_detections": 0,
+        "unmatched_base_detections": 0,
+        "polygon_point_count_mismatches": 0,
+        "box_ious": [],
+        "score_deltas": [],
+    }
+    base_footer = None
+    candidate_footer = None
+
+    for base_record, candidate_record in zip(base_iter, candidate_iter):
+        if (
+            base_record.get("_kind") == "footer"
+            or candidate_record.get("_kind") == "footer"
+        ):
+            base_footer = base_record
+            candidate_footer = candidate_record
+            break
+        if base_record["frame_id"] != candidate_record["frame_id"]:
+            errors.append(
+                f"frame id mismatch {base_record['frame_id']} != "
+                f"{candidate_record['frame_id']}"
+            )
+            break
+        compared += 1
+        base_detections = _extract_detection_list(base_record["prediction"])
+        candidate_detections = _extract_detection_list(candidate_record["prediction"])
+        if base_detections is not None and candidate_detections is not None:
+            _compare_detection_lists(
+                base_detections=base_detections,
+                candidate_detections=candidate_detections,
+                frame_id=base_record["frame_id"],
+                min_box_iou=min_box_iou,
+                max_score_delta=max_score_delta,
+                stats=stats,
+                errors=errors,
+            )
+        else:
+            _compare_values(
+                base_record["prediction"],
+                candidate_record["prediction"],
+                f"frame[{base_record['frame_id']}]",
+                atol,
+                errors,
+            )
+        if len(errors) >= 20:
+            break
+
+    if base_footer is None:
+        for obj in base_iter:
+            if obj.get("_kind") == "footer":
+                base_footer = obj
+                break
+    if candidate_footer is None:
+        for obj in candidate_iter:
+            if obj.get("_kind") == "footer":
+                candidate_footer = obj
+                break
+
+    print()
+    print(
+        f"==== RF-DETR workflow video parity: {base_header['label']} vs "
+        f"{candidate_header['label']} ===="
+    )
+    print(f"  base repo                  : {base_header['git_describe']}")
+    print(f"  candidate repo             : {candidate_header['git_describe']}")
+    print(
+        f"  frames base / candidate    : "
+        f"{base_footer['n_records']} / {candidate_footer['n_records']}"
+    )
+    print(f"  compared frames            : {compared}")
+    print(
+        f"  detections base / candidate: "
+        f"{stats['base_detections']} / {stats['candidate_detections']}"
+    )
+    print(f"  matched detections         : {stats['matched_detections']}")
+    print(f"  count-mismatch frames      : {stats['count_mismatch_frames']}")
+    print(
+        f"  unmatched base / candidate : "
+        f"{stats['unmatched_base_detections']} / "
+        f"{stats['unmatched_candidate_detections']}"
+    )
+    if stats["box_ious"]:
+        print(
+            f"  mean / min box IoU         : "
+            f"{np.mean(stats['box_ious']):.6f} / {np.min(stats['box_ious']):.6f}"
+        )
+    if stats["score_deltas"]:
+        print(
+            f"  mean / max |delta score|   : "
+            f"{np.mean(stats['score_deltas']):.3e} / "
+            f"{np.max(stats['score_deltas']):.3e}"
+        )
+    print(
+        f"  polygon point-count diffs  : " f"{stats['polygon_point_count_mismatches']}"
+    )
+    if errors:
+        print("  first mismatches:")
+        for error in errors[:20]:
+            print(f"    - {error}")
+        raise AssertionError(f"{len(errors)} parity mismatches found")
+    print("  result                     : all detections matched semantic thresholds")
+
+
+def _run_child(
+    repo_root: Path,
+    label: str,
+    out_path: str,
+    video_reference: str,
+    backend: str,
+    confidence: float,
+    flags: dict,
+) -> None:
+    env = os.environ.copy()
+    env.update(flags)
+    env["MPLCONFIGDIR"] = "/tmp/mpl"
+    model_package = _resolve_model_package()
+    if model_package is not None:
+        env["PARITY_MODEL_PATH"] = str(model_package)
+    env["PYTHONPATH"] = _child_pythonpath(repo_root, env.get("PYTHONPATH"))
+    video_path = Path(video_reference)
+    if not video_path.is_absolute():
+        candidate = SCRIPT_REPO_ROOT / video_path
+        if candidate.exists():
+            video_reference = str(candidate.resolve())
+    args = [
+        PY,
+        str(SELF),
+        "--mode",
+        "run",
+        "--repo-root",
+        str(repo_root),
+        "--label",
+        label,
+        "--out",
+        out_path,
+        "--video_reference",
+        video_reference,
+        "--backend",
+        backend,
+        "--confidence",
+        str(confidence),
+    ]
+    print(
+        "\n---- child ----\n"
+        f"  label={label}\n"
+        f"  repo_root={repo_root}\n"
+        f"  out={out_path}\n"
+        f"  flags={flags}",
+        flush=True,
+    )
+    subprocess.run(args, cwd=str(repo_root), env=env, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode", choices=("driver", "run", "compare"), default="driver"
+    )
+    parser.add_argument("--repo-root")
+    parser.add_argument("--label")
+    parser.add_argument("--out")
+    parser.add_argument("--base", default=DEFAULT_BASE_OUT)
+    parser.add_argument("--candidate", default=DEFAULT_CANDIDATE_OUT)
+    parser.add_argument("--base-ref", default="main")
+    parser.add_argument("--candidate-ref", default="working-tree")
+    parser.add_argument("--video_reference", default="vehicles_1080p.mp4")
+    parser.add_argument("--confidence", type=float, default=CONFIDENCE)
+    parser.add_argument("--backend", choices=("trt", "onnx", "torch"), default="trt")
+    parser.add_argument("--float-atol", type=float, default=1e-4)
+    parser.add_argument("--min-box-iou", type=float, default=0.5)
+    parser.add_argument("--max-score-delta", type=float, default=0.25)
+    parser.add_argument("--keep-worktrees", action="store_true")
+    args = parser.parse_args()
+
+    if args.mode == "run":
+        if not args.out:
+            raise ValueError("--out is required in run mode")
+        do_run(
+            out_path=args.out,
+            repo_root=args.repo_root or str(SCRIPT_REPO_ROOT),
+            label=args.label or "run",
+            video_reference=args.video_reference,
+            backend=args.backend,
+            confidence=args.confidence,
+        )
+        return
+    if args.mode == "compare":
+        do_compare(
+            args.base,
+            args.candidate,
+            args.float_atol,
+            args.min_box_iou,
+            args.max_score_delta,
+        )
+        return
+
+    base_target = _materialize_target(args.base_ref)
+    candidate_target = _materialize_target(args.candidate_ref)
+    cleanup_callbacks = [
+        target["cleanup"]
+        for target in (base_target, candidate_target)
+        if callable(target["cleanup"])
+    ]
+    try:
+        _run_child(
+            repo_root=Path(base_target["repo_root"]),
+            label=f"{base_target['label']} flags-off",
+            out_path=args.base,
+            video_reference=args.video_reference,
+            backend=args.backend,
+            confidence=args.confidence,
+            flags=BASE_FLAGS_OFF,
+        )
+        _run_child(
+            repo_root=Path(candidate_target["repo_root"]),
+            label=f"{candidate_target['label']} flags-on",
+            out_path=args.candidate,
+            video_reference=args.video_reference,
+            backend=args.backend,
+            confidence=args.confidence,
+            flags=CANDIDATE_FLAGS_ON,
+        )
+    finally:
+        if not args.keep_worktrees:
+            for cleanup in reversed(cleanup_callbacks):
+                cleanup()
+    do_compare(
+        args.base,
+        args.candidate,
+        args.float_atol,
+        args.min_box_iou,
+        args.max_score_delta,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/development/stream_interface/rfdetr_workflow_video_parity.py
+++ b/development/stream_interface/rfdetr_workflow_video_parity.py
@@ -20,12 +20,12 @@ import importlib.util
 import json
 import math
 import os
-from pathlib import Path
 import pickle
 import shutil
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np

--- a/docs/workflows/execution_engine_changelog.md
+++ b/docs/workflows/execution_engine_changelog.md
@@ -2,6 +2,27 @@
 
 Below you can find the changelog for Execution Engine.
 
+## Execution Engine `v1.11.0` | inference `v1.3.1`
+
+**What changed**
+
+* **Per-case execution branches for dict step selectors** — When a flow-control block
+  declares step selectors inside a `Dict[str, StepSelector]` property (rather than a
+  `List[StepSelector]`), the compiler now creates a distinct execution branch per
+  dictionary key. Previously every selector in a single property shared one branch, so
+  a block could not route to its targets independently. Branch names now include the
+  dictionary key (e.g. `Branch[$steps.switch -> cases[red]]`). Selectors held in list
+  properties (such as `next_steps`) keep the prior shared-branch behavior, so existing
+  blocks are unaffected. This change is what enables the new
+  `roboflow_core/switch_case@v1` block (`graph_constructor.establish_control_flow_edge`).
+
+* **Fix: non-SIMD flow-control masks with repeated branch names** — A non-SIMD
+  flow-control step that selected more than one target through a single list property
+  raised `Attempted to re-register maks for execution branch`. Branch-mask registration
+  now deduplicates branch names before registering, fixing the crash (affected e.g.
+  `ContinueIf` with multiple `next_steps`;
+  `execution_data_manager.manager._register_control_flow_output_for_non_simd_step`).
+
 ## Execution Engine `v1.10.1` | inference `v1.2.12`
 
 **What changed**

--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -253,6 +253,10 @@ class InstanceSegmentationInferenceRequest(ObjectDetectionInferenceRequest):
         "RLE but consume more memory which may be unstable in some cases. This flag cannot be tweaked "
         "when used on Roboflow serverless platform.",
     )
+    disable_stream_pipeline: Optional[bool] = Field(
+        default=False,
+        description="Internal workflow flag forcing RF-DETR stream pipelining off for requests whose downstream graph needs same-frame context.",
+    )
 
 
 class SemanticSegmentationInferenceRequest(CVInferenceRequest):

--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -28,6 +28,14 @@ class BaseRequest(BaseModel):
     start: Optional[float] = None
     source: Optional[str] = None
     source_info: Optional[str] = None
+    stream_pipeline_context_id: Optional[str] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Internal stream-pipeline frame pairing id. Not part of the public API."
+        ),
+    )
     disable_model_monitoring: Optional[bool] = Field(
         default=False, description="If true, disables model monitoring for this request"
     )

--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -303,6 +303,7 @@ class InstanceSegmentationPredictionDC:
     class_name: str  # serialized as "class" in the dict form
     class_id: int
     points: list  # list[PointDC]
+    mask_format: Literal["polygon"] = "polygon"
     detection_id: str = field(default_factory=lambda: str(uuid4()))
     parent_id: object = None
     class_confidence: object = None
@@ -337,6 +338,7 @@ def _is_pred_dc_to_dict(p: InstanceSegmentationPredictionDC) -> dict:
         "class_id": p.class_id,
         "detection_id": p.detection_id,
         "points": [{"x": pt.x, "y": pt.y} for pt in p.points],
+        "mask_format": p.mask_format,
     }
     if p.class_confidence is not None:
         d["class_confidence"] = p.class_confidence

--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -324,6 +324,7 @@ class InstanceSegmentationInferenceResponseDC:
     # response future through Model.infer_from_request without blocking the
     # inference thread. `_is_response_dc_to_dict` intentionally ignores it.
     _async_response_future: object = None
+    _async_response_context_id: object = None
 
 
 def _is_pred_dc_to_dict(p: InstanceSegmentationPredictionDC) -> dict:

--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -303,6 +303,7 @@ class InstanceSegmentationPredictionDC:
     class_name: str  # serialized as "class" in the dict form
     class_id: int
     points: list  # list[PointDC]
+    mask_format: Literal["polygon"] = "polygon"
     detection_id: str = field(default_factory=lambda: str(uuid4()))
     parent_id: object = None
     class_confidence: object = None
@@ -323,6 +324,7 @@ class InstanceSegmentationInferenceResponseDC:
     # response future through Model.infer_from_request without blocking the
     # inference thread. `_is_response_dc_to_dict` intentionally ignores it.
     _async_response_future: object = None
+    _async_response_context_id: object = None
 
 
 def _is_pred_dc_to_dict(p: InstanceSegmentationPredictionDC) -> dict:
@@ -337,6 +339,7 @@ def _is_pred_dc_to_dict(p: InstanceSegmentationPredictionDC) -> dict:
         "class_id": p.class_id,
         "detection_id": p.detection_id,
         "points": [{"x": pt.x, "y": pt.y} for pt in p.points],
+        "mask_format": p.mask_format,
     }
     if p.class_confidence is not None:
         d["class_confidence"] = p.class_confidence

--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -1,4 +1,5 @@
 import base64
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import uuid4
 
@@ -271,6 +272,94 @@ class InstanceSegmentationInferenceResponse(
     predictions: List[
         Union[InstanceSegmentationPrediction, InstanceSegmentationRLEPrediction]
     ]
+
+
+# Dataclass twins used on the workflow-local fast path in
+# `InferenceModelsInstanceSegmentationAdapter.postprocess` when
+# `kwargs["source"] == "workflow-execution"`. The workflow block consumes
+# a plain dict via `_is_response_dc_to_dict` and never needs the pydantic
+# interface. HTTP / cache / visualization paths still receive the pydantic
+# `InstanceSegmentationInferenceResponse` because they use
+# `source != "workflow-execution"`.
+@dataclass(slots=True)
+class PointDC:
+    x: float
+    y: float
+
+
+@dataclass(slots=True)
+class InferenceResponseImageDC:
+    width: int
+    height: int
+
+
+@dataclass(slots=True)
+class InstanceSegmentationPredictionDC:
+    x: float
+    y: float
+    width: float
+    height: float
+    confidence: float
+    class_name: str  # serialized as "class" in the dict form
+    class_id: int
+    points: list  # list[PointDC]
+    detection_id: str = field(default_factory=lambda: str(uuid4()))
+    parent_id: object = None
+    class_confidence: object = None
+
+
+@dataclass(slots=True)
+class InstanceSegmentationInferenceResponseDC:
+    predictions: list  # list[InstanceSegmentationPredictionDC]
+    image: InferenceResponseImageDC
+    # `Model.infer_from_request` assigns .time and .inference_id after
+    # construction (see inference/core/models/base.py:154-157); they're
+    # declared here so the slotted dataclass permits the reassignment.
+    inference_id: object = None
+    frame_id: object = None
+    time: object = None
+    visualization: object = None
+    # Internal stream-pipeline fast path: lets workflow execution carry a
+    # response future through Model.infer_from_request without blocking the
+    # inference thread. `_is_response_dc_to_dict` intentionally ignores it.
+    _async_response_future: object = None
+
+
+def _is_pred_dc_to_dict(p: InstanceSegmentationPredictionDC) -> dict:
+    """Bit-equivalent to `InstanceSegmentationPrediction(...).model_dump(by_alias=True, exclude_none=True)`."""
+    d = {
+        "x": p.x,
+        "y": p.y,
+        "width": p.width,
+        "height": p.height,
+        "confidence": p.confidence,
+        "class": p.class_name,  # alias
+        "class_id": p.class_id,
+        "detection_id": p.detection_id,
+        "points": [{"x": pt.x, "y": pt.y} for pt in p.points],
+    }
+    if p.class_confidence is not None:
+        d["class_confidence"] = p.class_confidence
+    if p.parent_id is not None:
+        d["parent_id"] = p.parent_id
+    return d
+
+
+def _is_response_dc_to_dict(r: InstanceSegmentationInferenceResponseDC) -> dict:
+    """Bit-equivalent to `InstanceSegmentationInferenceResponse(...).model_dump(by_alias=True, exclude_none=True)`."""
+    d = {
+        "image": {"width": r.image.width, "height": r.image.height},
+        "predictions": [_is_pred_dc_to_dict(p) for p in r.predictions],
+    }
+    if r.inference_id is not None:
+        d["inference_id"] = r.inference_id
+    if r.frame_id is not None:
+        d["frame_id"] = r.frame_id
+    if r.time is not None:
+        d["time"] = r.time
+    if r.visualization is not None:
+        d["visualization"] = r.visualization
+    return d
 
 
 class SemanticSegmentationInferenceResponse(

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -863,6 +863,12 @@ HOT_MODELS_QUEUE_LOCK_ACQUIRE_TIMEOUT = float(
 # 2048 -> ~22G
 RFDETR_ONNX_MAX_RESOLUTION = int(os.getenv("RFDETR_ONNX_MAX_RESOLUTION", "1600"))
 
+# Timeout in seconds for resolving asynchronous workflow / RF-DETR stream
+# pipeline futures on the main execution path.
+WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT = float(
+    os.getenv("WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT", "60.0")
+)
+
 # Confidence lower bound to prevent OOM when inferring on instance segmentation models
 CONFIDENCE_LOWER_BOUND_OOM_PREVENTION = float(
     os.getenv("CONFIDENCE_LOWER_BOUND_OOM_PREVENTION", "0.01")

--- a/inference/core/interfaces/stream/entities.py
+++ b/inference/core/interfaces/stream/entities.py
@@ -121,7 +121,15 @@ class PipelineStateReport:
     sources_metadata: List[SourceMetadata]
 
 
-InferenceHandler = Callable[[List[VideoFrame]], List[AnyPrediction]]
+@dataclass(frozen=True)
+class InferenceHandlerResult:
+    predictions: List[AnyPrediction]
+    video_frames: Optional[List[VideoFrame]] = None
+
+
+InferenceHandler = Callable[
+    [List[VideoFrame]], Optional[Union[List[AnyPrediction], InferenceHandlerResult]]
+]
 SinkHandler = Optional[
     Union[
         Callable[[AnyPrediction, VideoFrame], None],

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -62,7 +62,6 @@ from inference.core.managers.decorators.fixed_size_cache import WithFixedSizeCac
 from inference.core.registries.roboflow import RoboflowModelRegistry
 from inference.core.utils.function import experimental
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
-from inference.core.workflows.execution_engine.entities.base import CoordinatesSystem
 from inference.core.workflows.execution_engine.profiling.core import (
     BaseWorkflowsProfiler,
     NullWorkflowsProfiler,
@@ -571,9 +570,6 @@ class InferencePipeline:
                 newest version for the request. Only applies for Workflows definitions saved on Roboflow platform.
             serialize_results (bool): Boolean flag to decide if ExecutionEngine run should serialize workflow
                 results for each frame. If that is set true, sinks will receive serialized workflow responses.
-                When False, output futures are resolved in the dispatch thread and detections in workflow
-                outputs declared with `coordinates_system: parent` are converted to root coordinates at
-                dispatch time instead of in the execution engine.
             predictions_queue_size int: Size of buffer for predictions that are ready for dispatching
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
@@ -610,8 +606,6 @@ class InferencePipeline:
             raise ValueError(
                 "Either (`workspace_name`, `workflow_id`) or `workflow_specification` must be provided."
             )
-        workflow_parent_coordinate_outputs = frozenset()
-        workflow_defer_output_coordinate_conversion = False
         try:
             from inference.core.interfaces.stream.model_handlers.workflows import (
                 WorkflowRunner,
@@ -676,12 +670,6 @@ class InferencePipeline:
                 workflow_runner=workflow_runner,
                 execution_engine=execution_engine,
             )
-            workflow_parent_coordinate_outputs = (
-                _workflow_parent_coordinate_output_names(
-                    workflow_specification=workflow_specification,
-                )
-            )
-            workflow_defer_output_coordinate_conversion = not serialize_results
         except ImportError as error:
             raise CannotInitialiseModelError(
                 f"Could not initialise workflow processing due to lack of dependencies required. "
@@ -709,10 +697,6 @@ class InferencePipeline:
             batch_collection_timeout=batch_collection_timeout,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
-            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
-            workflow_defer_output_coordinate_conversion=(
-                workflow_defer_output_coordinate_conversion
-            ),
         )
 
     @classmethod
@@ -733,8 +717,6 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
-        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
-        workflow_defer_output_coordinate_conversion: bool = False,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -805,15 +787,6 @@ class InferencePipeline:
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
-            workflow_parent_coordinate_outputs (Optional[frozenset[str]]): Names of workflow outputs whose
-                `coordinates_system` is `parent`. Used by the dispatch thread to convert `sv.Detections`
-                to root coordinates when coordinate conversion is deferred. Populated automatically by
-                `init_with_workflow(...)`; only needed when constructing the pipeline via
-                `init_with_custom_logic(...)` with a workflow-backed handler.
-            workflow_defer_output_coordinate_conversion (bool): When True, parent-coordinate conversion
-                for workflow detections is applied in `_dispatch_inference_results(...)` after futures
-                are resolved, rather than in the execution engine output constructor. Set automatically
-                to `not serialize_results` by `init_with_workflow(...)`.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -868,10 +841,6 @@ class InferencePipeline:
             on_pipeline_end=on_pipeline_end,
             batch_collection_timeout=batch_collection_timeout,
             sink_mode=sink_mode,
-            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
-            workflow_defer_output_coordinate_conversion=(
-                workflow_defer_output_coordinate_conversion
-            ),
         )
 
     def __init__(
@@ -887,8 +856,6 @@ class InferencePipeline:
         max_fps: Optional[float] = None,
         batch_collection_timeout: Optional[float] = None,
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
-        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
-        workflow_defer_output_coordinate_conversion: bool = False,
     ):
         self._on_video_frame = on_video_frame
         self._video_sources = video_sources
@@ -906,12 +873,6 @@ class InferencePipeline:
         self._on_pipeline_end = on_pipeline_end
         self._batch_collection_timeout = batch_collection_timeout
         self._sink_mode = sink_mode
-        self._workflow_parent_coordinate_outputs = (
-            workflow_parent_coordinate_outputs or frozenset()
-        )
-        self._workflow_defer_output_coordinate_conversion = (
-            workflow_defer_output_coordinate_conversion
-        )
 
     def start(self, use_main_thread: bool = True) -> None:
         self._stop = False
@@ -1028,11 +989,6 @@ class InferencePipeline:
             predictions, video_frames = inference_results
             if _rfdetr_stream_pipeline_enabled():
                 predictions = _resolve_prediction_futures(predictions)
-                if self._workflow_defer_output_coordinate_conversion:
-                    predictions = _apply_workflow_parent_coordinate_conversion(
-                        predictions=predictions,
-                        parent_output_names=self._workflow_parent_coordinate_outputs,
-                    )
             if self._on_prediction is not None:
                 self._handle_predictions_dispatching(
                     predictions=predictions,
@@ -1230,55 +1186,6 @@ def _resolve_prediction_futures(value: Any) -> Any:
             key: _resolve_prediction_futures(element) for key, element in value.items()
         }
     return value
-
-
-def _workflow_parent_coordinate_output_names(
-    workflow_specification: Optional[dict],
-) -> frozenset[str]:
-    if workflow_specification is None:
-        return frozenset()
-    parent_output_names = set()
-    for output in workflow_specification.get("outputs", []):
-        coordinates_system = output.get(
-            "coordinates_system",
-            CoordinatesSystem.PARENT.value,
-        )
-        if coordinates_system in (
-            CoordinatesSystem.PARENT,
-            CoordinatesSystem.PARENT.value,
-        ):
-            parent_output_names.add(output["name"])
-    return frozenset(parent_output_names)
-
-
-def _apply_workflow_parent_coordinate_conversion(
-    predictions: Any,
-    parent_output_names: frozenset[str],
-) -> Any:
-    if not parent_output_names:
-        return predictions
-    from inference.core.workflows.execution_engine.v1.executor.output_constructor import (
-        convert_sv_detections_coordinates,
-    )
-
-    if isinstance(predictions, list):
-        return [
-            _apply_workflow_parent_coordinate_conversion(
-                predictions=item,
-                parent_output_names=parent_output_names,
-            )
-            for item in predictions
-        ]
-    if isinstance(predictions, dict):
-        converted = dict(predictions)
-        for output_name in parent_output_names:
-            if output_name not in converted:
-                continue
-            converted[output_name] = convert_sv_detections_coordinates(
-                data=converted[output_name]
-            )
-        return converted
-    return predictions
 
 
 def _rfdetr_stream_pipeline_enabled() -> bool:

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -1,5 +1,5 @@
 import os
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from enum import Enum
 from functools import partial
@@ -67,6 +67,7 @@ from inference.core.workflows.execution_engine.profiling.core import (
     BaseWorkflowsProfiler,
     NullWorkflowsProfiler,
 )
+from inference.core.workflows.execution_engine.v1.executor.utils import resolve_futures
 from inference.models.aliases import resolve_roboflow_model_alias
 from inference.models.utils import ROBOFLOW_MODEL_TYPES, get_model
 
@@ -1219,17 +1220,10 @@ def send_inference_pipeline_status_update(
 
 
 def _resolve_prediction_futures(value: Any) -> Any:
-    if isinstance(value, Future):
-        return _resolve_prediction_futures(value.result())
-    if isinstance(value, list):
-        return [_resolve_prediction_futures(element) for element in value]
-    if isinstance(value, tuple):
-        return tuple(_resolve_prediction_futures(element) for element in value)
-    if isinstance(value, dict):
-        return {
-            key: _resolve_prediction_futures(element) for key, element in value.items()
-        }
-    return value
+    return resolve_futures(
+        value=value,
+        context="inference_pipeline | prediction_dispatch",
+    )
 
 
 def _workflow_parent_coordinate_output_names(

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -62,6 +62,7 @@ from inference.core.managers.decorators.fixed_size_cache import WithFixedSizeCac
 from inference.core.registries.roboflow import RoboflowModelRegistry
 from inference.core.utils.function import experimental
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.entities.base import CoordinatesSystem
 from inference.core.workflows.execution_engine.profiling.core import (
     BaseWorkflowsProfiler,
     NullWorkflowsProfiler,
@@ -570,6 +571,9 @@ class InferencePipeline:
                 newest version for the request. Only applies for Workflows definitions saved on Roboflow platform.
             serialize_results (bool): Boolean flag to decide if ExecutionEngine run should serialize workflow
                 results for each frame. If that is set true, sinks will receive serialized workflow responses.
+                When False, output futures are resolved in the dispatch thread and detections in workflow
+                outputs declared with `coordinates_system: parent` are converted to root coordinates at
+                dispatch time instead of in the execution engine.
             predictions_queue_size int: Size of buffer for predictions that are ready for dispatching
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
@@ -606,6 +610,8 @@ class InferencePipeline:
             raise ValueError(
                 "Either (`workspace_name`, `workflow_id`) or `workflow_specification` must be provided."
             )
+        workflow_parent_coordinate_outputs = frozenset()
+        workflow_defer_output_coordinate_conversion = False
         try:
             from inference.core.interfaces.stream.model_handlers.workflows import (
                 WorkflowRunner,
@@ -670,6 +676,12 @@ class InferencePipeline:
                 workflow_runner=workflow_runner,
                 execution_engine=execution_engine,
             )
+            workflow_parent_coordinate_outputs = (
+                _workflow_parent_coordinate_output_names(
+                    workflow_specification=workflow_specification,
+                )
+            )
+            workflow_defer_output_coordinate_conversion = not serialize_results
         except ImportError as error:
             raise CannotInitialiseModelError(
                 f"Could not initialise workflow processing due to lack of dependencies required. "
@@ -697,6 +709,10 @@ class InferencePipeline:
             batch_collection_timeout=batch_collection_timeout,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
+            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
+            workflow_defer_output_coordinate_conversion=(
+                workflow_defer_output_coordinate_conversion
+            ),
         )
 
     @classmethod
@@ -717,6 +733,8 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
+        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
+        workflow_defer_output_coordinate_conversion: bool = False,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -787,6 +805,15 @@ class InferencePipeline:
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
+            workflow_parent_coordinate_outputs (Optional[frozenset[str]]): Names of workflow outputs whose
+                `coordinates_system` is `parent`. Used by the dispatch thread to convert `sv.Detections`
+                to root coordinates when coordinate conversion is deferred. Populated automatically by
+                `init_with_workflow(...)`; only needed when constructing the pipeline via
+                `init_with_custom_logic(...)` with a workflow-backed handler.
+            workflow_defer_output_coordinate_conversion (bool): When True, parent-coordinate conversion
+                for workflow detections is applied in `_dispatch_inference_results(...)` after futures
+                are resolved, rather than in the execution engine output constructor. Set automatically
+                to `not serialize_results` by `init_with_workflow(...)`.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -841,6 +868,10 @@ class InferencePipeline:
             on_pipeline_end=on_pipeline_end,
             batch_collection_timeout=batch_collection_timeout,
             sink_mode=sink_mode,
+            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
+            workflow_defer_output_coordinate_conversion=(
+                workflow_defer_output_coordinate_conversion
+            ),
         )
 
     def __init__(
@@ -856,6 +887,8 @@ class InferencePipeline:
         max_fps: Optional[float] = None,
         batch_collection_timeout: Optional[float] = None,
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
+        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
+        workflow_defer_output_coordinate_conversion: bool = False,
     ):
         self._on_video_frame = on_video_frame
         self._video_sources = video_sources
@@ -873,6 +906,12 @@ class InferencePipeline:
         self._on_pipeline_end = on_pipeline_end
         self._batch_collection_timeout = batch_collection_timeout
         self._sink_mode = sink_mode
+        self._workflow_parent_coordinate_outputs = (
+            workflow_parent_coordinate_outputs or frozenset()
+        )
+        self._workflow_defer_output_coordinate_conversion = (
+            workflow_defer_output_coordinate_conversion
+        )
 
     def start(self, use_main_thread: bool = True) -> None:
         self._stop = False
@@ -989,6 +1028,11 @@ class InferencePipeline:
             predictions, video_frames = inference_results
             if _rfdetr_stream_pipeline_enabled():
                 predictions = _resolve_prediction_futures(predictions)
+                if self._workflow_defer_output_coordinate_conversion:
+                    predictions = _apply_workflow_parent_coordinate_conversion(
+                        predictions=predictions,
+                        parent_output_names=self._workflow_parent_coordinate_outputs,
+                    )
             if self._on_prediction is not None:
                 self._handle_predictions_dispatching(
                     predictions=predictions,
@@ -1186,6 +1230,55 @@ def _resolve_prediction_futures(value: Any) -> Any:
             key: _resolve_prediction_futures(element) for key, element in value.items()
         }
     return value
+
+
+def _workflow_parent_coordinate_output_names(
+    workflow_specification: Optional[dict],
+) -> frozenset[str]:
+    if workflow_specification is None:
+        return frozenset()
+    parent_output_names = set()
+    for output in workflow_specification.get("outputs", []):
+        coordinates_system = output.get(
+            "coordinates_system",
+            CoordinatesSystem.PARENT.value,
+        )
+        if coordinates_system in (
+            CoordinatesSystem.PARENT,
+            CoordinatesSystem.PARENT.value,
+        ):
+            parent_output_names.add(output["name"])
+    return frozenset(parent_output_names)
+
+
+def _apply_workflow_parent_coordinate_conversion(
+    predictions: Any,
+    parent_output_names: frozenset[str],
+) -> Any:
+    if not parent_output_names:
+        return predictions
+    from inference.core.workflows.execution_engine.v1.executor.output_constructor import (
+        convert_sv_detections_coordinates,
+    )
+
+    if isinstance(predictions, list):
+        return [
+            _apply_workflow_parent_coordinate_conversion(
+                predictions=item,
+                parent_output_names=parent_output_names,
+            )
+            for item in predictions
+        ]
+    if isinstance(predictions, dict):
+        converted = dict(predictions)
+        for output_name in parent_output_names:
+            if output_name not in converted:
+                continue
+            converted[output_name] = convert_sv_detections_coordinates(
+                data=converted[output_name]
+            )
+        return converted
+    return predictions
 
 
 def _rfdetr_stream_pipeline_enabled() -> bool:

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -1,4 +1,5 @@
-from concurrent.futures import ThreadPoolExecutor
+import os
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
 from enum import Enum
 from functools import partial
@@ -39,6 +40,7 @@ from inference.core.interfaces.camera.video_source import (
 from inference.core.interfaces.stream.entities import (
     AnyPrediction,
     InferenceHandler,
+    InferenceHandlerResult,
     ModelConfig,
     SinkHandler,
 )
@@ -253,7 +255,9 @@ class InferencePipeline:
         )
         model = get_model(model_id=model_id, api_key=api_key)
         on_video_frame = partial(
-            default_process_frame, model=model, inference_config=inference_config
+            default_process_frame,
+            model=model,
+            inference_config=inference_config,
         )
         active_learning_middleware = NullActiveLearningMiddleware()
         if active_learning_enabled is None:
@@ -605,6 +609,7 @@ class InferencePipeline:
         try:
             from inference.core.interfaces.stream.model_handlers.workflows import (
                 WorkflowRunner,
+                wrap_workflow_runner_for_stream_pipeline,
             )
             from inference.core.roboflow_api import get_workflow_specification
             from inference.core.workflows.execution_engine.core import ExecutionEngine
@@ -653,15 +658,17 @@ class InferencePipeline:
                 workflow_id=workflow_id,
                 profiler=profiler,
             )
-            workflow_runner = WorkflowRunner()
-            on_video_frame = partial(
-                workflow_runner.run_workflow,
+            workflow_runner = WorkflowRunner(
                 workflows_parameters=workflows_parameters,
                 execution_engine=execution_engine,
                 image_input_name=image_input_name,
                 video_metadata_input_name=video_metadata_input_name,
                 serialize_results=serialize_results,
                 _is_preview=_is_preview,
+            )
+            on_video_frame = wrap_workflow_runner_for_stream_pipeline(
+                workflow_runner=workflow_runner,
+                execution_engine=execution_engine,
             )
         except ImportError as error:
             raise CannotInitialiseModelError(
@@ -813,6 +820,14 @@ class InferencePipeline:
             predictions_queue_size = int(predictions_queue_size)
         except ValueError:
             predictions_queue_size = 512
+        if (
+            _rfdetr_stream_pipeline_enabled()
+            and "INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE" not in os.environ
+        ):
+            # Stream-pipelined RF-DETR returns async response futures. Letting
+            # the producer queue hundreds of full-resolution VideoFrame objects
+            # can exhaust host memory on 4K videos before dispatch catches up.
+            predictions_queue_size = min(predictions_queue_size, 4)
         predictions_queue = Queue(maxsize=predictions_queue_size)
         return cls(
             on_video_frame=on_video_frame,
@@ -916,6 +931,12 @@ class InferencePipeline:
                     frames=video_frames,
                 )
                 predictions = self._on_video_frame(video_frames)
+                if _rfdetr_stream_pipeline_enabled():
+                    self._queue_inference_result(
+                        inference_result=predictions,
+                        fallback_video_frames=video_frames,
+                    )
+                    continue
                 self._watchdog.on_model_prediction_ready(
                     frames=video_frames,
                 )
@@ -930,6 +951,8 @@ class InferencePipeline:
                     },
                     status_update_handlers=self._status_update_handlers,
                 )
+            if _rfdetr_stream_pipeline_enabled():
+                self._drain_inference_handler()
 
         except Exception as error:
             payload = {
@@ -945,6 +968,8 @@ class InferencePipeline:
             )
             logger.exception(f"Encountered inference error: {error}")
         finally:
+            if _rfdetr_stream_pipeline_enabled():
+                self._close_inference_handler()
             self._predictions_queue.put(None)
             send_inference_pipeline_status_update(
                 severity=UpdateSeverity.INFO,
@@ -962,12 +987,91 @@ class InferencePipeline:
                 self._predictions_queue.task_done()
                 break
             predictions, video_frames = inference_results
+            if _rfdetr_stream_pipeline_enabled():
+                predictions = _resolve_prediction_futures(predictions)
             if self._on_prediction is not None:
                 self._handle_predictions_dispatching(
                     predictions=predictions,
                     video_frames=video_frames,
                 )
             self._predictions_queue.task_done()
+
+    def _queue_inference_result(
+        self,
+        inference_result: Optional[Union[List[AnyPrediction], InferenceHandlerResult]],
+        fallback_video_frames: List[VideoFrame],
+    ) -> None:
+        normalised_result = self._normalise_inference_result(
+            inference_result=inference_result,
+            fallback_video_frames=fallback_video_frames,
+        )
+        if normalised_result is None:
+            return None
+        predictions, video_frames = normalised_result
+        self._watchdog.on_model_prediction_ready(
+            frames=video_frames,
+        )
+        self._predictions_queue.put((predictions, video_frames))
+        send_inference_pipeline_status_update(
+            severity=UpdateSeverity.DEBUG,
+            event_type=INFERENCE_COMPLETED_EVENT,
+            payload={
+                "frames_ids": [f.frame_id for f in video_frames],
+                "frames_timestamps": [f.frame_timestamp for f in video_frames],
+                "sources_id": [f.source_id for f in video_frames],
+            },
+            status_update_handlers=self._status_update_handlers,
+        )
+
+    def _normalise_inference_result(
+        self,
+        inference_result: Optional[Union[List[AnyPrediction], InferenceHandlerResult]],
+        fallback_video_frames: List[VideoFrame],
+    ) -> Optional[Tuple[List[AnyPrediction], List[VideoFrame]]]:
+        if inference_result is None:
+            return None
+        if isinstance(inference_result, InferenceHandlerResult):
+            video_frames = (
+                inference_result.video_frames
+                if inference_result.video_frames is not None
+                else fallback_video_frames
+            )
+            if len(video_frames) == 0:
+                return None
+            return inference_result.predictions, video_frames
+        if len(fallback_video_frames) == 0:
+            return None
+        return inference_result, fallback_video_frames
+
+    def _drain_inference_handler(self) -> None:
+        flush_fn = getattr(self._on_video_frame, "flush", None)
+        if not callable(flush_fn):
+            return None
+        flush_result = flush_fn()
+        if flush_result is None:
+            return None
+        if isinstance(flush_result, list) and all(
+            isinstance(result, InferenceHandlerResult) for result in flush_result
+        ):
+            for result in flush_result:
+                self._queue_inference_result(
+                    inference_result=result,
+                    fallback_video_frames=[],
+                )
+            return None
+        self._queue_inference_result(
+            inference_result=flush_result,
+            fallback_video_frames=[],
+        )
+
+    def _close_inference_handler(self) -> None:
+        close_fn = getattr(self._on_video_frame, "close", None)
+        if not callable(close_fn):
+            return None
+        try:
+            close_fn()
+        except Exception as error:
+            logger.warning(f"Could not close inference handler. Cause: {error}")
 
     def _handle_predictions_dispatching(
         self,
@@ -1068,3 +1172,24 @@ def send_inference_pipeline_status_update(
             handler(status_update)
         except Exception as error:
             logger.warning(f"Could not execute handler update. Cause: {error}")
+
+
+def _resolve_prediction_futures(value: Any) -> Any:
+    if isinstance(value, Future):
+        return _resolve_prediction_futures(value.result())
+    if isinstance(value, list):
+        return [_resolve_prediction_futures(element) for element in value]
+    if isinstance(value, tuple):
+        return tuple(_resolve_prediction_futures(element) for element in value)
+    if isinstance(value, dict):
+        return {
+            key: _resolve_prediction_futures(element) for key, element in value.items()
+        }
+    return value
+
+
+def _rfdetr_stream_pipeline_enabled() -> bool:
+    try:
+        return int(os.getenv("RFDETR_PIPELINE_DEPTH", "1").strip()) > 1
+    except ValueError:
+        return False

--- a/inference/core/interfaces/stream/model_handlers/workflows.py
+++ b/inference/core/interfaces/stream/model_handlers/workflows.py
@@ -1,14 +1,29 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+import networkx as nx
+
 from inference.core.interfaces.camera.entities import VideoFrame
 from inference.core.interfaces.stream.entities import InferenceHandlerResult
+from inference.core.workflows.execution_engine.constants import (
+    NODE_COMPILATION_OUTPUT_PROPERTY,
+)
 from inference.core.workflows.execution_engine.core import ExecutionEngine
 from inference.core.workflows.execution_engine.entities.base import VideoMetadata
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    DynamicStepInputDefinition,
+    NodeCategory,
+    StepInputDefinition,
+    StepNode,
+)
+from inference.core.workflows.execution_engine.v1.compiler.utils import (
+    get_step_selector_from_its_output,
+)
 
 
 @dataclass(frozen=True)
 class _StreamPipelineStep:
+    selector: str
     step: Any
 
 
@@ -184,6 +199,12 @@ def wrap_workflow_runner_for_stream_pipeline(
     stream_steps = _stream_pipeline_steps(execution_engine=execution_engine)
     if not stream_steps:
         return workflow_runner
+    if _workflow_requires_synchronous_stream_steps(
+        execution_engine=execution_engine,
+        stream_steps=stream_steps,
+    ):
+        _disable_stream_pipeline_steps(stream_steps=stream_steps)
+        return workflow_runner
     return PipelinedWorkflowRunner(
         workflow_runner=workflow_runner,
         stream_steps=stream_steps,
@@ -197,10 +218,15 @@ def _stream_pipeline_steps(
     compiled_workflow = getattr(engine, "_compiled_workflow", None)
     steps = getattr(compiled_workflow, "steps", {})
     stream_steps = []
-    for initialised_step in steps.values():
+    for step_name, initialised_step in steps.items():
         step_instance = getattr(initialised_step, "step", None)
         if _is_stream_pipeline_step(step_instance=step_instance):
-            stream_steps.append(_StreamPipelineStep(step=step_instance))
+            stream_steps.append(
+                _StreamPipelineStep(
+                    selector=f"$steps.{step_name}",
+                    step=step_instance,
+                )
+            )
     return stream_steps
 
 
@@ -217,3 +243,92 @@ def _stream_step_depth(stream_step: _StreamPipelineStep) -> int:
     if not callable(get_depth):
         return 0
     return max(0, int(get_depth()))
+
+
+def _workflow_requires_synchronous_stream_steps(
+    execution_engine: ExecutionEngine,
+    stream_steps: List[_StreamPipelineStep],
+) -> bool:
+    engine = getattr(execution_engine, "_engine", None)
+    compiled_workflow = getattr(engine, "_compiled_workflow", None)
+    execution_graph = getattr(compiled_workflow, "execution_graph", None)
+    if execution_graph is None:
+        return False
+    stream_step_selectors = {stream_step.selector for stream_step in stream_steps}
+    safe_step_selectors = set(stream_step_selectors)
+    downstream_step_selectors = set()
+    for stream_step_selector in stream_step_selectors:
+        if stream_step_selector not in execution_graph:
+            continue
+        downstream_step_selectors.update(
+            node
+            for node in nx.descendants(execution_graph, stream_step_selector)
+            if _is_step_node(execution_graph=execution_graph, node=node)
+        )
+    for node in nx.topological_sort(execution_graph):
+        if node not in downstream_step_selectors:
+            continue
+        step_node = _get_step_node(execution_graph=execution_graph, node=node)
+        if step_node is None:
+            continue
+        if _step_has_unsafe_stream_dependency(
+            step_node=step_node,
+            safe_step_selectors=safe_step_selectors,
+        ):
+            return True
+        safe_step_selectors.add(node)
+    return False
+
+
+def _disable_stream_pipeline_steps(stream_steps: List[_StreamPipelineStep]) -> None:
+    for stream_step in stream_steps:
+        disable_fn = getattr(
+            stream_step.step,
+            "disable_stream_pipeline_for_workflow",
+            None,
+        )
+        if callable(disable_fn):
+            disable_fn()
+
+
+def _step_has_unsafe_stream_dependency(
+    step_node: StepNode,
+    safe_step_selectors: set[str],
+) -> bool:
+    for input_definition in step_node.input_data.values():
+        for leaf_definition in _iter_step_input_definitions(input_definition):
+            if leaf_definition.is_static_value():
+                continue
+            if leaf_definition.points_to_input():
+                return True
+            if not isinstance(leaf_definition, DynamicStepInputDefinition):
+                continue
+            producer_step_selector = get_step_selector_from_its_output(
+                step_output_selector=leaf_definition.selector,
+            )
+            if producer_step_selector not in safe_step_selectors:
+                return True
+    return False
+
+
+def _iter_step_input_definitions(input_definition: Any):
+    iterate_definitions = getattr(input_definition, "iterate_through_definitions", None)
+    if callable(iterate_definitions):
+        yield from iterate_definitions()
+        return
+    if isinstance(input_definition, StepInputDefinition):
+        yield input_definition
+
+
+def _is_step_node(execution_graph: Any, node: str) -> bool:
+    step_node = _get_step_node(execution_graph=execution_graph, node=node)
+    return step_node is not None
+
+
+def _get_step_node(execution_graph: Any, node: str) -> Optional[StepNode]:
+    node_data = execution_graph.nodes[node].get(NODE_COMPILATION_OUTPUT_PROPERTY)
+    if getattr(node_data, "node_category", None) is not NodeCategory.STEP_NODE:
+        return None
+    if not isinstance(node_data, StepNode):
+        return None
+    return node_data

--- a/inference/core/interfaces/stream/model_handlers/workflows.py
+++ b/inference/core/interfaces/stream/model_handlers/workflows.py
@@ -1,24 +1,69 @@
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 from inference.core.interfaces.camera.entities import VideoFrame
+from inference.core.interfaces.stream.entities import InferenceHandlerResult
 from inference.core.workflows.execution_engine.core import ExecutionEngine
 from inference.core.workflows.execution_engine.entities.base import VideoMetadata
 
 
-class WorkflowRunner:
+@dataclass(frozen=True)
+class _StreamPipelineStep:
+    step: Any
 
-    def run_workflow(
+
+class WorkflowRunner:
+    def __init__(
         self,
-        video_frames: List[VideoFrame],
-        workflows_parameters: Optional[dict],
+        workflows_parameters: Optional[Dict[str, Any]],
         execution_engine: ExecutionEngine,
         image_input_name: str,
         video_metadata_input_name: str,
         serialize_results: bool = False,
         _is_preview: bool = False,
+    ):
+        self._workflows_parameters = workflows_parameters
+        self._execution_engine = execution_engine
+        self._image_input_name = image_input_name
+        self._video_metadata_input_name = video_metadata_input_name
+        self._serialize_results = serialize_results
+        self._is_preview = _is_preview
+
+    def __call__(self, video_frames: List[VideoFrame]) -> List[dict]:
+        return self._run_workflow(video_frames=video_frames)
+
+    def _run_workflow(
+        self,
+        video_frames: List[VideoFrame],
+        defer_stream_pipeline_flush: bool = False,
     ) -> List[dict]:
-        if workflows_parameters is None:
-            workflows_parameters = {}
+        workflows_parameters, fps = self._build_workflows_parameters(
+            video_frames=video_frames
+        )
+        return self._execution_engine.run(
+            runtime_parameters=workflows_parameters,
+            fps=fps,
+            serialize_results=self._serialize_results,
+            _is_preview=self._is_preview,
+            defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+        )
+
+    def _flush_stream_pipeline(self, video_frames: List[VideoFrame]) -> List[dict]:
+        workflows_parameters, fps = self._build_workflows_parameters(
+            video_frames=video_frames
+        )
+        return self._execution_engine.flush_stream_pipeline(
+            runtime_parameters=workflows_parameters,
+            fps=fps,
+            serialize_results=self._serialize_results,
+            _is_preview=self._is_preview,
+        )
+
+    def _build_workflows_parameters(
+        self,
+        video_frames: List[VideoFrame],
+    ) -> tuple[Dict[str, Any], float]:
+        workflows_parameters: Dict[str, Any] = dict(self._workflows_parameters or {})
         # TODO: pass fps reflecting each stream to workflows_parameters
         fps = video_frames[0].fps
         if video_frames[0].measured_fps:
@@ -41,7 +86,7 @@ class WorkflowRunner:
             )
             for video_frame in video_frames
         ]
-        workflows_parameters[image_input_name] = [
+        workflows_parameters[self._image_input_name] = [
             {
                 "type": "numpy_object",
                 "value": video_frame.image,
@@ -51,10 +96,118 @@ class WorkflowRunner:
                 video_frames, video_metadata_for_images
             )
         ]
-        workflows_parameters[video_metadata_input_name] = video_metadata_for_images
-        return execution_engine.run(
-            runtime_parameters=workflows_parameters,
-            fps=fps,
-            serialize_results=serialize_results,
-            _is_preview=_is_preview,
+        workflows_parameters[self._video_metadata_input_name] = (
+            video_metadata_for_images
         )
+        return workflows_parameters, fps
+
+
+class PipelinedWorkflowRunner:
+    def __init__(
+        self,
+        workflow_runner: WorkflowRunner,
+        stream_steps: List[_StreamPipelineStep],
+    ) -> None:
+        self._workflow_runner = workflow_runner
+        self._stream_steps = stream_steps
+        self._pending_video_frames: List[List[VideoFrame]] = []
+
+    def __call__(
+        self, video_frames: List[VideoFrame]
+    ) -> Optional[InferenceHandlerResult]:
+        predictions = self._workflow_runner._run_workflow(
+            video_frames=video_frames,
+            defer_stream_pipeline_flush=True,
+        )
+        stream_buffer_depth = self._stream_buffer_depth()
+        if stream_buffer_depth <= 0:
+            self._pending_video_frames.clear()
+            return InferenceHandlerResult(
+                predictions=predictions,
+                video_frames=video_frames,
+            )
+        self._pending_video_frames.append(video_frames)
+        if len(self._pending_video_frames) <= stream_buffer_depth:
+            return None
+        emit_video_frames = self._pending_video_frames.pop(0)
+        return InferenceHandlerResult(
+            predictions=predictions,
+            video_frames=emit_video_frames,
+        )
+
+    def flush(self) -> Optional[List[InferenceHandlerResult]]:
+        stream_steps = self._stream_steps
+        if not stream_steps:
+            self._pending_video_frames.clear()
+            return None
+        if not self._pending_video_frames:
+            return None
+        if len(stream_steps) != 1:
+            raise RuntimeError("Stream pipeline flushing supports one pipelined step")
+        results = []
+        for pending_video_frames in list(self._pending_video_frames):
+            prediction = self._workflow_runner._flush_stream_pipeline(
+                video_frames=pending_video_frames,
+            )
+            emit_video_frames = self._pending_video_frames.pop(0)
+            results.append(
+                InferenceHandlerResult(
+                    predictions=prediction,
+                    video_frames=emit_video_frames,
+                )
+            )
+        return results
+
+    def close(self) -> None:
+        for stream_step in self._stream_steps:
+            close_fn = getattr(stream_step.step, "close_stream_pipeline", None)
+            if callable(close_fn):
+                close_fn()
+
+    def _stream_buffer_depth(self) -> int:
+        return max(
+            (_stream_step_depth(stream_step) for stream_step in self._stream_steps),
+            default=0,
+        )
+
+
+def wrap_workflow_runner_for_stream_pipeline(
+    workflow_runner: WorkflowRunner,
+    execution_engine: ExecutionEngine,
+):
+    stream_steps = _stream_pipeline_steps(execution_engine=execution_engine)
+    if not stream_steps:
+        return workflow_runner
+    return PipelinedWorkflowRunner(
+        workflow_runner=workflow_runner,
+        stream_steps=stream_steps,
+    )
+
+
+def _stream_pipeline_steps(
+    execution_engine: ExecutionEngine,
+) -> List[_StreamPipelineStep]:
+    engine = getattr(execution_engine, "_engine", None)
+    compiled_workflow = getattr(engine, "_compiled_workflow", None)
+    steps = getattr(compiled_workflow, "steps", {})
+    stream_steps = []
+    for initialised_step in steps.values():
+        step_instance = getattr(initialised_step, "step", None)
+        if _is_stream_pipeline_step(step_instance=step_instance):
+            stream_steps.append(_StreamPipelineStep(step=step_instance))
+    return stream_steps
+
+
+def _is_stream_pipeline_step(step_instance: Any) -> bool:
+    is_stream_pipelined = getattr(step_instance, "is_stream_pipelined", None)
+    if callable(is_stream_pipelined) and is_stream_pipelined():
+        return True
+    can_activate_pipeline = getattr(step_instance, "can_activate_stream_pipeline", None)
+    return callable(can_activate_pipeline) and can_activate_pipeline()
+
+
+def _stream_step_depth(stream_step: _StreamPipelineStep) -> int:
+    get_depth = getattr(stream_step.step, "stream_pipeline_depth", None)
+    if not callable(get_depth):
+        return 0
+    return max(0, int(get_depth()))

--- a/inference/core/interfaces/stream/model_handlers/workflows.py
+++ b/inference/core/interfaces/stream/model_handlers/workflows.py
@@ -36,6 +36,7 @@ class WorkflowRunner:
         self,
         video_frames: List[VideoFrame],
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[dict]:
         workflows_parameters, fps = self._build_workflows_parameters(
             video_frames=video_frames
@@ -46,6 +47,7 @@ class WorkflowRunner:
             serialize_results=self._serialize_results,
             _is_preview=self._is_preview,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
     def _flush_stream_pipeline(self, video_frames: List[VideoFrame]) -> List[dict]:
@@ -115,9 +117,13 @@ class PipelinedWorkflowRunner:
     def __call__(
         self, video_frames: List[VideoFrame]
     ) -> Optional[InferenceHandlerResult]:
+        # Resolving RF-DETR output futures here serializes postprocess before the
+        # next frame can launch. The stream dispatcher resolves them after the
+        # frame buffer delay, when they should already be ready.
         predictions = self._workflow_runner._run_workflow(
             video_frames=video_frames,
             defer_stream_pipeline_flush=True,
+            resolve_output_futures=self._workflow_runner._serialize_results,
         )
         stream_buffer_depth = self._stream_buffer_depth()
         if stream_buffer_depth <= 0:

--- a/inference/core/models/base.py
+++ b/inference/core/models/base.py
@@ -141,6 +141,11 @@ class Model(BaseInference):
         """
         t1 = perf_counter()
         kwargs = request.dict()
+        stream_pipeline_context_id = getattr(
+            request, "stream_pipeline_context_id", None
+        )
+        if stream_pipeline_context_id is not None:
+            kwargs["stream_pipeline_context_id"] = stream_pipeline_context_id
         confidence = kwargs.get("confidence")
         if isinstance(confidence, str) and not USE_INFERENCE_MODELS:
             logger.warning(

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -74,11 +74,13 @@ from inference_models.configuration import (
     get_rfdetr_pipeline_depth,
 )
 from inference_models.models.base.async_handoff import (
+    STREAM_PIPELINE_CONTEXT_ID_KWARG,
     adapter_gpu_work_submitted,
     attach_adapter_mapped_kwargs,
     attach_async_response_future,
     get_adapter_gpu_submit_generation,
     get_adapter_mapped_kwargs,
+    get_adapter_stream_pipeline_context_id,
     get_deferred_postprocess_done_event,
     get_deferred_postprocess_finalizer,
     mark_adapter_gpu_work_submitted,
@@ -357,7 +359,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._gpu_submit_generation = 0
         self._response_executor: Optional[ThreadPoolExecutor] = None
         self._response_futures: Deque[
-            Future[List[InstanceSegmentationInferenceResponse]]
+            Tuple[
+                Future[List[InstanceSegmentationInferenceResponse]],
+                Optional[str],
+            ]
         ] = deque()
 
     def _resolve_pipeline_depth(self) -> int:
@@ -394,6 +399,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             and not enforce_dense_masks_in_inference_models
         ):
             kwargs["mask_format"] = "rle"
+        kwargs.pop(STREAM_PIPELINE_CONTEXT_ID_KWARG, None)
         return kwargs
 
     def preprocess(self, image: Any, **kwargs):
@@ -443,7 +449,14 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._submit_next_pending_gpu_work()
         pre_processing_meta = getattr(img_in, "_pre_processing_meta", None)
         fut = self._model.forward_async(img_in, pre_processing_meta, **mapped_kwargs)
-        attach_adapter_mapped_kwargs(fut, mapped_kwargs)
+        stream_pipeline_context_id = kwargs.get(STREAM_PIPELINE_CONTEXT_ID_KWARG)
+        if not isinstance(stream_pipeline_context_id, str):
+            stream_pipeline_context_id = None
+        attach_adapter_mapped_kwargs(
+            fut,
+            mapped_kwargs,
+            stream_pipeline_context_id=stream_pipeline_context_id,
+        )
         if pre_processing_meta is not None:
             self._submit_future_gpu_work(fut, pre_processing_meta, mapped_kwargs)
         self._submit_ready_responses()
@@ -463,7 +476,8 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._submit_all_pending_responses()
         responses: List[InstanceSegmentationInferenceResponse] = []
         while self._response_futures:
-            responses.extend(self._response_futures.popleft().result())
+            response_future, _ = self._response_futures.popleft()
+            responses.extend(response_future.result())
         return responses
 
     def shutdown_pipeline(self) -> None:
@@ -516,7 +530,13 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             meta,
             mapped_kwargs,
         )
-        self._response_futures.append(response_future)
+        context_id = get_adapter_stream_pipeline_context_id(fut)
+        self._response_futures.append(
+            (
+                response_future,
+                context_id,
+            )
+        )
 
     def _submit_ready_responses(self) -> None:
         while self._pending_futures:
@@ -566,14 +586,18 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                 workflow_execution=kwargs.get("source") == "workflow-execution",
             )
 
-        response_future = self._response_futures.popleft()
+        response_future, context_id = self._response_futures.popleft()
         if kwargs.get("source") == "workflow-execution":
             responses = self._empty_responses_for_metadata(
                 preprocess_return_metadata=preprocess_return_metadata,
                 workflow_execution=True,
             )
             if responses:
-                attach_async_response_future(responses[0], response_future)
+                attach_async_response_future(
+                    response=responses[0],
+                    response_future=response_future,
+                    context_id=context_id,
+                )
             return responses
         return response_future.result()
 

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -1,7 +1,7 @@
 import base64
 import io
 from collections import OrderedDict, deque
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from io import BytesIO
 from threading import local
 from time import perf_counter
@@ -45,6 +45,7 @@ from inference.core.env import (
     GCP_SERVERLESS,
     RFDETR_ONNX_MAX_RESOLUTION,
     VALID_INFERENCE_MODELS_BACKENDS,
+    WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
 )
 from inference.core.exceptions import PostProcessingError
 from inference.core.models.base import Model
@@ -143,6 +144,16 @@ def get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
     while len(cache) > _PINNED_HOST_BUFFER_CACHE_SIZE:
         cache.popitem(last=False)
     return buf
+
+
+def _resolve_response_future(
+    future: Future,
+    context: str,
+):
+    try:
+        return future.result(timeout=WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT)
+    except TimeoutError as error:
+        raise RuntimeError(f"Timed out while waiting for {context}.") from error
 
 
 class _PipelinePrimingSentinel:
@@ -477,7 +488,12 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         responses: List[InstanceSegmentationInferenceResponse] = []
         while self._response_futures:
             response_future, _ = self._response_futures.popleft()
-            responses.extend(response_future.result())
+            responses.extend(
+                _resolve_response_future(
+                    future=response_future,
+                    context="RF-DETR stream pipeline flush",
+                )
+            )
         return responses
 
     def shutdown_pipeline(self) -> None:
@@ -599,7 +615,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                     context_id=context_id,
                 )
             return responses
-        return response_future.result()
+        return _resolve_response_future(
+            future=response_future,
+            context="RF-DETR stream pipeline response finalization",
+        )
 
     def _empty_responses_for_metadata(
         self,

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -1,11 +1,12 @@
 import base64
 import io
 from collections import OrderedDict, deque
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from io import BytesIO
 from threading import local
 from time import perf_counter
 from typing import Any, Deque, List, Optional, Tuple, Union
+from weakref import finalize
 
 import numpy as np
 import torch
@@ -45,6 +46,7 @@ from inference.core.env import (
     GCP_SERVERLESS,
     RFDETR_ONNX_MAX_RESOLUTION,
     VALID_INFERENCE_MODELS_BACKENDS,
+    WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
 )
 from inference.core.exceptions import PostProcessingError
 from inference.core.models.base import Model
@@ -141,6 +143,16 @@ def get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
     while len(cache) > _PINNED_HOST_BUFFER_CACHE_SIZE:
         cache.popitem(last=False)
     return buf
+
+
+def _resolve_response_future(
+    future: Future,
+    context: str,
+):
+    try:
+        return future.result(timeout=WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT)
+    except TimeoutError as error:
+        raise RuntimeError(f"Timed out while waiting for {context}.") from error
 
 
 class _PipelinePrimingSentinel:
@@ -356,8 +368,12 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         ] = deque()
         self._gpu_submit_generation = 0
         self._response_executor: Optional[ThreadPoolExecutor] = None
+        self._response_executor_finalizer = None
         self._response_futures: Deque[
-            Future[List[InstanceSegmentationInferenceResponse]]
+            Tuple[
+                Future[List[InstanceSegmentationInferenceResponse]],
+                Optional[str],
+            ]
         ] = deque()
 
     def _resolve_pipeline_depth(self) -> int:
@@ -463,18 +479,33 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._submit_all_pending_responses()
         responses: List[InstanceSegmentationInferenceResponse] = []
         while self._response_futures:
-            responses.extend(self._response_futures.popleft().result())
+            response_future, _ = self._response_futures.popleft()
+            responses.extend(
+                _resolve_response_future(
+                    future=response_future,
+                    context="RF-DETR stream pipeline flush",
+                )
+            )
         return responses
 
     def shutdown_pipeline(self) -> None:
         if self._response_executor is None:
             return None
+        finalizer = getattr(self, "_response_executor_finalizer", None)
+        if finalizer is not None and finalizer.alive:
+            finalizer.detach()
         self._response_executor.shutdown(wait=False)
         self._response_executor = None
+        self._response_executor_finalizer = None
 
     def _get_response_executor(self) -> ThreadPoolExecutor:
         if self._response_executor is None:
             self._response_executor = ThreadPoolExecutor(max_workers=1)
+            self._response_executor_finalizer = finalize(
+                self,
+                self._response_executor.shutdown,
+                wait=False,
+            )
         return self._response_executor
 
     def _submit_future_gpu_work(
@@ -490,7 +521,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         submit_gpu_work = getattr(fut, "submit_gpu_work", None)
         if callable(submit_gpu_work):
             submit_gpu_work(meta)
-            self._gpu_submit_generation = getattr(self, "_gpu_submit_generation", 0) + 1
+            self._gpu_submit_generation += 1
             mark_adapter_gpu_work_submitted(fut, self._gpu_submit_generation)
 
     def _submit_next_pending_gpu_work(self) -> None:
@@ -516,7 +547,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             meta,
             mapped_kwargs,
         )
-        self._response_futures.append(response_future)
+        context_id = mapped_kwargs.get("source_info")
+        self._response_futures.append(
+            (response_future, context_id if isinstance(context_id, str) else None)
+        )
 
     def _submit_ready_responses(self) -> None:
         while self._pending_futures:
@@ -527,7 +561,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                 submit_generation = get_adapter_gpu_submit_generation(fut)
             if submit_generation is None:
                 break
-            gpu_submit_generation = getattr(self, "_gpu_submit_generation", 0)
+            gpu_submit_generation = self._gpu_submit_generation
             if gpu_submit_generation < submit_generation + self._response_delay:
                 break
             self._submit_response_build(*self._pending_futures.popleft())
@@ -566,16 +600,23 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                 workflow_execution=kwargs.get("source") == "workflow-execution",
             )
 
-        response_future = self._response_futures.popleft()
+        response_future, context_id = self._response_futures.popleft()
         if kwargs.get("source") == "workflow-execution":
             responses = self._empty_responses_for_metadata(
                 preprocess_return_metadata=preprocess_return_metadata,
                 workflow_execution=True,
             )
             if responses:
-                attach_async_response_future(responses[0], response_future)
+                attach_async_response_future(
+                    response=responses[0],
+                    response_future=response_future,
+                    context_id=context_id,
+                )
             return responses
-        return response_future.result()
+        return _resolve_response_future(
+            future=response_future,
+            context="RF-DETR stream pipeline response finalization",
+        )
 
     def _empty_responses_for_metadata(
         self,
@@ -809,6 +850,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                         polys_or_rles = rle_masks2poly(det.mask)
                 class_ids = det.class_id.detach().cpu().numpy()
 
+            # Some branches above intentionally keep numpy views into
+            # thread-local pinned scratch buffers. Only scalar values and
+            # polygon/RLE lists may be stored on responses below; do not return
+            # those arrays or any view derived from them.
             predictions: List[
                 Union[InstanceSegmentationPrediction, InstanceSegmentationRLEPrediction]
             ] = []

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -1,8 +1,11 @@
 import base64
 import io
+from collections import OrderedDict, deque
+from concurrent.futures import Future, ThreadPoolExecutor
 from io import BytesIO
+from threading import local
 from time import perf_counter
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Deque, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -17,8 +20,11 @@ from inference.core.entities.responses.inference import (
     ClassificationInferenceResponse,
     InferenceResponse,
     InferenceResponseImage,
+    InferenceResponseImageDC,
     InstanceSegmentationInferenceResponse,
+    InstanceSegmentationInferenceResponseDC,
     InstanceSegmentationPrediction,
+    InstanceSegmentationPredictionDC,
     InstanceSegmentationRLEPrediction,
     Keypoint,
     KeypointsDetectionInferenceResponse,
@@ -27,6 +33,7 @@ from inference.core.entities.responses.inference import (
     ObjectDetectionInferenceResponse,
     ObjectDetectionPrediction,
     Point,
+    PointDC,
     SemanticSegmentationInferenceResponse,
     SemanticSegmentationPrediction,
 )
@@ -43,7 +50,8 @@ from inference.core.exceptions import PostProcessingError
 from inference.core.models.base import Model
 from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr, load_image_rgb
-from inference.core.utils.postprocess import mask2poly, masks2poly
+from inference.core.utils.postprocess import bitpacked_masks2poly, mask2poly, masks2poly
+from inference.core.utils.rle_to_polygon import rle_masks_to_polygons
 from inference.core.utils.visualisation import draw_detection_predictions
 from inference.models.aliases import resolve_roboflow_model_alias
 from inference_models import (
@@ -60,6 +68,24 @@ from inference_models import (
     ObjectDetectionModel,
     PreProcessingOverrides,
     SemanticSegmentationModel,
+)
+from inference_models.configuration import (
+    INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED,
+    get_rfdetr_pipeline_depth,
+)
+from inference_models.models.base.async_handoff import (
+    adapter_gpu_work_submitted,
+    attach_adapter_mapped_kwargs,
+    attach_async_response_future,
+    get_adapter_gpu_submit_generation,
+    get_adapter_mapped_kwargs,
+    get_deferred_postprocess_done_event,
+    get_deferred_postprocess_finalizer,
+    mark_adapter_gpu_work_submitted,
+)
+from inference_models.models.base.instance_segmentation import InferenceFuture
+from inference_models.models.base.semantic_segmentation import (
+    SemanticSegmentationResult,
 )
 from inference_models.models.base.types import InstancesRLEMasks, PreprocessingMetadata
 from inference_models.models.common.rle_utils import torch_mask_to_coco_rle
@@ -87,6 +113,44 @@ DEFAULT_COLOR_PALETTE = [
     "#FF97CA",
     "#FF39C9",
 ]
+
+_PINNED_HOST_BUFFER_CACHE_SIZE = 16
+_PINNED_HOST_BUFFER_CONTEXT = local()
+
+
+def get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
+    """Return a thread-local pinned CPU scratch tensor for async DtoH copies.
+
+    Response finalization can run on a worker thread while the inference thread
+    submits later GPU work. Keeping this cache thread-local avoids two workers
+    writing into the same scratch tensor. The small LRU cap prevents retaining a
+    new pinned allocation for every transient shape.
+    """
+    cache = getattr(_PINNED_HOST_BUFFER_CONTEXT, "cache", None)
+    if cache is None:
+        cache = OrderedDict()
+        _PINNED_HOST_BUFFER_CONTEXT.cache = cache
+    key = (name, dtype)
+    buf = cache.get(key)
+    if buf is not None and all(buf.shape[i] >= shape[i] for i in range(len(shape))):
+        cache.move_to_end(key)
+        return buf[tuple(slice(0, s) for s in shape)]
+    buf = torch.empty(shape, dtype=dtype, pin_memory=True)
+    cache[key] = buf
+    cache.move_to_end(key)
+    while len(cache) > _PINNED_HOST_BUFFER_CACHE_SIZE:
+        cache.popitem(last=False)
+    return buf
+
+
+class _PipelinePrimingSentinel:
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debug only
+        return "<_PIPELINE_PRIMING>"
+
+
+_PIPELINE_PRIMING = _PipelinePrimingSentinel()
 
 
 class InferenceModelsObjectDetectionAdapter(Model):
@@ -272,6 +336,43 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             **kwargs,
         )
         self.class_names = list(self._model.class_names)
+        # Stream pipelining: depth=1 means original synchronous behavior
+        # (preprocess→forward→postprocess on each frame, in order). depth=2
+        # means two stages in parallel: while the GPU works on the current
+        # frame, the CPU prepares/submits the next frame, then harvests the
+        # previous response. Only models that explicitly support the deferred
+        # GPU handoff contract can use this; other instance-segmentation
+        # backends keep depth=1 even if RFDETR_PIPELINE_DEPTH is set.
+        self._pipeline_depth = self._resolve_pipeline_depth()
+        self._response_delay = max(1, self._pipeline_depth - 1)
+        # Per-adapter in-flight futures + metadata. Not thread-safe; the
+        # InferencePipeline is single-producer and the adapter is owned by a
+        # single worker.
+        self._pending_gpu_submissions: Deque[
+            Tuple[InferenceFuture, PreprocessingMetadata, dict]
+        ] = deque()
+        self._pending_futures: Deque[
+            Tuple[InferenceFuture, PreprocessingMetadata, dict]
+        ] = deque()
+        self._gpu_submit_generation = 0
+        self._response_executor: Optional[ThreadPoolExecutor] = None
+        self._response_futures: Deque[
+            Future[List[InstanceSegmentationInferenceResponse]]
+        ] = deque()
+
+    def _resolve_pipeline_depth(self) -> int:
+        requested_depth = get_rfdetr_pipeline_depth()
+        if requested_depth <= 1 or self._model_supports_stream_pipeline():
+            return requested_depth
+        return 1
+
+    def _model_supports_stream_pipeline(self) -> bool:
+        supports_stream_pipeline = getattr(
+            self._model, "supports_stream_pipeline", False
+        )
+        if callable(supports_stream_pipeline):
+            return bool(supports_stream_pipeline())
+        return bool(supports_stream_pipeline)
 
     def map_inference_kwargs(self, kwargs: dict) -> dict:
         kwargs["input_color_format"] = "bgr"
@@ -310,11 +411,217 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
         return self._model.pre_process(np_images, **mapped_kwargs)
 
+    def _request_batch_size(self, img_in: Any) -> int:
+        pre_processing_meta = getattr(img_in, "_pre_processing_meta", None)
+        if isinstance(pre_processing_meta, (list, tuple)):
+            return len(pre_processing_meta)
+        shape = getattr(img_in, "shape", None)
+        if shape is not None and len(shape) > 0:
+            return int(shape[0])
+        if isinstance(img_in, (list, tuple)):
+            return len(img_in)
+        return 1
+
     def predict(self, img_in, **kwargs):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
-        return self._model.forward(img_in, **mapped_kwargs)
+        if self._pipeline_depth <= 1:
+            # Original path: forward on current frame, postprocess on
+            # current frame, all synchronous.
+            return self._model.forward(img_in, **mapped_kwargs)
+        if self._request_batch_size(img_in) > 1:
+            return self._model.forward(img_in, **mapped_kwargs)
+
+        mapped_kwargs["defer_count_to_adapter"] = (
+            kwargs.get("response_mask_format") != "rle"
+        )
+        mapped_kwargs["defer_postprocess_sync"] = True
+        mapped_kwargs["reuse_trt_graph_outputs"] = True
+        # Pipelined path: before launching frame N's forward, enqueue the
+        # oldest frame whose postprocess metadata is already known. That keeps
+        # postprocess off the current frame's postprocess() host path while
+        # still preserving the correctness dependency for reused TRT outputs.
+        self._submit_next_pending_gpu_work()
+        pre_processing_meta = getattr(img_in, "_pre_processing_meta", None)
+        fut = self._model.forward_async(img_in, pre_processing_meta, **mapped_kwargs)
+        attach_adapter_mapped_kwargs(fut, mapped_kwargs)
+        if pre_processing_meta is not None:
+            self._submit_future_gpu_work(fut, pre_processing_meta, mapped_kwargs)
+        self._submit_ready_responses()
+        return fut
+
+    def flush(self) -> List[InstanceSegmentationInferenceResponse]:
+        """Drain the tail of the pipelined queue.
+
+        Returns responses for any in-flight frames whose forward/postprocess
+        GPU work was submitted but whose CPU-visible response has not yet been
+        materialized. Callers that use `RFDETR_PIPELINE_DEPTH>=2` MUST invoke
+        this at stream end or the final frames will be dropped.
+        """
+        if self._pipeline_depth <= 1:
+            return []
+        self._submit_all_pending_gpu_work()
+        self._submit_all_pending_responses()
+        responses: List[InstanceSegmentationInferenceResponse] = []
+        while self._response_futures:
+            responses.extend(self._response_futures.popleft().result())
+        return responses
+
+    def shutdown_pipeline(self) -> None:
+        if self._response_executor is None:
+            return None
+        self._response_executor.shutdown(wait=False)
+        self._response_executor = None
+
+    def _get_response_executor(self) -> ThreadPoolExecutor:
+        if self._response_executor is None:
+            self._response_executor = ThreadPoolExecutor(max_workers=1)
+        return self._response_executor
+
+    def _submit_future_gpu_work(
+        self,
+        fut: InferenceFuture,
+        meta: PreprocessingMetadata,
+        mapped_kwargs: dict,
+    ) -> None:
+        if adapter_gpu_work_submitted(fut):
+            return None
+        fut._meta = meta  # type: ignore[attr-defined]
+        fut._kwargs = mapped_kwargs  # type: ignore[attr-defined]
+        submit_gpu_work = getattr(fut, "submit_gpu_work", None)
+        if callable(submit_gpu_work):
+            submit_gpu_work(meta)
+            self._gpu_submit_generation = getattr(self, "_gpu_submit_generation", 0) + 1
+            mark_adapter_gpu_work_submitted(fut, self._gpu_submit_generation)
+
+    def _submit_next_pending_gpu_work(self) -> None:
+        if not self._pending_gpu_submissions:
+            return None
+        self._submit_future_gpu_work(*self._pending_gpu_submissions.popleft())
+
+    def _submit_all_pending_gpu_work(self) -> None:
+        while self._pending_gpu_submissions:
+            self._submit_future_gpu_work(*self._pending_gpu_submissions.popleft())
+
+    def _submit_response_build(
+        self,
+        fut: InferenceFuture,
+        meta: PreprocessingMetadata,
+        mapped_kwargs: dict,
+    ) -> None:
+        fut._meta = meta  # type: ignore[attr-defined]
+        fut._kwargs = mapped_kwargs  # type: ignore[attr-defined]
+        response_future = self._get_response_executor().submit(
+            self._finalize_future,
+            fut,
+            meta,
+            mapped_kwargs,
+        )
+        self._response_futures.append(response_future)
+
+    def _submit_ready_responses(self) -> None:
+        while self._pending_futures:
+            fut, meta, mapped_kwargs = self._pending_futures[0]
+            submit_generation = get_adapter_gpu_submit_generation(fut)
+            if submit_generation is None:
+                self._submit_future_gpu_work(fut, meta, mapped_kwargs)
+                submit_generation = get_adapter_gpu_submit_generation(fut)
+            if submit_generation is None:
+                break
+            gpu_submit_generation = getattr(self, "_gpu_submit_generation", 0)
+            if gpu_submit_generation < submit_generation + self._response_delay:
+                break
+            self._submit_response_build(*self._pending_futures.popleft())
+
+    def _submit_all_pending_responses(self) -> None:
+        while self._pending_futures:
+            self._submit_response_build(*self._pending_futures.popleft())
 
     def postprocess(
+        self,
+        predictions,
+        preprocess_return_metadata: PreprocessingMetadata,
+        **kwargs,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        if self._pipeline_depth <= 1 or not isinstance(predictions, InferenceFuture):
+            return self._postprocess_sync(
+                predictions, preprocess_return_metadata, **kwargs
+            )
+        fut: InferenceFuture = predictions
+        mapped_kwargs = get_adapter_mapped_kwargs(fut)
+        self._pending_gpu_submissions.append(
+            (
+                fut,
+                preprocess_return_metadata,
+                mapped_kwargs,
+            )
+        )
+        self._pending_futures.append((fut, preprocess_return_metadata, mapped_kwargs))
+        if len(self._pending_futures) > self._response_delay:
+            self._submit_next_pending_gpu_work()
+            self._submit_ready_responses()
+
+        if not self._response_futures:
+            return self._empty_responses_for_metadata(
+                preprocess_return_metadata=preprocess_return_metadata,
+                workflow_execution=kwargs.get("source") == "workflow-execution",
+            )
+
+        response_future = self._response_futures.popleft()
+        if kwargs.get("source") == "workflow-execution":
+            responses = self._empty_responses_for_metadata(
+                preprocess_return_metadata=preprocess_return_metadata,
+                workflow_execution=True,
+            )
+            if responses:
+                attach_async_response_future(responses[0], response_future)
+            return responses
+        return response_future.result()
+
+    def _empty_responses_for_metadata(
+        self,
+        preprocess_return_metadata: PreprocessingMetadata,
+        workflow_execution: bool,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        if workflow_execution:
+            return [
+                InstanceSegmentationInferenceResponseDC(
+                    predictions=[],
+                    image=InferenceResponseImageDC(
+                        width=m.original_size.width,
+                        height=m.original_size.height,
+                    ),
+                )
+                for m in preprocess_return_metadata
+            ]
+        return [
+            InstanceSegmentationInferenceResponse(
+                predictions=[],
+                image=InferenceResponseImage(
+                    width=m.original_size.width,
+                    height=m.original_size.height,
+                ),
+            )
+            for m in preprocess_return_metadata
+        ]
+
+    def _finalize_future(
+        self,
+        fut: InferenceFuture,
+        preprocess_return_metadata: PreprocessingMetadata,
+        mapped_kwargs: dict,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        # Override the future's stashed meta (which was `None` at submit
+        # time) with the correct metadata for the frame whose forward pass
+        # the future represents. This is an allowed private-surface tweak
+        # because _DirectInferenceFuture's post_process is memoised.
+        fut._meta = preprocess_return_metadata  # type: ignore[attr-defined]
+        fut._kwargs = mapped_kwargs  # type: ignore[attr-defined]
+        detections_list = fut.result()
+        return self._build_responses_from_detections(
+            detections_list, preprocess_return_metadata, **mapped_kwargs
+        )
+
+    def _postprocess_sync(
         self,
         predictions: List[InstanceDetections],
         preprocess_return_metadata: PreprocessingMetadata,
@@ -322,31 +629,185 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
     ) -> List[InstanceSegmentationInferenceResponse]:
         return_in_rle = kwargs.get("response_mask_format") == "rle"
         mapped_kwargs = self.map_inference_kwargs(kwargs)
+        mapped_kwargs["defer_count_to_adapter"] = not return_in_rle
         detections_list = self._model.post_process(
             predictions, preprocess_return_metadata, **mapped_kwargs
+        )
+        return self._build_responses_from_detections(
+            detections_list, preprocess_return_metadata, **kwargs
+        )
+
+    def _build_responses_from_detections(
+        self,
+        detections_list: List[InstanceDetections],
+        preprocess_return_metadata: PreprocessingMetadata,
+        **kwargs,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        return_in_rle = kwargs.get("response_mask_format") == "rle"
+        # Workflow callers consume a plain dict via `_is_response_dc_to_dict`;
+        # dataclasses avoid pydantic validation + `model_dump` overhead per
+        # frame. Keep the pydantic path for RLE responses and for non-workflow
+        # callers that rely on the response model type.
+        use_dc = (
+            kwargs.get("source") == "workflow-execution"
+            and not return_in_rle
+            and getattr(self, "_pipeline_depth", 1) > 1
         )
 
         responses: List[InstanceSegmentationInferenceResponse] = []
         for preproc_metadata, det in zip(preprocess_return_metadata, detections_list):
+            finalize_pending = get_deferred_postprocess_finalizer(det)
+            if callable(finalize_pending):
+                det = finalize_pending()
             H = preproc_metadata.original_size.height
             W = preproc_metadata.original_size.width
 
-            xyxy = det.xyxy.detach().cpu().numpy()
-            confs = det.confidence.detach().cpu().numpy()
-            if isinstance(det.mask, torch.Tensor):
-                masks = det.mask.detach().cpu().numpy()
-                if return_in_rle:
-                    polys_or_rles = [
-                        torch_mask_to_coco_rle(mask=mask) for mask in masks
-                    ]
+            combined_gpu = getattr(det, "_combined_gpu", None)
+            mask_gpu = getattr(det, "_mask_gpu", None)
+            mask_packed_gpu = getattr(det, "_mask_packed_gpu", None)
+            mask_cpu = getattr(det, "_mask_cpu", None)
+            defer_count_to_adapter = getattr(det, "_defer_count_to_adapter", False)
+            done_event = get_deferred_postprocess_done_event(det)
+            dense_mask_cuda = isinstance(mask_gpu, torch.Tensor) and mask_gpu.is_cuda
+            packed_mask_cuda = (
+                isinstance(mask_packed_gpu, torch.Tensor) and mask_packed_gpu.is_cuda
+            )
+            if (
+                not return_in_rle
+                and done_event is not None
+                and (dense_mask_cuda or packed_mask_cuda)
+            ):
+                device = mask_gpu.device if dense_mask_cuda else mask_packed_gpu.device
+                stream = torch.cuda.current_stream(device)
+                done_event.wait(stream)
+
+                if (
+                    defer_count_to_adapter
+                    and isinstance(combined_gpu, torch.Tensor)
+                    and combined_gpu.is_cuda
+                ):
+                    combined_host = get_pinned_buffer(
+                        "combined_full",
+                        tuple(combined_gpu.shape),
+                        combined_gpu.dtype,
+                    )
+                    combined_host.copy_(combined_gpu, non_blocking=True)
+                    stream.synchronize()
+                    combined_np = combined_host.numpy()
+                    class_column = combined_np[:, 5]
+                    inactive_indices = np.flatnonzero(class_column < 0)
+                    n_survivors = (
+                        int(inactive_indices[0])
+                        if inactive_indices.size > 0
+                        else int(class_column.shape[0])
+                    )
+                    if n_survivors == 0:
+                        xyxy = np.empty((0, 4), dtype=np.int32)
+                        confs = np.empty((0,), dtype=np.float32)
+                        class_ids = np.empty((0,), dtype=np.int32)
+                        polys_or_rles = []
+                    else:
+                        combined_slice = combined_np[:n_survivors]
+                        xyxy = combined_slice[:, :4]
+                        confs = combined_slice[:, 4].view(np.float32)
+                        class_ids = combined_slice[:, 5]
+                        if packed_mask_cuda:
+                            packed_slice = mask_packed_gpu[:n_survivors]
+                            packed_host = get_pinned_buffer(
+                                "mask_packed",
+                                tuple(packed_slice.shape),
+                                packed_slice.dtype,
+                            )
+                            packed_host.copy_(packed_slice, non_blocking=True)
+                            stream.synchronize()
+                            polys_or_rles = bitpacked_masks2poly(
+                                packed_host.numpy(), width=W
+                            )
+                        else:
+                            mask_slice = mask_gpu[:n_survivors]
+                            mask_host = get_pinned_buffer(
+                                "mask", tuple(mask_slice.shape), mask_slice.dtype
+                            )
+                            mask_host.copy_(mask_slice, non_blocking=True)
+                            stream.synchronize()
+                            polys_or_rles = masks2poly(mask_host.numpy())
                 else:
-                    polys_or_rles = masks2poly(masks)
+                    n_survivors = int(det.xyxy.shape[0])
+                    if n_survivors == 0:
+                        xyxy = np.empty((0, 4), dtype=np.int32)
+                        confs = np.empty((0,), dtype=np.float32)
+                        class_ids = np.empty((0,), dtype=np.int32)
+                        polys_or_rles = []
+                    else:
+                        mask_slice = mask_gpu[:n_survivors]
+                        mask_host = get_pinned_buffer(
+                            "mask", tuple(mask_slice.shape), mask_slice.dtype
+                        )
+                        if (
+                            isinstance(combined_gpu, torch.Tensor)
+                            and combined_gpu.is_cuda
+                            and tuple(combined_gpu.shape)
+                            == (n_survivors, det.xyxy.shape[1] + 2)
+                        ):
+                            combined_slice = combined_gpu[:n_survivors]
+                            combined_host = get_pinned_buffer(
+                                "combined",
+                                tuple(combined_slice.shape),
+                                combined_slice.dtype,
+                            )
+                            combined_host.copy_(combined_slice, non_blocking=True)
+                            mask_host.copy_(mask_slice, non_blocking=True)
+                            stream.synchronize()
+                            combined_np = combined_host.numpy()
+                            xyxy = combined_np[:, :4]
+                            confs = combined_np[:, 4].view(np.float32)
+                            class_ids = combined_np[:, 5]
+                            polys_or_rles = masks2poly(mask_host.numpy())
+                        else:
+                            xyxy_host = get_pinned_buffer(
+                                "xyxy", tuple(det.xyxy.shape), det.xyxy.dtype
+                            )
+                            conf_host = get_pinned_buffer(
+                                "conf",
+                                tuple(det.confidence.shape),
+                                det.confidence.dtype,
+                            )
+                            class_host = get_pinned_buffer(
+                                "class_id",
+                                tuple(det.class_id.shape),
+                                det.class_id.dtype,
+                            )
+                            xyxy_host.copy_(det.xyxy, non_blocking=True)
+                            conf_host.copy_(det.confidence, non_blocking=True)
+                            class_host.copy_(det.class_id, non_blocking=True)
+                            mask_host.copy_(mask_slice, non_blocking=True)
+                            stream.synchronize()
+                            xyxy = xyxy_host.numpy()
+                            confs = conf_host.numpy()
+                            class_ids = class_host.numpy()
+                            polys_or_rles = masks2poly(mask_host.numpy())
+            elif not return_in_rle and isinstance(mask_cpu, np.ndarray):
+                xyxy = det.xyxy.detach().cpu().numpy()
+                confs = det.confidence.detach().cpu().numpy()
+                class_ids = det.class_id.detach().cpu().numpy()
+                polys_or_rles = masks2poly(mask_cpu)
             else:
-                if return_in_rle:
-                    polys_or_rles = det.mask.to_coco_rle_masks()
+                xyxy = det.xyxy.detach().cpu().numpy()
+                confs = det.confidence.detach().cpu().numpy()
+                if isinstance(det.mask, torch.Tensor):
+                    masks = det.mask.detach().cpu().numpy()
+                    if return_in_rle:
+                        polys_or_rles = [
+                            torch_mask_to_coco_rle(mask=mask) for mask in masks
+                        ]
+                    else:
+                        polys_or_rles = masks2poly(masks)
                 else:
-                    polys_or_rles = rle_masks2poly(det.mask)
-            class_ids = det.class_id.detach().cpu().numpy()
+                    if return_in_rle:
+                        polys_or_rles = det.mask.to_coco_rle_masks()
+                    else:
+                        polys_or_rles = rle_masks2poly(det.mask)
+                class_ids = det.class_id.detach().cpu().numpy()
 
             predictions: List[
                 Union[InstanceSegmentationPrediction, InstanceSegmentationRLEPrediction]
@@ -370,46 +831,71 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                     and class_name not in kwargs["class_filter"]
                 ):
                     continue
-                if not return_in_rle:
+                if use_dc:
                     predictions.append(
-                        InstanceSegmentationPrediction(
+                        InstanceSegmentationPredictionDC(
                             x=cx,
                             y=cy,
                             width=w,
                             height=h,
                             confidence=float(conf),
+                            class_name=class_name,
+                            class_id=class_id_int,
                             points=[
-                                Point(x=point[0], y=point[1])
+                                PointDC(x=float(point[0]), y=float(point[1]))
                                 for point in mask_as_poly_or_rle
                             ],
-                            **{"class": class_name},
-                            class_id=class_id_int,
                         )
                     )
                 else:
-                    if isinstance(mask_as_poly_or_rle["counts"], bytes):
-                        mask_as_poly_or_rle["counts"] = mask_as_poly_or_rle[
-                            "counts"
-                        ].decode("ascii")
-                    predictions.append(
-                        InstanceSegmentationRLEPrediction(
-                            x=cx,
-                            y=cy,
-                            width=w,
-                            height=h,
-                            confidence=float(conf),
-                            rle=mask_as_poly_or_rle,
-                            **{"class": class_name},
-                            class_id=class_id_int,
+                    if not return_in_rle:
+                        predictions.append(
+                            InstanceSegmentationPrediction(
+                                x=cx,
+                                y=cy,
+                                width=w,
+                                height=h,
+                                confidence=float(conf),
+                                points=[
+                                    Point(x=point[0], y=point[1])
+                                    for point in mask_as_poly_or_rle
+                                ],
+                                **{"class": class_name},
+                                class_id=class_id_int,
+                            )
                         )
-                    )
+                    else:
+                        if isinstance(mask_as_poly_or_rle["counts"], bytes):
+                            mask_as_poly_or_rle["counts"] = mask_as_poly_or_rle[
+                                "counts"
+                            ].decode("ascii")
+                        predictions.append(
+                            InstanceSegmentationRLEPrediction(
+                                x=cx,
+                                y=cy,
+                                width=w,
+                                height=h,
+                                confidence=float(conf),
+                                rle=mask_as_poly_or_rle,
+                                **{"class": class_name},
+                                class_id=class_id_int,
+                            )
+                        )
 
-            responses.append(
-                InstanceSegmentationInferenceResponse(
-                    predictions=predictions,
-                    image=InferenceResponseImage(width=W, height=H),
+            if use_dc:
+                responses.append(
+                    InstanceSegmentationInferenceResponseDC(
+                        predictions=predictions,
+                        image=InferenceResponseImageDC(width=W, height=H),
+                    )
                 )
-            )
+            else:
+                responses.append(
+                    InstanceSegmentationInferenceResponse(
+                        predictions=predictions,
+                        image=InferenceResponseImage(width=W, height=H),
+                    )
+                )
         return responses
 
     def clear_cache(self, delete_from_disk: bool = True) -> None:
@@ -446,13 +932,14 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
 
 
 def rle_masks2poly(masks: InstancesRLEMasks) -> List[np.ndarray]:
+    if INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED:
+        return rle_masks_to_polygons(masks=masks)
+
     segments = []
     h, w = masks.image_size
     for counts in masks.masks:
         rle_dict = {"size": [h, w], "counts": counts}
-        decoded_rle = np.ascontiguousarray(
-            mask_utils.decode(rle_dict)
-        )  # (H, W) uint8, already C-contiguous
+        decoded_rle = np.ascontiguousarray(mask_utils.decode(rle_dict))
         if not np.any(decoded_rle):
             segments.append(np.zeros((0, 2), dtype=np.float32))
             continue

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -118,6 +118,7 @@ DEFAULT_COLOR_PALETTE = [
 
 _PINNED_HOST_BUFFER_CACHE_SIZE = 16
 _PINNED_HOST_BUFFER_CONTEXT = local()
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
 
 
 def get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
@@ -440,11 +441,13 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
 
     def predict(self, img_in, **kwargs):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
-        if self._pipeline_depth <= 1:
+        if (
+            self._pipeline_depth <= 1
+            or kwargs.get("disable_stream_pipeline")
+            or self._request_batch_size(img_in) > 1
+        ):
             # Original path: forward on current frame, postprocess on
             # current frame, all synchronous.
-            return self._model.forward(img_in, **mapped_kwargs)
-        if self._request_batch_size(img_in) > 1:
             return self._model.forward(img_in, **mapped_kwargs)
 
         mapped_kwargs["defer_count_to_adapter"] = (
@@ -576,7 +579,11 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         preprocess_return_metadata: PreprocessingMetadata,
         **kwargs,
     ) -> List[InstanceSegmentationInferenceResponse]:
-        if self._pipeline_depth <= 1 or not isinstance(predictions, InferenceFuture):
+        if (
+            self._pipeline_depth <= 1
+            or kwargs.get("disable_stream_pipeline")
+            or not isinstance(predictions, InferenceFuture)
+        ):
             return self._postprocess_sync(
                 predictions, preprocess_return_metadata, **kwargs
             )
@@ -671,6 +678,8 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         return_in_rle = kwargs.get("response_mask_format") == "rle"
         mapped_kwargs = self.map_inference_kwargs(kwargs)
         mapped_kwargs["defer_count_to_adapter"] = not return_in_rle
+        if len(preprocess_return_metadata) > 1:
+            mapped_kwargs["use_triton_postprocess"] = False
         detections_list = self._model.post_process(
             predictions, preprocess_return_metadata, **mapped_kwargs
         )
@@ -700,6 +709,9 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             finalize_pending = get_deferred_postprocess_finalizer(det)
             if callable(finalize_pending):
                 det = finalize_pending()
+            sparse_rle_postprocess = return_in_rle and bool(
+                getattr(det, _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR, False)
+            )
             H = preproc_metadata.original_size.height
             W = preproc_metadata.original_size.width
 
@@ -928,19 +940,22 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                         )
 
             if use_dc:
-                responses.append(
-                    InstanceSegmentationInferenceResponseDC(
-                        predictions=predictions,
-                        image=InferenceResponseImageDC(width=W, height=H),
-                    )
+                response = InstanceSegmentationInferenceResponseDC(
+                    predictions=predictions,
+                    image=InferenceResponseImageDC(width=W, height=H),
                 )
             else:
-                responses.append(
-                    InstanceSegmentationInferenceResponse(
-                        predictions=predictions,
-                        image=InferenceResponseImage(width=W, height=H),
-                    )
+                response = InstanceSegmentationInferenceResponse(
+                    predictions=predictions,
+                    image=InferenceResponseImage(width=W, height=H),
                 )
+            if sparse_rle_postprocess:
+                object.__setattr__(
+                    response,
+                    _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR,
+                    True,
+                )
+            responses.append(response)
         return responses
 
     def clear_cache(self, delete_from_disk: bool = True) -> None:

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -128,6 +128,13 @@ def get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
     submits later GPU work. Keeping this cache thread-local avoids two workers
     writing into the same scratch tensor. The small LRU cap prevents retaining a
     new pinned allocation for every transient shape.
+
+    The cache is keyed by ``(name, dtype)`` only. When a cached buffer is large
+    enough, this returns a **view** into that entry, not a fresh allocation.
+    ``.numpy()`` and any slices alias the scratch memory until the next
+    ``copy_`` into the same cache slot. Values that outlive the current
+    finalization must be copied or reduced to scalars / fresh polygon arrays
+    before returning.
     """
     cache = getattr(_PINNED_HOST_BUFFER_CONTEXT, "cache", None)
     if cache is None:
@@ -729,6 +736,8 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                     and isinstance(combined_gpu, torch.Tensor)
                     and combined_gpu.is_cuda
                 ):
+                    # combined_np / class_column / combined_slice are scratch views;
+                    # use only for survivor counting and in-loop scalar extraction.
                     combined_host = get_pinned_buffer(
                         "combined_full",
                         tuple(combined_gpu.shape),
@@ -852,6 +861,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                         polys_or_rles = rle_masks2poly(det.mask)
                 class_ids = det.class_id.detach().cpu().numpy()
 
+            # Some branches above intentionally keep numpy views into
+            # thread-local pinned scratch buffers. Only scalar values and
+            # polygon/RLE lists may be stored on responses below; do not return
+            # those arrays or any view derived from them.
             predictions: List[
                 Union[InstanceSegmentationPrediction, InstanceSegmentationRLEPrediction]
             ] = []

--- a/inference/core/utils/postprocess.py
+++ b/inference/core/utils/postprocess.py
@@ -61,6 +61,23 @@ def masks2poly(masks: np.ndarray) -> List[np.ndarray]:
     return segments
 
 
+def bitpacked_masks2poly(bitpacked_masks: np.ndarray, width: int) -> List[np.ndarray]:
+    """Convert bit-packed masks with 8 pixels per byte into polygons."""
+    segments = []
+    for packed_mask in bitpacked_masks:
+        packed = (
+            packed_mask
+            if packed_mask.flags.c_contiguous
+            else np.ascontiguousarray(packed_mask)
+        )
+        unpacked = np.unpackbits(packed, axis=-1, bitorder="little")[..., :width]
+        if not np.any(unpacked):
+            segments.append(np.zeros((0, 2), dtype=np.float32))
+            continue
+        segments.append(mask2poly(unpacked))
+    return segments
+
+
 def masks2multipoly(masks: np.ndarray) -> List[np.ndarray]:
     """Converts binary masks to polygonal segments.
 

--- a/inference/core/utils/rle_to_polygon.py
+++ b/inference/core/utils/rle_to_polygon.py
@@ -1,0 +1,279 @@
+"""COCO RLE to OpenCV-style polygon conversion."""
+
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+_EMPTY_POLYGON = np.zeros((0, 2), dtype=np.float32)
+_ColumnIntervals = Dict[int, List[Tuple[int, int]]]
+
+
+def rle_masks_to_polygons(masks: object) -> List[np.ndarray]:
+    """Convert COCO RLE masks into the legacy largest external polygon.
+
+    The old adapter path decoded every RLE into a full-frame dense mask and then
+    called ``cv2.findContours(mask, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE)``. This
+    path keeps the RLE sparse until the final contour step, where it materializes
+    only the foreground bounding crop needed by OpenCV.
+    """
+
+    height, width = masks.image_size
+    sparse_counts = _get_lazy_uncompressed_counts(masks=masks)
+    if sparse_counts is not None:
+        counts, lengths = sparse_counts
+        return [
+            polygon_from_uncompressed_counts(
+                counts=counts[i, : int(lengths[i])],
+                height=height,
+                width=width,
+            )
+            for i in range(lengths.shape[0])
+        ]
+    return [
+        polygon_from_coco_counts(counts=counts, height=height, width=width)
+        for counts in masks.masks
+    ]
+
+
+def polygon_from_coco_counts(
+    counts: object,
+    height: int,
+    width: int,
+) -> np.ndarray:
+    columns = _coco_counts_to_column_intervals(
+        counts=counts,
+        height=height,
+        width=width,
+    )
+    return _polygon_from_column_intervals(columns=columns)
+
+
+def polygon_from_uncompressed_counts(
+    counts: Iterable[int],
+    height: int,
+    width: int,
+) -> np.ndarray:
+    counts_array = _counts_to_array(counts=counts)
+    polygon = _polygon_from_column_aligned_counts(
+        counts=counts_array,
+        height=height,
+        width=width,
+    )
+    if polygon is not None:
+        return polygon
+    columns = _counts_to_column_intervals(
+        counts=counts_array,
+        height=height,
+        width=width,
+    )
+    return _polygon_from_column_intervals(columns=columns)
+
+
+def _counts_to_array(counts: Iterable[int]) -> np.ndarray:
+    if isinstance(counts, np.ndarray):
+        return counts.astype(np.int64, copy=False)
+    return np.fromiter((int(count) for count in counts), dtype=np.int64)
+
+
+def _polygon_from_column_aligned_counts(
+    counts: np.ndarray,
+    height: int,
+    width: int,
+) -> Optional[np.ndarray]:
+    if counts.size == 0:
+        return _EMPTY_POLYGON.copy()
+    if np.any(counts < 0):
+        raise ValueError("COCO RLE counts must be non-negative")
+
+    total_size = height * width
+    ends = np.cumsum(counts, dtype=np.int64)
+    if ends[-1] > total_size:
+        raise ValueError("COCO RLE counts exceed the mask size")
+
+    foreground_lengths = counts[1::2]
+    if foreground_lengths.size == 0:
+        return _EMPTY_POLYGON.copy()
+    foreground_ends = ends[1::2]
+    foreground_starts = foreground_ends - foreground_lengths
+    non_empty = foreground_lengths > 0
+    if not np.any(non_empty):
+        return _EMPTY_POLYGON.copy()
+    foreground_starts = foreground_starts[non_empty]
+    foreground_ends = foreground_ends[non_empty]
+
+    columns = foreground_starts // height
+    y_starts = foreground_starts - columns * height
+    last_pixels = foreground_ends - 1
+    end_columns = last_pixels // height
+    if np.any(end_columns != columns):
+        return None
+    y_ends = foreground_ends - columns * height
+
+    x_min = int(columns.min())
+    x_max = int(columns.max())
+    y_min = int(y_starts.min())
+    y_max = int(y_ends.max())
+    crop = np.zeros((y_max - y_min, x_max - x_min + 1), dtype=np.uint8)
+    for x, y0, y1 in zip(columns, y_starts, y_ends):
+        crop[int(y0) - y_min : int(y1) - y_min, int(x) - x_min] = 1
+
+    contours = cv2.findContours(
+        crop,
+        cv2.RETR_EXTERNAL,
+        cv2.CHAIN_APPROX_SIMPLE,
+        offset=(x_min, y_min),
+    )[0]
+    if not contours:
+        return _EMPTY_POLYGON.copy()
+
+    contour_lengths = np.fromiter((len(c) for c in contours), dtype=np.intp)
+    selected_contour = contours[int(contour_lengths.argmax())]
+    return np.asarray(selected_contour, dtype=np.float32).reshape(-1, 2)
+
+
+def _get_lazy_uncompressed_counts(
+    masks: object,
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    ensure_rle_cpu = getattr(masks, "_ensure_rle_cpu", None)
+    if callable(ensure_rle_cpu):
+        ensure_rle_cpu()
+    counts = getattr(masks, "_rle_counts_cpu", None)
+    lengths = getattr(masks, "_rle_lengths_cpu", None)
+    if counts is None or lengths is None:
+        return None
+    return counts, lengths
+
+
+def _coco_counts_to_column_intervals(
+    counts: object,
+    height: int,
+    width: int,
+) -> _ColumnIntervals:
+    if isinstance(counts, str):
+        encoded = counts.encode("ascii")
+    elif isinstance(counts, bytes):
+        encoded = counts
+    elif isinstance(counts, bytearray):
+        encoded = bytes(counts)
+    else:
+        return _counts_to_column_intervals(
+            counts=counts,
+            height=height,
+            width=width,
+        )
+
+    total_size = height * width
+    columns: _ColumnIntervals = {}
+    cursor = 0
+    value = 0
+    previous_two = 0
+    previous_one = 0
+    count_index = 0
+    index = 0
+    encoded_len = len(encoded)
+    while index < encoded_len:
+        run_length = 0
+        shift = 0
+        while True:
+            char = encoded[index] - 48
+            index += 1
+            run_length |= (char & 0x1F) << shift
+            shift += 5
+            if char & 0x20:
+                continue
+            if char & 0x10:
+                run_length |= -1 << shift
+            break
+        # Compressed COCO RLE stores deltas from count index 3 onward.
+        if count_index > 2:
+            run_length += previous_two
+        if run_length < 0:
+            raise ValueError("COCO RLE counts must be non-negative")
+        next_cursor = cursor + run_length
+        if next_cursor > total_size:
+            raise ValueError("COCO RLE counts exceed the mask size")
+        if value and run_length:
+            _append_foreground_run(
+                columns=columns,
+                cursor=cursor,
+                run_length=run_length,
+                height=height,
+            )
+        cursor = next_cursor
+        previous_two, previous_one = previous_one, run_length
+        count_index += 1
+        value ^= 1
+    return columns
+
+
+def _counts_to_column_intervals(
+    counts: Iterable[int],
+    height: int,
+    width: int,
+) -> _ColumnIntervals:
+    total_size = height * width
+    columns: _ColumnIntervals = {}
+    cursor = 0
+    value = 0
+    for raw_count in counts:
+        count = int(raw_count)
+        if count < 0:
+            raise ValueError("COCO RLE counts must be non-negative")
+        next_cursor = cursor + count
+        if next_cursor > total_size:
+            raise ValueError("COCO RLE counts exceed the mask size")
+        if value and count:
+            _append_foreground_run(
+                columns=columns,
+                cursor=cursor,
+                run_length=count,
+                height=height,
+            )
+        cursor = next_cursor
+        value ^= 1
+    return columns
+
+
+def _append_foreground_run(
+    columns: _ColumnIntervals,
+    cursor: int,
+    run_length: int,
+    height: int,
+) -> None:
+    end = cursor + run_length
+    run_cursor = cursor
+    while run_cursor < end:
+        x = run_cursor // height
+        y = run_cursor - x * height
+        column_run_length = min(end - run_cursor, height - y)
+        columns.setdefault(x, []).append((y, y + column_run_length))
+        run_cursor += column_run_length
+
+
+def _polygon_from_column_intervals(columns: _ColumnIntervals) -> np.ndarray:
+    if not columns:
+        return _EMPTY_POLYGON.copy()
+
+    x_min = min(columns)
+    x_max = max(columns)
+    y_min = min(y0 for intervals in columns.values() for y0, _ in intervals)
+    y_max = max(y1 for intervals in columns.values() for _, y1 in intervals)
+    crop = np.zeros((y_max - y_min, x_max - x_min + 1), dtype=np.uint8)
+    for x, intervals in columns.items():
+        crop_x = x - x_min
+        for y0, y1 in intervals:
+            crop[y0 - y_min : y1 - y_min, crop_x] = 1
+
+    contours = cv2.findContours(
+        crop,
+        cv2.RETR_EXTERNAL,
+        cv2.CHAIN_APPROX_SIMPLE,
+        offset=(x_min, y_min),
+    )[0]
+    if not contours:
+        return _EMPTY_POLYGON.copy()
+
+    contour_lengths = np.fromiter((len(c) for c in contours), dtype=np.intp)
+    selected_contour = contours[int(contour_lengths.argmax())]
+    return np.asarray(selected_contour, dtype=np.float32).reshape(-1, 2)

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -66,6 +66,7 @@ from inference.core.workflows.execution_engine.entities.base import (
 from inference.core.workflows.prototypes.block import BlockResult
 
 T = TypeVar("T")
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
 
 
 def load_core_model(
@@ -281,6 +282,8 @@ def convert_inference_detections_batch_to_sv_detections(
                 raw_predictions = filter_out_invalid_polygons(
                     predictions=raw_predictions
                 )
+            if _has_sparse_rle_postprocess_marker(prediction=p):
+                detections.data.pop(POLYGON_KEY_IN_SV_DETECTIONS, None)
         else:
             detections, raw_predictions = fast_result
 
@@ -304,6 +307,16 @@ def convert_inference_detections_batch_to_sv_detections(
             )
         batch_of_detections.append(detections)
     return batch_of_detections
+
+
+def _has_sparse_rle_postprocess_marker(prediction: Dict[str, Any]) -> bool:
+    if not prediction.get(_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR):
+        return False
+    return any(
+        d.get(RLE_MASK_KEY_IN_INFERENCE_RESPONSE) is not None
+        or d.get("rle") is not None
+        for d in prediction.get("predictions", [])
+    )
 
 
 def add_inference_keypoints_to_sv_detections(

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -463,6 +463,11 @@ def sv_detections_to_root_coordinates(
         for keypoints in detections_copy[keypoints_key]:
             if len(keypoints):
                 keypoints += [shift_x, shift_y]
+    if POLYGON_KEY_IN_SV_DETECTIONS in detections_copy.data:
+        polygon_shift = np.asarray([shift_x, shift_y])
+        detections_copy.data[POLYGON_KEY_IN_SV_DETECTIONS] = (
+            detections_copy.data[POLYGON_KEY_IN_SV_DETECTIONS] + polygon_shift
+        )
     if detections_copy.mask is not None:
         origin_mask_base = np.full((origin_height, origin_width), False)
         new_anchored_masks = np.array(

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -2,11 +2,24 @@ import logging
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
+import cv2
 import numpy as np
 import supervision as sv
 from supervision.config import CLASS_NAME_DATA_FIELD
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.entities.requests.clip import ClipCompareRequest
 from inference.core.entities.requests.doctr import DoctrOCRInferenceRequest
@@ -94,6 +107,150 @@ def filter_out_invalid_polygons(predictions: List[dict]) -> List[dict]:
     ]
 
 
+def _get_or_create_detection_id(prediction: dict) -> object:
+    if DETECTION_ID_KEY in prediction:
+        return prediction[DETECTION_ID_KEY]
+    return str(uuid.uuid4())
+
+
+def _mask_crop_to_compact_rle_counts(mask: np.ndarray) -> np.ndarray:
+    flat = np.asarray(mask, dtype=np.bool_).ravel(order="F")
+    if len(flat) == 0:
+        return np.array([0], dtype=np.int32)
+    changes = np.diff(flat.view(np.uint8))
+    boundaries = np.where(changes != 0)[0] + 1
+    positions = np.concatenate(([0], boundaries, [len(flat)]))
+    run_lengths = np.diff(positions).astype(np.int32)
+    if flat[0]:
+        run_lengths = np.concatenate(([np.int32(0)], run_lengths))
+    return run_lengths
+
+
+def _polygon_prediction_to_compact_mask_crop(
+    polygon: np.ndarray,
+    image_width: int,
+    image_height: int,
+) -> Tuple[np.ndarray, Tuple[int, int], Tuple[int, int]]:
+    x_min = int(np.min(polygon[:, 0]))
+    x_max = int(np.max(polygon[:, 0]))
+    y_min = int(np.min(polygon[:, 1]))
+    y_max = int(np.max(polygon[:, 1]))
+
+    if x_max < 0 or y_max < 0 or x_min >= image_width or y_min >= image_height:
+        mask = np.zeros((1, 1), dtype=bool)
+        return (
+            _mask_crop_to_compact_rle_counts(mask),
+            (1, 1),
+            (
+                min(max(x_min, 0), image_width - 1),
+                min(max(y_min, 0), image_height - 1),
+            ),
+        )
+
+    x1 = max(0, x_min)
+    y1 = max(0, y_min)
+    x2 = min(image_width - 1, x_max)
+    y2 = min(image_height - 1, y_max)
+    crop = np.zeros((y2 - y1 + 1, x2 - x1 + 1), dtype=np.uint8)
+    shifted_polygon = polygon - np.array([x1, y1], dtype=np.int32)
+    cv2.fillPoly(crop, [shifted_polygon], color=(1,))
+    return (
+        _mask_crop_to_compact_rle_counts(crop),
+        (crop.shape[0], crop.shape[1]),
+        (x1, y1),
+    )
+
+
+def _try_convert_polygon_predictions_to_sv_detections(
+    prediction: Dict[str, Union[List[Dict[str, Any]], Any]],
+    predictions_key: str,
+    image_key: str,
+) -> Optional[Tuple[sv.Detections, List[Dict[str, Any]]]]:
+    raw_predictions = prediction[predictions_key]
+    required_prediction_keys = {
+        X_KEY,
+        Y_KEY,
+        WIDTH_KEY,
+        HEIGHT_KEY,
+        "confidence",
+        "class_id",
+        "class",
+        "points",
+    }
+    if any(
+        not required_prediction_keys.issubset(p)
+        or p.get("rle") is not None
+        or p.get(RLE_MASK_KEY_IN_INFERENCE_RESPONSE) is not None
+        for p in raw_predictions
+    ):
+        return None
+
+    has_tracker = ["tracker_id" in p for p in raw_predictions]
+    if any(has_tracker) and not all(has_tracker):
+        return None
+
+    image_width = int(prediction[image_key][WIDTH_KEY])
+    image_height = int(prediction[image_key][HEIGHT_KEY])
+    valid_predictions = filter_out_invalid_polygons(predictions=raw_predictions)
+    if not valid_predictions:
+        detections = sv.Detections.empty()
+        detections.data = {CLASS_NAME_DATA_FIELD: np.empty(0, dtype=str)}
+        return detections, valid_predictions
+
+    count = len(valid_predictions)
+    xyxy = np.empty((count, 4), dtype=np.float64)
+    confidence = np.empty(count, dtype=np.float64)
+    class_id = np.empty(count, dtype=np.int64)
+    class_name = []
+    tracker_id = np.empty(count, dtype=np.int64) if all(has_tracker) else None
+    rles = []
+    crop_shapes = np.empty((count, 2), dtype=np.int32)
+    offsets = np.empty((count, 2), dtype=np.int32)
+
+    for idx, item in enumerate(valid_predictions):
+        x = float(item[X_KEY])
+        y = float(item[Y_KEY])
+        width = float(item[WIDTH_KEY])
+        height = float(item[HEIGHT_KEY])
+        x_min = x - width / 2
+        y_min = y - height / 2
+        xyxy[idx] = [x_min, y_min, x_min + width, y_min + height]
+        confidence[idx] = float(item["confidence"])
+        class_id[idx] = int(item["class_id"])
+        class_name.append(item["class"])
+        if tracker_id is not None:
+            tracker_id[idx] = int(item["tracker_id"])
+
+        polygon = np.array(
+            [[point[X_KEY], point[Y_KEY]] for point in item["points"]],
+            dtype=np.int32,
+        )
+        rle, crop_shape, offset = _polygon_prediction_to_compact_mask_crop(
+            polygon=polygon,
+            image_width=image_width,
+            image_height=image_height,
+        )
+        rles.append(rle)
+        crop_shapes[idx] = crop_shape
+        offsets[idx] = offset
+
+    masks = CompactMask(
+        rles=rles,
+        crop_shapes=crop_shapes,
+        offsets=offsets,
+        image_shape=(image_height, image_width),
+    )
+    detections = sv.Detections(
+        xyxy=xyxy,
+        confidence=confidence,
+        class_id=class_id,
+        mask=masks,
+        tracker_id=tracker_id,
+        data={CLASS_NAME_DATA_FIELD: np.array(class_name)},
+    )
+    return detections, valid_predictions
+
+
 def attach_prediction_type_info_to_sv_detections_batch(
     predictions: List[sv.Detections],
     prediction_type: str,
@@ -112,14 +269,23 @@ def convert_inference_detections_batch_to_sv_detections(
     batch_of_detections: List[sv.Detections] = []
     for p in predictions:
         width, height = p[image_key][WIDTH_KEY], p[image_key][HEIGHT_KEY]
-        detections = sv.Detections.from_inference(p)
-        raw_predictions = p[predictions_key]
-        if len(detections) != len(raw_predictions):
-            raw_predictions = filter_out_invalid_polygons(predictions=raw_predictions)
+        fast_result = _try_convert_polygon_predictions_to_sv_detections(
+            prediction=p,
+            predictions_key=predictions_key,
+            image_key=image_key,
+        )
+        if fast_result is None:
+            detections = sv.Detections.from_inference(p)
+            raw_predictions = p[predictions_key]
+            if len(detections) != len(raw_predictions):
+                raw_predictions = filter_out_invalid_polygons(
+                    predictions=raw_predictions
+                )
+        else:
+            detections, raw_predictions = fast_result
+
         parent_ids = [d.get(PARENT_ID_KEY, "") for d in raw_predictions]
-        detection_ids = [
-            d.get(DETECTION_ID_KEY, str(uuid.uuid4())) for d in raw_predictions
-        ]
+        detection_ids = [_get_or_create_detection_id(d) for d in raw_predictions]
         detections[DETECTION_ID_KEY] = np.array(detection_ids)
         detections[PARENT_ID_KEY] = np.array(parent_ids)
         detections[IMAGE_DIMENSIONS_KEY] = np.array([[height, width]] * len(detections))
@@ -127,6 +293,7 @@ def convert_inference_detections_batch_to_sv_detections(
             detections[INFERENCE_ID_KEY] = np.array(
                 [p[INFERENCE_ID_KEY]] * len(detections)
             )
+
         rle_masks = [
             d.get(RLE_MASK_KEY_IN_INFERENCE_RESPONSE) or d.get("rle")
             for d in raw_predictions
@@ -455,9 +622,7 @@ def post_process_ocr_result(
         prediction["predictions"] = sv.Detections.from_inference(prediction)
         if len(prediction["predictions"]) != len(raw_predictions):
             raw_predictions = filter_out_invalid_polygons(predictions=raw_predictions)
-        detection_ids = [
-            p.get("detection_id", str(uuid.uuid4())) for p in raw_predictions
-        ]
+        detection_ids = [_get_or_create_detection_id(p) for p in raw_predictions]
         prediction["predictions"]["detection_id"] = detection_ids
         prediction[PREDICTION_TYPE_KEY] = "ocr"
         prediction[PARENT_ID_KEY] = image.parent_metadata.parent_id

--- a/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
@@ -1,0 +1,185 @@
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.workflows.execution_engine.entities.base import OutputDefinition
+from inference.core.workflows.execution_engine.entities.types import (
+    Selector,
+    StepSelector,
+)
+from inference.core.workflows.execution_engine.v1.entities import FlowControl
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Route workflow execution to one of several branches by matching an input value against a set of
+case values, similar to a switch-case statement in programming, enabling multi-way branching,
+value-based routing, and decision trees without chaining multiple Continue If blocks.
+
+## How This Block Works
+
+This block compares a single input value against the keys of a case mapping and directs execution
+to the step associated with the first matching case. The block:
+
+1. Takes a `value` input (typically a selector referencing a workflow input or a step output, e.g.
+   a classification result) and converts it to a string
+2. Looks the string up in the `cases` mapping, where each key is a case value and each value is the
+   step to execute when that case matches (e.g. `{"red": "$steps.on_red", "blue": "$steps.on_blue"}`)
+3. If `case_insensitive` is enabled, the comparison ignores letter case
+4. If a case matches, execution continues to that case's step and all other branches terminate
+5. If no case matches, execution continues to the steps listed in `default_next_steps`
+6. If no case matches and `default_next_steps` is empty, the branch terminates
+
+Because the input value is converted to a string before matching, non-string values match their
+string representation: `True` matches the key `"True"`, `1.0` matches `"1.0"` (not `"1"`), and a
+missing/None value matches `"None"`. Each target step may appear at most once across `cases` and
+`default_next_steps` — to route several case values to the same logic, point each case at its own
+step or normalize the value upstream (e.g. with an Expression block).
+
+## Common Use Cases
+
+- **Routing by classification result**: Send images down different processing paths based on the
+  top class predicted by a classification model (e.g. "damaged" → alert branch, "ok" → logging
+  branch, anything else → default review branch)
+- **Mode-based pipelines**: Use a workflow input parameter (e.g. `$inputs.mode`) to select between
+  alternative processing branches at runtime without editing the workflow
+- **Multi-way alerting**: Route to different notification blocks (email, Slack, webhook) depending
+  on a severity or category value computed earlier in the workflow
+- **Replacing chained conditions**: Collapse a ladder of Continue If blocks comparing the same
+  value against different constants into a single, easier-to-read block
+
+## Connecting to Other Blocks
+
+This block controls workflow execution flow and can be connected:
+
+- **After classification or detection blocks** to branch on predicted classes, counts, or other
+  prediction properties (often via a Property Definition or Expression block that extracts the
+  value to switch on)
+- **After workflow inputs** to select a branch from a runtime parameter
+- **Before any downstream blocks** (models, notifications, sinks) that should only run for a
+  specific case — each case target becomes the head of its own execution branch
+- **With a default branch** wired via `default_next_steps` to handle unmatched values, or left
+  empty to simply stop when nothing matches
+"""
+
+SHORT_DESCRIPTION = (
+    "Route execution to one of several branches based on the value of an input."
+)
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Switch Case",
+            "version": "v1",
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "flow_control",
+            "ui_manifest": {
+                "section": "flow_control",
+                "icon": "far fa-split",
+                "blockPriority": 4,
+                "popular": True,
+            },
+        }
+    )
+    type: Literal["roboflow_core/switch_case@v1", "SwitchCase"]
+    value: Union[Selector(), str, int, float, bool] = Field(
+        title="Value",
+        description="Value to match against the case keys. Typically a selector referencing a "
+        "workflow input or a step output (e.g. $inputs.mode or $steps.classifier.top). The value "
+        "is converted to a string before comparison, so booleans match keys 'True'/'False', "
+        "1.0 matches '1.0' and a None value matches 'None'.",
+        examples=["$steps.classifier.top", "$inputs.mode", "red"],
+    )
+    cases: Dict[str, StepSelector] = Field(
+        title="Cases",
+        description="Mapping of case value to the step that should execute when `value` matches "
+        'it, e.g. {"red": "$steps.on_red", "blue": "$steps.on_blue"}. Each target step '
+        "may appear at most once across `cases` and `default_next_steps`.",
+        examples=[{"red": "$steps.on_red", "blue": "$steps.on_blue"}],
+        default_factory=dict,
+        json_schema_extra={"always_visible": True},
+    )
+    case_insensitive: bool = Field(
+        title="Case Insensitive",
+        description="When enabled, case values are matched ignoring letter case "
+        "(e.g. value 'RED' matches case key 'red').",
+        default=False,
+        examples=[False],
+    )
+    default_next_steps: List[StepSelector] = Field(
+        title="Default Steps",
+        description="Steps to execute when no case matches. Leave empty to terminate the branch "
+        "when nothing matches.",
+        examples=[["$steps.fallback"]],
+        default_factory=list,
+    )
+
+    @model_validator(mode="after")
+    def validate_targets_and_keys(self) -> "BlockManifest":
+        targets = list(self.cases.values()) + list(self.default_next_steps)
+        seen, duplicated = set(), set()
+        for target in targets:
+            if target in seen:
+                duplicated.add(target)
+            seen.add(target)
+        if duplicated:
+            raise ValueError(
+                f"Each step may be targeted at most once across `cases` and "
+                f"`default_next_steps`. Duplicated targets: {sorted(duplicated)}"
+            )
+        if self.case_insensitive:
+            lowered_keys = [key.lower() for key in self.cases]
+            if len(set(lowered_keys)) != len(lowered_keys):
+                raise ValueError(
+                    "`cases` contains keys that collide when case_insensitive is enabled"
+                )
+        return self
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return []
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        # Requires per-key execution branches for dict step selectors, added in
+        # Execution Engine v1.11.0.
+        return ">=1.11.0,<2.0.0"
+
+
+class SwitchCaseBlockV1(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        value: Any,
+        cases: Dict[str, StepSelector],
+        case_insensitive: bool,
+        default_next_steps: List[StepSelector],
+    ) -> BlockResult:
+        coerced_value = str(value)
+        if case_insensitive:
+            coerced_value = coerced_value.lower()
+            matched_step = next(
+                (
+                    target
+                    for case_key, target in cases.items()
+                    if case_key.lower() == coerced_value
+                ),
+                None,
+            )
+        else:
+            matched_step = cases.get(coerced_value)
+        if matched_step is not None:
+            return FlowControl(mode="select_step", context=[matched_step])
+        if default_next_steps:
+            return FlowControl(mode="select_step", context=default_next_steps)
+        return FlowControl(mode="terminate_branch")

--- a/inference/core/workflows/core_steps/fusion/detections_stitch/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_stitch/v1.py
@@ -6,6 +6,7 @@ import supervision as sv
 from pydantic import ConfigDict, Field
 from supervision import OverlapFilter, move_boxes, move_masks
 from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_sv_detections,
@@ -286,9 +287,16 @@ def move_detections(
             raise ValueError(
                 "To move non-empty detections with segmentation mask, resolution_wh is needed, but not given."
             )
-        detections.mask = move_masks(
-            masks=detections.mask, offset=offset, resolution_wh=resolution_wh
-        )
+        if isinstance(detections.mask, CompactMask):
+            detections.mask = detections.mask.with_offset(
+                dx=int(offset[0]),
+                dy=int(offset[1]),
+                new_image_shape=(resolution_wh[1], resolution_wh[0]),
+            )
+        else:
+            detections.mask = move_masks(
+                masks=detections.mask, offset=offset, resolution_wh=resolution_wh
+            )
     return detections
 
 

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -153,6 +153,9 @@ from inference.core.workflows.core_steps.flow_control.inner_workflow.v1 import (
 from inference.core.workflows.core_steps.flow_control.rate_limiter.v1 import (
     RateLimiterBlockV1,
 )
+from inference.core.workflows.core_steps.flow_control.switch_case.v1 import (
+    SwitchCaseBlockV1,
+)
 from inference.core.workflows.core_steps.formatters.csv.v1 import CSVFormatterBlockV1
 from inference.core.workflows.core_steps.formatters.current_time.v1 import (
     CurrentTimeBlockV1,
@@ -817,6 +820,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         ContinueIfBlockV1,
         InnerWorkflowBlockV1,
         RateLimiterBlockV1,
+        SwitchCaseBlockV1,
         PerspectiveCorrectionBlockV1,
         DeltaFilterBlockV1,
         CameraCalibrationBlockV1,

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -1,7 +1,8 @@
 from collections import deque
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from dataclasses import dataclass
 from typing import Deque, List, Literal, Optional, Tuple, Type, Union
+from weakref import finalize
 
 from pydantic import ConfigDict, Field, PositiveInt, model_validator
 
@@ -15,6 +16,7 @@ from inference.core.entities.responses.inference import (
 from inference.core.env import (
     HOSTED_INSTANCE_SEGMENTATION_URL,
     LOCAL_INFERENCE_API_URL,
+    WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
     WORKFLOWS_REMOTE_API_TARGET,
     WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
     WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
@@ -55,7 +57,10 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlockManifest,
 )
 from inference_models.configuration import get_rfdetr_pipeline_depth
-from inference_models.models.base.async_handoff import get_async_response_future
+from inference_models.models.base.async_handoff import (
+    get_async_response_context_id,
+    get_async_response_future,
+)
 from inference_sdk import InferenceConfiguration, InferenceHTTPClient
 
 LONG_DESCRIPTION = """
@@ -75,6 +80,7 @@ class _StreamPredictionContext:
     images: Batch[WorkflowImageData]
     class_filter: Optional[List[str]]
     model_id: str
+    context_id: str
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -250,9 +256,11 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         self._step_execution_mode = step_execution_mode
         self._last_model_id: Optional[str] = None
         self._stream_response_executor: Optional[ThreadPoolExecutor] = None
+        self._stream_response_executor_finalizer = None
         self._pending_stream_prediction_contexts: Deque[_StreamPredictionContext] = (
             deque()
         )
+        self._stream_context_generation = 0
 
     @classmethod
     def get_init_parameters(cls) -> List[str]:
@@ -344,6 +352,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             images=images,
             class_filter=class_filter,
             model_id=model_id,
+            context_id=self._next_stream_context_id(),
         )
         if self.stream_pipeline_depth() > 0 and len(images) == 1:
             self._pending_stream_prediction_contexts.append(stream_context)
@@ -362,6 +371,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
             source="workflow-execution",
+            source_info=stream_context.context_id,
             enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
         )
         predictions = self._model_manager.infer_from_request_sync(
@@ -373,7 +383,13 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             predictions=predictions
         )
         if async_response_future is not None:
-            stream_context = self._pop_stream_prediction_context(default=stream_context)
+            response_context_id = self._extract_async_response_context_id(
+                predictions=predictions
+            )
+            stream_context = self._pop_stream_prediction_context(
+                default=stream_context,
+                context_id=response_context_id,
+            )
             return self._submit_async_post_process_result(
                 predictions_future=async_response_future,
                 stream_context=stream_context,
@@ -393,9 +409,24 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
                 return async_response_future
         return None
 
+    def _extract_async_response_context_id(
+        self,
+        predictions: List[object],
+    ) -> Optional[str]:
+        for prediction in predictions:
+            context_id = get_async_response_context_id(prediction)
+            if context_id is not None:
+                return context_id
+        return None
+
     def _get_stream_response_executor(self) -> ThreadPoolExecutor:
         if self._stream_response_executor is None:
             self._stream_response_executor = ThreadPoolExecutor(max_workers=1)
+            self._stream_response_executor_finalizer = finalize(
+                self,
+                self._stream_response_executor.shutdown,
+                wait=False,
+            )
         return self._stream_response_executor
 
     def _submit_async_post_process_result(
@@ -436,7 +467,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         predictions_future: Future,
         stream_context: _StreamPredictionContext,
     ) -> BlockResult:
-        predictions = predictions_future.result()
+        predictions = _resolve_stream_future(
+            future=predictions_future,
+            context="RF-DETR async prediction finalization",
+        )
         if not isinstance(predictions, list):
             predictions = [predictions]
         return self._finalize_prediction_responses(
@@ -461,6 +495,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             )
             for e in predictions
         ]
+        _validate_stream_prediction_alignment(
+            predictions=predictions,
+            stream_context=stream_context,
+        )
         return self._post_process_result(
             images=stream_context.images,
             predictions=predictions,
@@ -471,7 +509,22 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
     def _pop_stream_prediction_context(
         self,
         default: _StreamPredictionContext,
+        context_id: Optional[str],
     ) -> _StreamPredictionContext:
+        if context_id is not None:
+            for index, stream_context in enumerate(
+                self._pending_stream_prediction_contexts
+            ):
+                if stream_context.context_id != context_id:
+                    continue
+                del self._pending_stream_prediction_contexts[index]
+                return stream_context
+            if default.context_id == context_id:
+                return default
+            raise RuntimeError(
+                "Async instance-segmentation response context did not match any "
+                "pending stream frame."
+            )
         if self._pending_stream_prediction_contexts:
             return self._pending_stream_prediction_contexts.popleft()
         return default
@@ -481,9 +534,15 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         result_future: Future,
         image_index: int,
     ):
-        result = result_future.result()
+        result = _resolve_stream_future(
+            future=result_future,
+            context="RF-DETR async prediction selection",
+        )
         if image_index >= len(result):
-            return []
+            raise RuntimeError(
+                "Async instance-segmentation result count did not match the "
+                "stream frame batch size."
+            )
         return result[image_index]["predictions"]
 
     def is_stream_pipelined(self) -> bool:
@@ -561,8 +620,12 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
 
     def close_stream_pipeline(self) -> None:
         if self._stream_response_executor is not None:
+            finalizer = getattr(self, "_stream_response_executor_finalizer", None)
+            if finalizer is not None and finalizer.alive:
+                finalizer.detach()
             self._stream_response_executor.shutdown(wait=False)
             self._stream_response_executor = None
+            self._stream_response_executor_finalizer = None
         if (
             self._last_model_id is None
             or self._last_model_id not in self._model_manager
@@ -572,6 +635,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         shutdown_fn = getattr(model, "shutdown_pipeline", None)
         if callable(shutdown_fn):
             shutdown_fn()
+
+    def _next_stream_context_id(self) -> str:
+        self._stream_context_generation += 1
+        return f"instance-segmentation-v3:{id(self)}:{self._stream_context_generation}"
 
     def run_remotely(
         self,
@@ -665,3 +732,57 @@ def _stream_context_indices(images: Batch[WorkflowImageData]) -> List[Tuple[int,
     if indices is not None:
         return indices
     return [(i,) for i in range(len(images))]
+
+
+def _resolve_stream_future(
+    future: Future,
+    context: str,
+):
+    try:
+        return future.result(timeout=WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT)
+    except TimeoutError as error:
+        raise RuntimeError(f"Timed out while waiting for {context}.") from error
+
+
+def _validate_stream_prediction_alignment(
+    predictions: List[dict],
+    stream_context: _StreamPredictionContext,
+) -> None:
+    if len(predictions) != len(stream_context.images):
+        raise RuntimeError(
+            "Async instance-segmentation prediction count did not match the "
+            "stream frame batch size."
+        )
+    for prediction, image in zip(predictions, stream_context.images):
+        response_image = prediction.get("image")
+        if not isinstance(response_image, dict):
+            continue
+        image_size = _workflow_image_size(image=image)
+        if image_size is None:
+            continue
+        image_width, image_height = image_size
+        if (
+            response_image.get("width") != image_width
+            or response_image.get("height") != image_height
+        ):
+            raise RuntimeError(
+                "Async instance-segmentation response image metadata did not "
+                "match the paired stream frame."
+            )
+
+
+def _workflow_image_size(image: WorkflowImageData) -> Optional[Tuple[int, int]]:
+    try:
+        numpy_image = getattr(image, "numpy_image", None)
+    except Exception:
+        numpy_image = None
+    shape = getattr(numpy_image, "shape", None)
+    if shape is None:
+        try:
+            inference_image = image.to_inference_format(numpy_preferred=True)
+        except Exception:
+            return None
+        shape = getattr(inference_image.get("value"), "shape", None)
+    if shape is None or len(shape) < 2:
+        return None
+    return int(shape[1]), int(shape[0])

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -55,7 +55,10 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlockManifest,
 )
 from inference_models.configuration import get_rfdetr_pipeline_depth
-from inference_models.models.base.async_handoff import get_async_response_future
+from inference_models.models.base.async_handoff import (
+    get_async_response_context_id,
+    get_async_response_future,
+)
 from inference_sdk import InferenceConfiguration, InferenceHTTPClient
 
 LONG_DESCRIPTION = """
@@ -75,6 +78,7 @@ class _StreamPredictionContext:
     images: Batch[WorkflowImageData]
     class_filter: Optional[List[str]]
     model_id: str
+    context_id: str
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -253,6 +257,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         self._pending_stream_prediction_contexts: Deque[_StreamPredictionContext] = (
             deque()
         )
+        self._stream_context_generation = 0
 
     @classmethod
     def get_init_parameters(cls) -> List[str]:
@@ -344,6 +349,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             images=images,
             class_filter=class_filter,
             model_id=model_id,
+            context_id=self._build_stream_context_id(images=images),
         )
         if self.stream_pipeline_depth() > 0 and len(images) == 1:
             self._pending_stream_prediction_contexts.append(stream_context)
@@ -362,6 +368,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
             source="workflow-execution",
+            stream_pipeline_context_id=stream_context.context_id,
             enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
         )
         predictions = self._model_manager.infer_from_request_sync(
@@ -373,7 +380,13 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             predictions=predictions
         )
         if async_response_future is not None:
-            stream_context = self._pop_stream_prediction_context(default=stream_context)
+            response_context_id = self._extract_async_response_context_id(
+                predictions=predictions
+            )
+            stream_context = self._pop_stream_prediction_context(
+                default=stream_context,
+                context_id=response_context_id,
+            )
             return self._submit_async_post_process_result(
                 predictions_future=async_response_future,
                 stream_context=stream_context,
@@ -391,6 +404,16 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             async_response_future = get_async_response_future(prediction)
             if isinstance(async_response_future, Future):
                 return async_response_future
+        return None
+
+    def _extract_async_response_context_id(
+        self,
+        predictions: List[object],
+    ) -> Optional[str]:
+        for prediction in predictions:
+            context_id = get_async_response_context_id(prediction)
+            if context_id is not None:
+                return context_id
         return None
 
     def _get_stream_response_executor(self) -> ThreadPoolExecutor:
@@ -461,6 +484,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             )
             for e in predictions
         ]
+        _validate_stream_prediction_alignment(
+            predictions=predictions,
+            stream_context=stream_context,
+        )
         return self._post_process_result(
             images=stream_context.images,
             predictions=predictions,
@@ -471,7 +498,22 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
     def _pop_stream_prediction_context(
         self,
         default: _StreamPredictionContext,
+        context_id: Optional[str],
     ) -> _StreamPredictionContext:
+        if context_id is not None:
+            for index, stream_context in enumerate(
+                self._pending_stream_prediction_contexts
+            ):
+                if stream_context.context_id != context_id:
+                    continue
+                del self._pending_stream_prediction_contexts[index]
+                return stream_context
+            if default.context_id == context_id:
+                return default
+            raise RuntimeError(
+                "Async instance-segmentation response context did not match any "
+                "pending stream frame."
+            )
         if self._pending_stream_prediction_contexts:
             return self._pending_stream_prediction_contexts.popleft()
         return default
@@ -573,6 +615,22 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         if callable(shutdown_fn):
             shutdown_fn()
 
+    def _build_stream_context_id(self, images: Batch[WorkflowImageData]) -> str:
+        self._stream_context_generation += 1
+        if len(images) == 1:
+            video_metadata = images[0].video_metadata
+            return (
+                "instance-segmentation-v3:"
+                f"{video_metadata.video_identifier}:"
+                f"{video_metadata.frame_number}:"
+                f"{self._stream_context_generation}"
+            )
+        return (
+            "instance-segmentation-v3:"
+            f"batch:{len(images)}:"
+            f"{self._stream_context_generation}"
+        )
+
     def run_remotely(
         self,
         images: Batch[WorkflowImageData],
@@ -665,3 +723,47 @@ def _stream_context_indices(images: Batch[WorkflowImageData]) -> List[Tuple[int,
     if indices is not None:
         return indices
     return [(i,) for i in range(len(images))]
+
+
+def _validate_stream_prediction_alignment(
+    predictions: List[dict],
+    stream_context: _StreamPredictionContext,
+) -> None:
+    if len(predictions) != len(stream_context.images):
+        raise RuntimeError(
+            "Async instance-segmentation prediction count did not match the "
+            "stream frame batch size."
+        )
+    for prediction, image in zip(predictions, stream_context.images):
+        response_image = prediction.get("image")
+        if not isinstance(response_image, dict):
+            continue
+        image_size = _workflow_image_size(image=image)
+        if image_size is None:
+            continue
+        image_width, image_height = image_size
+        if (
+            response_image.get("width") != image_width
+            or response_image.get("height") != image_height
+        ):
+            raise RuntimeError(
+                "Async instance-segmentation response image metadata did not "
+                "match the paired stream frame."
+            )
+
+
+def _workflow_image_size(image: WorkflowImageData) -> Optional[Tuple[int, int]]:
+    try:
+        numpy_image = image.numpy_image
+    except Exception:
+        numpy_image = None
+    shape = getattr(numpy_image, "shape", None)
+    if shape is None:
+        try:
+            inference_image = image.to_inference_format(numpy_preferred=True)
+        except Exception:
+            return None
+        shape = getattr(inference_image.get("value"), "shape", None)
+    if shape is None or len(shape) < 2:
+        return None
+    return int(shape[1]), int(shape[0])

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -74,6 +74,8 @@ block. To learn more about setting your Roboflow API key, [refer to the Inferenc
 documentation](https://inference.roboflow.com/quickstart/configure_api_key/).
 """
 
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
+
 
 @dataclass(frozen=True)
 class _StreamPredictionContext:
@@ -260,6 +262,8 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         self._pending_stream_prediction_contexts: Deque[_StreamPredictionContext] = (
             deque()
         )
+        self._last_request_used_stream_pipeline = False
+        self._stream_pipeline_disabled_for_workflow = False
         self._stream_context_generation = 0
 
     @classmethod
@@ -348,13 +352,20 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             model_id=model_id,
             api_key=self._api_key,
         )
+        stream_pipeline_disabled = (
+            self._stream_pipeline_disabled_for_workflow or len(images) != 1
+        )
+        model_stream_pipeline_depth = self._model_stream_pipeline_depth()
+        self._last_request_used_stream_pipeline = (
+            not stream_pipeline_disabled and model_stream_pipeline_depth > 0
+        )
         stream_context = _StreamPredictionContext(
             images=images,
             class_filter=class_filter,
             model_id=model_id,
             context_id=self._next_stream_context_id(),
         )
-        if self.stream_pipeline_depth() > 0 and len(images) == 1:
+        if self._last_request_used_stream_pipeline:
             self._pending_stream_prediction_contexts.append(stream_context)
         request = InstanceSegmentationInferenceRequest(
             api_key=self._api_key,
@@ -373,6 +384,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             source="workflow-execution",
             source_info=stream_context.context_id,
             enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
+            disable_stream_pipeline=stream_pipeline_disabled,
         )
         predictions = self._model_manager.infer_from_request_sync(
             model_id=model_id, request=request
@@ -487,14 +499,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         # (cheaper construct + dict-walk than pydantic). Any other response type
         # (e.g. if a non-rfdetr backend is bound to the same block) falls back
         # to `model_dump`.
-        predictions = [
-            (
-                _is_response_dc_to_dict(e)
-                if isinstance(e, InstanceSegmentationInferenceResponseDC)
-                else e.model_dump(by_alias=True, exclude_none=True)
-            )
-            for e in predictions
-        ]
+        predictions = [_prediction_response_to_dict(e) for e in predictions]
         _validate_stream_prediction_alignment(
             predictions=predictions,
             stream_context=stream_context,
@@ -546,34 +551,44 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         return result[image_index]["predictions"]
 
     def is_stream_pipelined(self) -> bool:
+        return self.stream_pipeline_depth() > 0
+
+    def _model_stream_pipeline_depth(self) -> int:
         if self._step_execution_mode is not StepExecutionMode.LOCAL:
-            return False
+            return 0
         if (
             self._last_model_id is None
             or self._last_model_id not in self._model_manager
         ):
-            return False
+            return 0
         model = self._model_manager[self._last_model_id]
-        return (
-            callable(getattr(model, "flush", None))
-            and getattr(model, "_pipeline_depth", 1) > 1
-        )
+        if not callable(getattr(model, "flush", None)):
+            return 0
+        return max(0, int(getattr(model, "_pipeline_depth", 1)) - 1)
 
     def can_activate_stream_pipeline(self) -> bool:
         return (
             self._step_execution_mode is StepExecutionMode.LOCAL
             and get_rfdetr_pipeline_depth() > 1
+            and not self._stream_pipeline_disabled_for_workflow
         )
 
     def stream_pipeline_depth(self) -> int:
-        if not self.is_stream_pipelined():
+        if not self._last_request_used_stream_pipeline:
             return 0
-        model = self._model_manager[self._last_model_id]
-        return max(0, int(getattr(model, "_pipeline_depth", 1)) - 1)
+        return self._model_stream_pipeline_depth()
+
+    def disable_stream_pipeline_for_workflow(self) -> None:
+        self._stream_pipeline_disabled_for_workflow = True
+        self._last_request_used_stream_pipeline = False
+        self._pending_stream_prediction_contexts.clear()
 
     def flush_stream_pipeline_outputs(
         self,
     ) -> List[Tuple[List[Tuple[int, ...]], BlockResult]]:
+        if not self._last_request_used_stream_pipeline:
+            self._pending_stream_prediction_contexts.clear()
+            return []
         if (
             self._last_model_id is None
             or self._last_model_id not in self._model_manager
@@ -732,6 +747,16 @@ def _stream_context_indices(images: Batch[WorkflowImageData]) -> List[Tuple[int,
     if indices is not None:
         return indices
     return [(i,) for i in range(len(images))]
+
+
+def _prediction_response_to_dict(response: object) -> dict:
+    if isinstance(response, InstanceSegmentationInferenceResponseDC):
+        result = _is_response_dc_to_dict(response)
+    else:
+        result = response.model_dump(by_alias=True, exclude_none=True)
+    if getattr(response, _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR, False):
+        result[_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR] = True
+    return result
 
 
 def _resolve_stream_future(

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -1,9 +1,16 @@
-from typing import List, Literal, Optional, Type, Union
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Deque, List, Literal, Optional, Tuple, Type, Union
 
 from pydantic import ConfigDict, Field, PositiveInt, model_validator
 
 from inference.core.entities.requests.inference import (
     InstanceSegmentationInferenceRequest,
+)
+from inference.core.entities.responses.inference import (
+    InstanceSegmentationInferenceResponseDC,
+    _is_response_dc_to_dict,
 )
 from inference.core.env import (
     HOSTED_INSTANCE_SEGMENTATION_URL,
@@ -47,6 +54,8 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlock,
     WorkflowBlockManifest,
 )
+from inference_models.configuration import get_rfdetr_pipeline_depth
+from inference_models.models.base.async_handoff import get_async_response_future
 from inference_sdk import InferenceConfiguration, InferenceHTTPClient
 
 LONG_DESCRIPTION = """
@@ -59,6 +68,13 @@ You will need to set your Roboflow API key in your Inference environment to use 
 block. To learn more about setting your Roboflow API key, [refer to the Inference
 documentation](https://inference.roboflow.com/quickstart/configure_api_key/).
 """
+
+
+@dataclass(frozen=True)
+class _StreamPredictionContext:
+    images: Batch[WorkflowImageData]
+    class_filter: Optional[List[str]]
+    model_id: str
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -232,6 +248,11 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         self._model_manager = model_manager
         self._api_key = api_key
         self._step_execution_mode = step_execution_mode
+        self._last_model_id: Optional[str] = None
+        self._stream_response_executor: Optional[ThreadPoolExecutor] = None
+        self._pending_stream_prediction_contexts: Deque[_StreamPredictionContext] = (
+            deque()
+        )
 
     @classmethod
     def get_init_parameters(cls) -> List[str]:
@@ -314,6 +335,18 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         enforce_dense_masks_in_inference_models: bool,
     ) -> BlockResult:
         inference_images = [i.to_inference_format(numpy_preferred=True) for i in images]
+        self._last_model_id = model_id
+        self._model_manager.add_model(
+            model_id=model_id,
+            api_key=self._api_key,
+        )
+        stream_context = _StreamPredictionContext(
+            images=images,
+            class_filter=class_filter,
+            model_id=model_id,
+        )
+        if self.stream_pipeline_depth() > 0 and len(images) == 1:
+            self._pending_stream_prediction_contexts.append(stream_context)
         request = InstanceSegmentationInferenceRequest(
             api_key=self._api_key,
             model_id=model_id,
@@ -331,24 +364,214 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             source="workflow-execution",
             enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
         )
-        self._model_manager.add_model(
-            model_id=model_id,
-            api_key=self._api_key,
-        )
         predictions = self._model_manager.infer_from_request_sync(
             model_id=model_id, request=request
         )
         if not isinstance(predictions, list):
             predictions = [predictions]
+        async_response_future = self._extract_async_response_future(
+            predictions=predictions
+        )
+        if async_response_future is not None:
+            stream_context = self._pop_stream_prediction_context(default=stream_context)
+            return self._submit_async_post_process_result(
+                predictions_future=async_response_future,
+                stream_context=stream_context,
+            )
+        return self._finalize_prediction_responses(
+            predictions=predictions,
+            stream_context=stream_context,
+        )
+
+    def _extract_async_response_future(
+        self,
+        predictions: List[object],
+    ) -> Optional[Future]:
+        for prediction in predictions:
+            async_response_future = get_async_response_future(prediction)
+            if isinstance(async_response_future, Future):
+                return async_response_future
+        return None
+
+    def _get_stream_response_executor(self) -> ThreadPoolExecutor:
+        if self._stream_response_executor is None:
+            self._stream_response_executor = ThreadPoolExecutor(max_workers=1)
+        return self._stream_response_executor
+
+    def _submit_async_post_process_result(
+        self,
+        predictions_future: Future,
+        stream_context: _StreamPredictionContext,
+    ) -> BlockResult:
+        finalized_result_future = self._get_stream_response_executor().submit(
+            self._finalize_async_prediction_value,
+            predictions_future,
+            stream_context,
+        )
+        return [
+            {
+                "inference_id": None,
+                "predictions": self._submit_async_prediction_selector(
+                    result_future=finalized_result_future,
+                    image_index=image_index,
+                ),
+                "model_id": stream_context.model_id,
+            }
+            for image_index in range(len(stream_context.images))
+        ]
+
+    def _submit_async_prediction_selector(
+        self,
+        result_future: Future,
+        image_index: int,
+    ) -> Future:
+        return self._get_stream_response_executor().submit(
+            self._select_async_prediction_value,
+            result_future,
+            image_index,
+        )
+
+    def _finalize_async_prediction_value(
+        self,
+        predictions_future: Future,
+        stream_context: _StreamPredictionContext,
+    ) -> BlockResult:
+        predictions = predictions_future.result()
+        if not isinstance(predictions, list):
+            predictions = [predictions]
+        return self._finalize_prediction_responses(
+            predictions=predictions,
+            stream_context=stream_context,
+        )
+
+    def _finalize_prediction_responses(
+        self,
+        predictions: List[object],
+        stream_context: _StreamPredictionContext,
+    ) -> BlockResult:
+        # The adapter returns dataclass responses when source="workflow-execution"
+        # (cheaper construct + dict-walk than pydantic). Any other response type
+        # (e.g. if a non-rfdetr backend is bound to the same block) falls back
+        # to `model_dump`.
         predictions = [
-            e.model_dump(by_alias=True, exclude_none=True) for e in predictions
+            (
+                _is_response_dc_to_dict(e)
+                if isinstance(e, InstanceSegmentationInferenceResponseDC)
+                else e.model_dump(by_alias=True, exclude_none=True)
+            )
+            for e in predictions
         ]
         return self._post_process_result(
-            images=images,
+            images=stream_context.images,
             predictions=predictions,
-            class_filter=class_filter,
-            model_id=model_id,
+            class_filter=stream_context.class_filter,
+            model_id=stream_context.model_id,
         )
+
+    def _pop_stream_prediction_context(
+        self,
+        default: _StreamPredictionContext,
+    ) -> _StreamPredictionContext:
+        if self._pending_stream_prediction_contexts:
+            return self._pending_stream_prediction_contexts.popleft()
+        return default
+
+    def _select_async_prediction_value(
+        self,
+        result_future: Future,
+        image_index: int,
+    ):
+        result = result_future.result()
+        if image_index >= len(result):
+            return []
+        return result[image_index]["predictions"]
+
+    def is_stream_pipelined(self) -> bool:
+        if self._step_execution_mode is not StepExecutionMode.LOCAL:
+            return False
+        if (
+            self._last_model_id is None
+            or self._last_model_id not in self._model_manager
+        ):
+            return False
+        model = self._model_manager[self._last_model_id]
+        return (
+            callable(getattr(model, "flush", None))
+            and getattr(model, "_pipeline_depth", 1) > 1
+        )
+
+    def can_activate_stream_pipeline(self) -> bool:
+        return (
+            self._step_execution_mode is StepExecutionMode.LOCAL
+            and get_rfdetr_pipeline_depth() > 1
+        )
+
+    def stream_pipeline_depth(self) -> int:
+        if not self.is_stream_pipelined():
+            return 0
+        model = self._model_manager[self._last_model_id]
+        return max(0, int(getattr(model, "_pipeline_depth", 1)) - 1)
+
+    def flush_stream_pipeline_outputs(
+        self,
+    ) -> List[Tuple[List[Tuple[int, ...]], BlockResult]]:
+        if (
+            self._last_model_id is None
+            or self._last_model_id not in self._model_manager
+        ):
+            self._pending_stream_prediction_contexts.clear()
+            return []
+        model = self._model_manager[self._last_model_id]
+        flush_fn = getattr(model, "flush", None)
+        if not callable(flush_fn):
+            self._pending_stream_prediction_contexts.clear()
+            return []
+        predictions = flush_fn()
+        if not isinstance(predictions, list):
+            predictions = [predictions]
+
+        results = []
+        offset = 0
+        while self._pending_stream_prediction_contexts:
+            stream_context = self._pending_stream_prediction_contexts.popleft()
+            batch_size = len(stream_context.images)
+            prediction_batch = predictions[offset : offset + batch_size]
+            offset += batch_size
+            if len(prediction_batch) != batch_size:
+                raise RuntimeError(
+                    "Stream pipeline flush returned fewer predictions than expected"
+                )
+            results.append(
+                (
+                    _stream_context_indices(images=stream_context.images),
+                    self._finalize_prediction_responses(
+                        predictions=prediction_batch,
+                        stream_context=stream_context,
+                    ),
+                )
+            )
+        if offset != len(predictions):
+            raise RuntimeError(
+                "Stream pipeline flush returned more predictions than expected"
+            )
+        return results
+
+    def flush_stream_pipeline(self) -> List[BlockResult]:
+        return [outputs for _, outputs in self.flush_stream_pipeline_outputs()]
+
+    def close_stream_pipeline(self) -> None:
+        if self._stream_response_executor is not None:
+            self._stream_response_executor.shutdown(wait=False)
+            self._stream_response_executor = None
+        if (
+            self._last_model_id is None
+            or self._last_model_id not in self._model_manager
+        ):
+            return None
+        model = self._model_manager[self._last_model_id]
+        shutdown_fn = getattr(model, "shutdown_pipeline", None)
+        if callable(shutdown_fn):
+            shutdown_fn()
 
     def run_remotely(
         self,
@@ -435,3 +658,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             }
             for inference_id, prediction in zip(inference_ids, predictions)
         ]
+
+
+def _stream_context_indices(images: Batch[WorkflowImageData]) -> List[Tuple[int, ...]]:
+    indices = getattr(images, "indices", None)
+    if indices is not None:
+        return indices
+    return [(i,) for i in range(len(images))]

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -1,5 +1,5 @@
 from collections import deque
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from dataclasses import dataclass
 from typing import Deque, List, Literal, Optional, Tuple, Type, Union
 
@@ -15,6 +15,7 @@ from inference.core.entities.responses.inference import (
 from inference.core.env import (
     HOSTED_INSTANCE_SEGMENTATION_URL,
     LOCAL_INFERENCE_API_URL,
+    WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
     WORKFLOWS_REMOTE_API_TARGET,
     WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
     WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
@@ -459,7 +460,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         predictions_future: Future,
         stream_context: _StreamPredictionContext,
     ) -> BlockResult:
-        predictions = predictions_future.result()
+        predictions = _resolve_stream_future(
+            future=predictions_future,
+            context="RF-DETR async prediction finalization",
+        )
         if not isinstance(predictions, list):
             predictions = [predictions]
         return self._finalize_prediction_responses(
@@ -523,7 +527,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         result_future: Future,
         image_index: int,
     ):
-        result = result_future.result()
+        result = _resolve_stream_future(
+            future=result_future,
+            context="RF-DETR async prediction selection",
+        )
         if image_index >= len(result):
             return []
         return result[image_index]["predictions"]
@@ -716,6 +723,16 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             }
             for inference_id, prediction in zip(inference_ids, predictions)
         ]
+
+
+def _resolve_stream_future(
+    future: Future,
+    context: str,
+):
+    try:
+        return future.result(timeout=WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT)
+    except TimeoutError as error:
+        raise RuntimeError(f"Timed out while waiting for {context}.") from error
 
 
 def _stream_context_indices(images: Batch[WorkflowImageData]) -> List[Tuple[int, ...]]:

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v4.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v4.py
@@ -65,6 +65,8 @@ This version of block introduces breaking change in behaviour of mask constructi
 shapes of any kind from remote server.
 """
 
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
+
 
 class BlockManifest(WorkflowBlockManifest):
     model_config = ConfigDict(
@@ -336,9 +338,7 @@ class RoboflowInstanceSegmentationModelBlockV4(WorkflowBlock):
         )
         if not isinstance(predictions, list):
             predictions = [predictions]
-        predictions = [
-            e.model_dump(by_alias=True, exclude_none=True) for e in predictions
-        ]
+        predictions = [_prediction_response_to_dict(e) for e in predictions]
         return self._post_process_result(
             images=images,
             predictions=predictions,
@@ -432,3 +432,10 @@ class RoboflowInstanceSegmentationModelBlockV4(WorkflowBlock):
             }
             for inference_id, prediction in zip(inference_ids, predictions)
         ]
+
+
+def _prediction_response_to_dict(response: object) -> dict:
+    result = response.model_dump(by_alias=True, exclude_none=True)
+    if getattr(response, _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR, False):
+        result[_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR] = True
+    return result

--- a/inference/core/workflows/execution_engine/core.py
+++ b/inference/core/workflows/execution_engine/core.py
@@ -75,6 +75,7 @@ class ExecutionEngine(BaseExecutionEngine):
         _is_preview: bool = False,
         serialize_results: bool = False,
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         return self._engine.run(
             runtime_parameters=runtime_parameters,
@@ -82,6 +83,7 @@ class ExecutionEngine(BaseExecutionEngine):
             _is_preview=_is_preview,
             serialize_results=serialize_results,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
     def flush_stream_pipeline(

--- a/inference/core/workflows/execution_engine/core.py
+++ b/inference/core/workflows/execution_engine/core.py
@@ -74,8 +74,24 @@ class ExecutionEngine(BaseExecutionEngine):
         fps: float = 0,
         _is_preview: bool = False,
         serialize_results: bool = False,
+        defer_stream_pipeline_flush: bool = False,
     ) -> List[Dict[str, Any]]:
         return self._engine.run(
+            runtime_parameters=runtime_parameters,
+            fps=fps,
+            _is_preview=_is_preview,
+            serialize_results=serialize_results,
+            defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+        )
+
+    def flush_stream_pipeline(
+        self,
+        runtime_parameters: Dict[str, Any],
+        fps: float = 0,
+        _is_preview: bool = False,
+        serialize_results: bool = False,
+    ) -> List[Dict[str, Any]]:
+        return self._engine.flush_stream_pipeline(
             runtime_parameters=runtime_parameters,
             fps=fps,
             _is_preview=_is_preview,

--- a/inference/core/workflows/execution_engine/entities/engine.py
+++ b/inference/core/workflows/execution_engine/entities/engine.py
@@ -31,5 +31,7 @@ class BaseExecutionEngine(ABC):
         fps: float = 0,
         _is_preview: bool = False,
         serialize_results: bool = False,
+        defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         pass

--- a/inference/core/workflows/execution_engine/v1/compiler/graph_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/graph_constructor.py
@@ -388,7 +388,14 @@ def establish_control_flow_edge(
             f"that situation creates ambiguity in selecting execution branch.",
             context="workflow_compilation | execution_graph_construction",
         )
-    execution_branch_name = f"Branch[{source_step_selector} -> {target_step_parsed_selector.definition.property_name}]"
+    # Selectors held in dict properties (e.g. switch-case mappings) each spawn their own
+    # execution branch, so flow-control blocks can select targets independently. Selectors
+    # in list properties (e.g. `next_steps`) share a single branch - they are selected
+    # together or not at all.
+    property_name = target_step_parsed_selector.definition.property_name
+    if target_step_parsed_selector.key is not None:
+        property_name = f"{property_name}[{target_step_parsed_selector.key}]"
+    execution_branch_name = f"Branch[{source_step_selector} -> {property_name}]"
     source_compilation_data.child_execution_branches[target_step_selector] = (
         execution_branch_name
     )

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -122,6 +122,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         _is_preview: bool = False,
         serialize_results: bool = False,
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         self._profiler.start_workflow_run()
         runtime_parameters = assemble_runtime_parameters(
@@ -156,6 +157,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
             executor=self._executor,
             step_error_handler=self._step_error_handler,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
         self._profiler.end_workflow_run()
         return result

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -29,7 +29,7 @@ from inference.core.workflows.execution_engine.v1.step_error_handlers import (
     legacy_step_error_handler,
 )
 
-EXECUTION_ENGINE_V1_VERSION = Version("1.10.1")
+EXECUTION_ENGINE_V1_VERSION = Version("1.11.0")
 
 DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER = os.getenv(
     "DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER", "extended_roboflow_errors"

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -18,6 +18,9 @@ from inference.core.workflows.execution_engine.v1.compiler.entities import (
     CompiledWorkflow,
 )
 from inference.core.workflows.execution_engine.v1.executor.core import run_workflow
+from inference.core.workflows.execution_engine.v1.executor.core import (
+    flush_stream_pipeline_workflow,
+)
 from inference.core.workflows.execution_engine.v1.executor.runtime_input_assembler import (
     assemble_runtime_parameters,
 )
@@ -118,6 +121,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         fps: float = 0,
         _is_preview: bool = False,
         serialize_results: bool = False,
+        defer_stream_pipeline_flush: bool = False,
     ) -> List[Dict[str, Any]]:
         self._profiler.start_workflow_run()
         runtime_parameters = assemble_runtime_parameters(
@@ -146,6 +150,40 @@ class ExecutionEngineV1(BaseExecutionEngine):
             usage_fps=fps,
             usage_workflow_id=usage_workflow_id,
             usage_workflow_preview=_is_preview,
+            kinds_serializers=self._compiled_workflow.kinds_serializers,
+            serialize_results=serialize_results,
+            profiler=self._profiler,
+            executor=self._executor,
+            step_error_handler=self._step_error_handler,
+            defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+        )
+        self._profiler.end_workflow_run()
+        return result
+
+    def flush_stream_pipeline(
+        self,
+        runtime_parameters: Dict[str, Any],
+        fps: float = 0,
+        _is_preview: bool = False,
+        serialize_results: bool = False,
+    ) -> List[Dict[str, Any]]:
+        self._profiler.start_workflow_run()
+        runtime_parameters = assemble_runtime_parameters(
+            runtime_parameters=runtime_parameters,
+            defined_inputs=self._compiled_workflow.workflow_definition.inputs,
+            kinds_deserializers=self._compiled_workflow.kinds_deserializers,
+            prevent_local_images_loading=self._prevent_local_images_loading,
+            profiler=self._profiler,
+        )
+        validate_runtime_input(
+            runtime_parameters=runtime_parameters,
+            input_substitutions=self._compiled_workflow.input_substitutions,
+            profiler=self._profiler,
+        )
+        result = flush_stream_pipeline_workflow(
+            workflow=self._compiled_workflow,
+            runtime_parameters=runtime_parameters,
+            max_concurrent_steps=self._max_concurrent_steps,
             kinds_serializers=self._compiled_workflow.kinds_serializers,
             serialize_results=serialize_results,
             profiler=self._profiler,

--- a/inference/core/workflows/execution_engine/v1/executor/core.py
+++ b/inference/core/workflows/execution_engine/v1/executor/core.py
@@ -101,6 +101,7 @@ def run_workflow(
     executor: Optional[ThreadPoolExecutor] = None,
     step_error_handler: Optional[Callable[[Exception], None]] = None,
     defer_stream_pipeline_flush: bool = False,
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     with start_span("workflow.run"):
         return _run_workflow(
@@ -113,6 +114,7 @@ def run_workflow(
             executor=executor,
             step_error_handler=step_error_handler,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
 
@@ -126,6 +128,7 @@ def _run_workflow(
     executor: Optional[ThreadPoolExecutor] = None,
     step_error_handler: Optional[Callable[[Exception], None]] = None,
     defer_stream_pipeline_flush: bool = False,
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     execution_data_manager = ExecutionDataManager.init(
         execution_graph=workflow.execution_graph,
@@ -168,6 +171,7 @@ def _run_workflow(
                 execution_data_manager=execution_data_manager,
                 serialize_results=serialize_results,
                 kinds_serializers=kinds_serializers,
+                resolve_output_futures=resolve_output_futures,
             )
     finally:
         if not defer_stream_pipeline_flush:

--- a/inference/core/workflows/execution_engine/v1/executor/core.py
+++ b/inference/core/workflows/execution_engine/v1/executor/core.py
@@ -42,6 +42,7 @@ from inference.core.workflows.execution_engine.v1.compiler.entities import (
     CompiledWorkflow,
 )
 from inference.core.workflows.execution_engine.v1.compiler.utils import (
+    construct_step_selector,
     get_last_chunk_of_selector,
 )
 from inference.core.workflows.execution_engine.v1.executor.execution_data_manager.manager import (
@@ -99,6 +100,7 @@ def run_workflow(
     profiler: Optional[WorkflowsProfiler] = None,
     executor: Optional[ThreadPoolExecutor] = None,
     step_error_handler: Optional[Callable[[Exception], None]] = None,
+    defer_stream_pipeline_flush: bool = False,
 ) -> List[Dict[str, Any]]:
     with start_span("workflow.run"):
         return _run_workflow(
@@ -110,10 +112,69 @@ def run_workflow(
             profiler=profiler,
             executor=executor,
             step_error_handler=step_error_handler,
+            defer_stream_pipeline_flush=defer_stream_pipeline_flush,
         )
 
 
 def _run_workflow(
+    workflow: CompiledWorkflow,
+    runtime_parameters: Dict[str, Any],
+    max_concurrent_steps: int,
+    kinds_serializers: Optional[Dict[str, Callable[[Any], Any]]],
+    serialize_results: bool = False,
+    profiler: Optional[WorkflowsProfiler] = None,
+    executor: Optional[ThreadPoolExecutor] = None,
+    step_error_handler: Optional[Callable[[Exception], None]] = None,
+    defer_stream_pipeline_flush: bool = False,
+) -> List[Dict[str, Any]]:
+    execution_data_manager = ExecutionDataManager.init(
+        execution_graph=workflow.execution_graph,
+        runtime_parameters=runtime_parameters,
+    )
+    execution_coordinator = ParallelStepExecutionCoordinator.init(
+        execution_graph=workflow.execution_graph,
+    )
+    try:
+        next_steps = execution_coordinator.get_steps_to_execute_next(profiler=profiler)
+        while next_steps is not None:
+            execute_steps(
+                next_steps=next_steps,
+                workflow=workflow,
+                execution_data_manager=execution_data_manager,
+                max_concurrent_steps=max_concurrent_steps,
+                profiler=profiler,
+                executor=executor,
+                step_error_handler=step_error_handler,
+            )
+            next_steps = execution_coordinator.get_steps_to_execute_next(
+                profiler=profiler
+            )
+        if not defer_stream_pipeline_flush:
+            with profiler.profile_execution_phase(
+                name="stream_pipeline_flush",
+                categories=["execution_engine_operation"],
+            ):
+                flush_stream_pipeline_outputs(
+                    workflow=workflow,
+                    execution_data_manager=execution_data_manager,
+                )
+        with profiler.profile_execution_phase(
+            name="outputs_construction",
+            categories=["execution_engine_operation"],
+        ):
+            return construct_workflow_output(
+                workflow_outputs=workflow.workflow_definition.outputs,
+                execution_graph=workflow.execution_graph,
+                execution_data_manager=execution_data_manager,
+                serialize_results=serialize_results,
+                kinds_serializers=kinds_serializers,
+            )
+    finally:
+        if not defer_stream_pipeline_flush:
+            close_stream_pipelines(workflow=workflow)
+
+
+def flush_stream_pipeline_workflow(
     workflow: CompiledWorkflow,
     runtime_parameters: Dict[str, Any],
     max_concurrent_steps: int,
@@ -130,29 +191,114 @@ def _run_workflow(
     execution_coordinator = ParallelStepExecutionCoordinator.init(
         execution_graph=workflow.execution_graph,
     )
+    flushed_step_selectors = flush_stream_pipeline_outputs(
+        workflow=workflow,
+        execution_data_manager=execution_data_manager,
+    )
+    downstream_step_selectors = _downstream_step_selectors(
+        workflow=workflow,
+        step_selectors=flushed_step_selectors,
+    )
     next_steps = execution_coordinator.get_steps_to_execute_next(profiler=profiler)
     while next_steps is not None:
-        execute_steps(
-            next_steps=next_steps,
-            workflow=workflow,
-            execution_data_manager=execution_data_manager,
-            max_concurrent_steps=max_concurrent_steps,
-            profiler=profiler,
-            executor=executor,
-            step_error_handler=step_error_handler,
-        )
+        runnable_steps = [
+            step_selector
+            for step_selector in next_steps
+            if step_selector in downstream_step_selectors
+            and execution_data_manager.all_inputs_impacting_step_are_registered(
+                step_selector=step_selector
+            )
+        ]
+        if runnable_steps:
+            execute_steps(
+                next_steps=runnable_steps,
+                workflow=workflow,
+                execution_data_manager=execution_data_manager,
+                max_concurrent_steps=max_concurrent_steps,
+                profiler=profiler,
+                executor=executor,
+                step_error_handler=step_error_handler,
+            )
         next_steps = execution_coordinator.get_steps_to_execute_next(profiler=profiler)
-    with profiler.profile_execution_phase(
-        name="outputs_construction",
-        categories=["execution_engine_operation"],
-    ):
-        return construct_workflow_output(
-            workflow_outputs=workflow.workflow_definition.outputs,
-            execution_graph=workflow.execution_graph,
-            execution_data_manager=execution_data_manager,
-            serialize_results=serialize_results,
-            kinds_serializers=kinds_serializers,
-        )
+    return construct_workflow_output(
+        workflow_outputs=workflow.workflow_definition.outputs,
+        execution_graph=workflow.execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=serialize_results,
+        kinds_serializers=kinds_serializers,
+    )
+
+
+def flush_stream_pipeline_outputs(
+    workflow: CompiledWorkflow,
+    execution_data_manager: ExecutionDataManager,
+    step_selectors: Optional[List[str]] = None,
+) -> List[str]:
+    flushed_step_selectors = []
+    step_names = (
+        [get_last_chunk_of_selector(selector=selector) for selector in step_selectors]
+        if step_selectors is not None
+        else list(workflow.steps)
+    )
+    for step_name in step_names:
+        step = workflow.steps[step_name]
+        flush_fn = getattr(step.step, "flush_stream_pipeline_outputs", None)
+        if not callable(flush_fn):
+            continue
+        step_selector = construct_step_selector(step_name=step_name)
+        flushed_outputs = flush_fn()
+        for indices, outputs in flushed_outputs:
+            if not outputs:
+                continue
+            if execution_data_manager.is_step_simd(step_selector=step_selector):
+                execution_data_manager.register_simd_step_output(
+                    step_selector=step_selector,
+                    indices=indices,
+                    outputs=outputs,
+                )
+                flushed_step_selectors.append(step_selector)
+                continue
+            if len(outputs) != 1:
+                raise StepExecutionError(
+                    block_id=step_name,
+                    block_type=step.manifest.type,
+                    public_message=(
+                        f"Flushed stream pipeline for non-SIMD step {step_name} "
+                        f"returned {len(outputs)} outputs."
+                    ),
+                    context="workflow_execution | stream_pipeline_flush",
+                )
+            execution_data_manager.register_non_simd_step_output(
+                step_selector=step_selector,
+                output=outputs[0],
+            )
+            flushed_step_selectors.append(step_selector)
+    return flushed_step_selectors
+
+
+def _downstream_step_selectors(
+    workflow: CompiledWorkflow,
+    step_selectors: List[str],
+) -> set[str]:
+    step_selector_set = {
+        construct_step_selector(step_name=step_name) for step_name in workflow.steps
+    }
+    result = set()
+    nodes_to_visit = list(step_selectors)
+    while nodes_to_visit:
+        node = nodes_to_visit.pop(0)
+        for successor in workflow.execution_graph.successors(node):
+            if successor in step_selector_set and successor not in result:
+                result.add(successor)
+            nodes_to_visit.append(successor)
+    return result
+
+
+def close_stream_pipelines(workflow: CompiledWorkflow) -> None:
+    for step in workflow.steps.values():
+        close_fn = getattr(step.step, "close_stream_pipeline", None)
+        if callable(close_fn):
+            close_fn()
 
 
 @execution_phase(

--- a/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/manager.py
+++ b/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/manager.py
@@ -569,7 +569,9 @@ class ExecutionDataManager:
         for target_step, branch_name in step_node.child_execution_branches.items():
             if target_step in selected_steps:
                 selected_execution_branches.add(branch_name)
-        for branch_name in step_node.child_execution_branches.values():
+        # multiple targets may share one execution branch (selectors kept in a list
+        # property), so deduplicate to avoid re-registering the same mask
+        for branch_name in set(step_node.child_execution_branches.values()):
             mask = branch_name in selected_execution_branches
             logger.debug(f"NON-SIMD flow control -> {branch_name}: {mask}")
             self._branching_manager.register_non_batch_mask(

--- a/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/step_input_assembler.py
+++ b/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/step_input_assembler.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, TypeVar, Union
 
@@ -38,6 +39,43 @@ class BatchModeSIMDStepInput:
 class NonBatchModeSIMDStepInput:
     index: DynamicBatchIndex
     parameters: Dict[str, Any]
+
+
+def _resolve_step_output_futures(value: Any) -> Any:
+    if isinstance(value, Future):
+        return _resolve_step_output_futures(value.result())
+    if isinstance(value, Batch):
+        return Batch.init(
+            content=[_resolve_step_output_futures(element) for element in value],
+            indices=value.indices,
+        )
+    if isinstance(value, list):
+        return [_resolve_step_output_futures(element) for element in value]
+    if isinstance(value, tuple):
+        return tuple(_resolve_step_output_futures(element) for element in value)
+    if isinstance(value, dict):
+        return {
+            key: _resolve_step_output_futures(element) for key, element in value.items()
+        }
+    return value
+
+
+def _step_output_contains_future(value: Any) -> bool:
+    if isinstance(value, Future):
+        return True
+    if isinstance(value, Batch):
+        return any(_step_output_contains_future(element) for element in value)
+    if isinstance(value, list) or isinstance(value, tuple):
+        return any(_step_output_contains_future(element) for element in value)
+    if isinstance(value, dict):
+        return any(_step_output_contains_future(element) for element in value.values())
+    return False
+
+
+def _maybe_resolve_step_output_futures(value: Any) -> Any:
+    if not _step_output_contains_future(value):
+        return value
+    return _resolve_step_output_futures(value)
 
 
 def construct_non_simd_step_input(
@@ -210,6 +248,7 @@ def construct_non_simd_step_non_compound_input(
         step_output = execution_cache.get_non_batch_output(
             selector=parameter_spec.selector
         )
+        step_output = _maybe_resolve_step_output_futures(step_output)
         return step_output, step_output is None
     parameter_spec: StaticStepInputDefinition = parameter_spec  # type: ignore
     return parameter_spec.value, False
@@ -635,6 +674,7 @@ def get_non_compound_parameter_value(
             value = execution_cache.get_non_batch_output(
                 selector=input_parameter.selector
             )
+            value = _maybe_resolve_step_output_futures(value)
             if not requested_as_batch:
                 return value, None, value is None
             else:
@@ -713,6 +753,7 @@ def get_non_compound_parameter_value(
             batch_elements_indices=lineage_indices,
             mask=mask_for_dimension,
         )
+        batch_input = _maybe_resolve_step_output_futures(batch_input)
     if step_execution_dimensionality == parameter_dimensionality:
         return Batch(batch_input, lineage_indices), lineage_indices, False
     if step_execution_dimensionality > parameter_dimensionality:

--- a/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/step_input_assembler.py
+++ b/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/step_input_assembler.py
@@ -1,4 +1,3 @@
-from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, TypeVar, Union
 
@@ -25,6 +24,11 @@ from inference.core.workflows.execution_engine.v1.executor.execution_data_manage
 from inference.core.workflows.execution_engine.v1.executor.execution_data_manager.execution_cache import (
     ExecutionCache,
 )
+from inference.core.workflows.execution_engine.v1.executor.utils import (
+    contains_future,
+    maybe_resolve_futures,
+    resolve_futures,
+)
 
 T = TypeVar("T")
 
@@ -42,40 +46,21 @@ class NonBatchModeSIMDStepInput:
 
 
 def _resolve_step_output_futures(value: Any) -> Any:
-    if isinstance(value, Future):
-        return _resolve_step_output_futures(value.result())
-    if isinstance(value, Batch):
-        return Batch.init(
-            content=[_resolve_step_output_futures(element) for element in value],
-            indices=value.indices,
-        )
-    if isinstance(value, list):
-        return [_resolve_step_output_futures(element) for element in value]
-    if isinstance(value, tuple):
-        return tuple(_resolve_step_output_futures(element) for element in value)
-    if isinstance(value, dict):
-        return {
-            key: _resolve_step_output_futures(element) for key, element in value.items()
-        }
-    return value
+    return resolve_futures(
+        value=value,
+        context="workflow_execution | step_input_assembling",
+    )
 
 
 def _step_output_contains_future(value: Any) -> bool:
-    if isinstance(value, Future):
-        return True
-    if isinstance(value, Batch):
-        return any(_step_output_contains_future(element) for element in value)
-    if isinstance(value, list) or isinstance(value, tuple):
-        return any(_step_output_contains_future(element) for element in value)
-    if isinstance(value, dict):
-        return any(_step_output_contains_future(element) for element in value.values())
-    return False
+    return contains_future(value=value)
 
 
 def _maybe_resolve_step_output_futures(value: Any) -> Any:
-    if not _step_output_contains_future(value):
-        return value
-    return _resolve_step_output_futures(value)
+    return maybe_resolve_futures(
+        value=value,
+        context="workflow_execution | step_input_assembling",
+    )
 
 
 def construct_non_simd_step_input(

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -1,5 +1,6 @@
 import traceback
 from collections import defaultdict
+from concurrent.futures import Future
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -63,6 +64,7 @@ def construct_workflow_output(
         if output.name in batch_oriented_outputs:
             continue
         data_piece = execution_data_manager.get_non_batch_data(selector=output.selector)
+        data_piece = _maybe_resolve_output_futures(data_piece)
         if serialize_results:
             output_kind = kinds_of_output_nodes[output.name]
             data_piece = serialize_data_piece(
@@ -169,6 +171,7 @@ def create_outputs_for_input_induced_lineages(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
+            data_piece = _maybe_resolve_output_futures(data_piece)
             if (
                 name in outputs_requested_in_parent_coordinates
                 and data_contains_sv_detections(data=data_piece)
@@ -263,6 +266,7 @@ def create_outputs_for_generated_lineage_outputs(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
+            data_piece = _maybe_resolve_output_futures(data_piece)
             if (
                 name in outputs_requested_in_parent_coordinates
                 and data_contains_sv_detections(data=data_piece)
@@ -310,6 +314,34 @@ def create_outputs_for_generated_lineage_outputs(
                 element = array[i]
             results[name].append(element)
     return results
+
+
+def _resolve_output_futures(value: Any) -> Any:
+    if isinstance(value, Future):
+        return _resolve_output_futures(value.result())
+    if isinstance(value, list):
+        return [_resolve_output_futures(element) for element in value]
+    if isinstance(value, tuple):
+        return tuple(_resolve_output_futures(element) for element in value)
+    if isinstance(value, dict):
+        return {key: _resolve_output_futures(element) for key, element in value.items()}
+    return value
+
+
+def _output_contains_future(value: Any) -> bool:
+    if isinstance(value, Future):
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(_output_contains_future(element) for element in value)
+    if isinstance(value, dict):
+        return any(_output_contains_future(element) for element in value.values())
+    return False
+
+
+def _maybe_resolve_output_futures(value: Any) -> Any:
+    if not _output_contains_future(value):
+        return value
+    return _resolve_output_futures(value)
 
 
 def create_array(indices: np.ndarray) -> Optional[list]:

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -1,5 +1,7 @@
 import traceback
 from collections import defaultdict
+from concurrent.futures import Future
+from threading import Lock
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -12,6 +14,10 @@ from inference.core.workflows.core_steps.common.utils import (
 )
 from inference.core.workflows.errors import AssumptionError, ExecutionEngineRuntimeError
 from inference.core.workflows.execution_engine.constants import (
+    IMAGE_DIMENSIONS_KEY,
+    ROOT_PARENT_COORDINATES_KEY,
+    ROOT_PARENT_DIMENSIONS_KEY,
+    SCALING_RELATIVE_TO_ROOT_PARENT_KEY,
     TOP_LEVEL_LINEAGES_KEY,
     WORKFLOW_INPUT_BATCH_LINEAGE_ID,
 )
@@ -180,13 +186,13 @@ def create_outputs_for_input_induced_lineages(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            if resolve_output_futures:
-                data_piece = _maybe_resolve_output_futures(data_piece)
-            if (
-                name in outputs_requested_in_parent_coordinates
-                and data_contains_sv_detections(data=data_piece)
-            ):
-                data_piece = convert_sv_detections_coordinates(data=data_piece)
+            data_piece = _prepare_data_piece_for_output(
+                data_piece=data_piece,
+                resolve_output_futures=resolve_output_futures,
+                convert_to_parent_coordinates=(
+                    name in outputs_requested_in_parent_coordinates
+                ),
+            )
             if serialize_results:
                 output_kind = kinds_of_output_nodes[name]
                 data_piece = serialize_data_piece(
@@ -277,13 +283,13 @@ def create_outputs_for_generated_lineage_outputs(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            if resolve_output_futures:
-                data_piece = _maybe_resolve_output_futures(data_piece)
-            if (
-                name in outputs_requested_in_parent_coordinates
-                and data_contains_sv_detections(data=data_piece)
-            ):
-                data_piece = convert_sv_detections_coordinates(data=data_piece)
+            data_piece = _prepare_data_piece_for_output(
+                data_piece=data_piece,
+                resolve_output_futures=resolve_output_futures,
+                convert_to_parent_coordinates=(
+                    name in outputs_requested_in_parent_coordinates
+                ),
+            )
             if serialize_results:
                 output_kind = kinds_of_output_nodes[name]
                 data_piece = serialize_data_piece(
@@ -326,6 +332,85 @@ def create_outputs_for_generated_lineage_outputs(
                 element = array[i]
             results[name].append(element)
     return results
+
+
+class _DeferredResolvedOutput(Future):
+    def __init__(
+        self,
+        value: Any,
+        transform: Callable[[Any], Any],
+    ) -> None:
+        super().__init__()
+        self._value = value
+        self._transform = transform
+        self._resolution_lock = Lock()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        if not self.done():
+            with self._resolution_lock:
+                if not self.done():
+                    try:
+                        resolved_value = _resolve_output_futures(value=self._value)
+                        self.set_result(self._transform(resolved_value))
+                    except BaseException as error:
+                        self.set_exception(error)
+        return super().result(timeout=timeout)
+
+
+def _prepare_data_piece_for_output(
+    data_piece: Any,
+    resolve_output_futures: bool,
+    convert_to_parent_coordinates: bool,
+) -> Any:
+    if resolve_output_futures:
+        data_piece = _maybe_resolve_output_futures(value=data_piece)
+    elif convert_to_parent_coordinates and _output_contains_future(value=data_piece):
+        return _DeferredResolvedOutput(
+            value=data_piece,
+            transform=_convert_sv_detections_coordinates_if_present,
+        )
+    if convert_to_parent_coordinates:
+        return _convert_sv_detections_coordinates_if_present(data=data_piece)
+    return data_piece
+
+
+def _convert_sv_detections_coordinates_if_present(data: Any) -> Any:
+    if data_needs_sv_detections_coordinate_conversion(data=data):
+        return convert_sv_detections_coordinates(data=data)
+    return data
+
+
+def data_needs_sv_detections_coordinate_conversion(data: Any) -> bool:
+    if isinstance(data, sv.Detections):
+        return _sv_detections_need_root_coordinate_conversion(detections=data)
+    if isinstance(data, (list, tuple)):
+        return any(data_needs_sv_detections_coordinate_conversion(data=e) for e in data)
+    if isinstance(data, dict):
+        return any(
+            data_needs_sv_detections_coordinate_conversion(data=e)
+            for e in data.values()
+        )
+    return False
+
+
+def _sv_detections_need_root_coordinate_conversion(detections: sv.Detections) -> bool:
+    if len(detections) == 0:
+        return False
+    root_coordinates = detections.data.get(ROOT_PARENT_COORDINATES_KEY)
+    if root_coordinates is None:
+        return False
+    if np.any(np.asarray(root_coordinates) != 0):
+        return True
+    root_dimensions = detections.data.get(ROOT_PARENT_DIMENSIONS_KEY)
+    image_dimensions = detections.data.get(IMAGE_DIMENSIONS_KEY)
+    if (
+        root_dimensions is not None
+        and image_dimensions is not None
+        and not np.array_equal(root_dimensions, image_dimensions)
+    ):
+        return True
+    root_scale = detections.data.get(SCALING_RELATIVE_TO_ROOT_PARENT_KEY)
+    return root_scale is not None and not np.allclose(root_scale, 1.0)
 
 
 def _resolve_output_futures(value: Any) -> Any:

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -1,6 +1,5 @@
 import traceback
 from collections import defaultdict
-from concurrent.futures import Future
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -31,6 +30,11 @@ from inference.core.workflows.execution_engine.v1.executor.execution_data_manage
 )
 from inference.core.workflows.execution_engine.v1.executor.execution_data_manager.manager import (
     ExecutionDataManager,
+)
+from inference.core.workflows.execution_engine.v1.executor.utils import (
+    contains_future,
+    maybe_resolve_futures,
+    resolve_futures,
 )
 
 
@@ -325,31 +329,21 @@ def create_outputs_for_generated_lineage_outputs(
 
 
 def _resolve_output_futures(value: Any) -> Any:
-    if isinstance(value, Future):
-        return _resolve_output_futures(value.result())
-    if isinstance(value, list):
-        return [_resolve_output_futures(element) for element in value]
-    if isinstance(value, tuple):
-        return tuple(_resolve_output_futures(element) for element in value)
-    if isinstance(value, dict):
-        return {key: _resolve_output_futures(element) for key, element in value.items()}
-    return value
+    return resolve_futures(
+        value=value,
+        context="workflow_execution | output_construction",
+    )
 
 
 def _output_contains_future(value: Any) -> bool:
-    if isinstance(value, Future):
-        return True
-    if isinstance(value, (list, tuple)):
-        return any(_output_contains_future(element) for element in value)
-    if isinstance(value, dict):
-        return any(_output_contains_future(element) for element in value.values())
-    return False
+    return contains_future(value=value)
 
 
 def _maybe_resolve_output_futures(value: Any) -> Any:
-    if not _output_contains_future(value):
-        return value
-    return _resolve_output_futures(value)
+    return maybe_resolve_futures(
+        value=value,
+        context="workflow_execution | output_construction",
+    )
 
 
 def create_array(indices: np.ndarray) -> Optional[list]:

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -40,6 +40,7 @@ def construct_workflow_output(
     execution_data_manager: ExecutionDataManager,
     serialize_results: bool,
     kinds_serializers: Dict[str, Callable[[Any], Any]],
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     # Maybe we should make blocks to change coordinates systems:
     # https://github.com/roboflow/inference/issues/440
@@ -64,7 +65,8 @@ def construct_workflow_output(
         if output.name in batch_oriented_outputs:
             continue
         data_piece = execution_data_manager.get_non_batch_data(selector=output.selector)
-        data_piece = _maybe_resolve_output_futures(data_piece)
+        if resolve_output_futures:
+            data_piece = _maybe_resolve_output_futures(data_piece)
         if serialize_results:
             output_kind = kinds_of_output_nodes[output.name]
             data_piece = serialize_data_piece(
@@ -110,6 +112,7 @@ def construct_workflow_output(
         non_batch_outputs=non_batch_outputs,
         dimensionality_for_output_nodes=dimensionality_for_output_nodes,
         batch_oriented_outputs=batch_oriented_outputs,
+        resolve_output_futures=resolve_output_futures,
     )
     if len(results) == 0 and len(outputs_for_generated_lineage) > 0:
         results.append({})
@@ -125,6 +128,7 @@ def construct_workflow_output(
                 kinds_serializers=kinds_serializers,
                 kinds_of_output_nodes=kinds_of_output_nodes,
                 dimensionality_for_output_nodes=dimensionality_for_output_nodes,
+                resolve_output_futures=resolve_output_futures,
             )
         )
         for output in results:
@@ -145,6 +149,7 @@ def create_outputs_for_input_induced_lineages(
     non_batch_outputs: Dict[str, Any],
     dimensionality_for_output_nodes: Dict[str, int],
     batch_oriented_outputs: Set[str],
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     outputs_arrays: Dict[str, Optional[list]] = {
         name: create_array(indices=np.array(indices))
@@ -171,7 +176,8 @@ def create_outputs_for_input_induced_lineages(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            data_piece = _maybe_resolve_output_futures(data_piece)
+            if resolve_output_futures:
+                data_piece = _maybe_resolve_output_futures(data_piece)
             if (
                 name in outputs_requested_in_parent_coordinates
                 and data_contains_sv_detections(data=data_piece)
@@ -242,6 +248,7 @@ def create_outputs_for_generated_lineage_outputs(
         str, Union[List[Union[Kind, str]], Dict[str, List[Union[Kind, str]]]]
     ],
     dimensionality_for_output_nodes: Dict[str, int],
+    resolve_output_futures: bool = True,
 ) -> Dict[str, List[Any]]:
     outputs_arrays: Dict[str, Optional[list]] = {
         name: create_array(indices=np.array(indices))
@@ -266,7 +273,8 @@ def create_outputs_for_generated_lineage_outputs(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            data_piece = _maybe_resolve_output_futures(data_piece)
+            if resolve_output_futures:
+                data_piece = _maybe_resolve_output_futures(data_piece)
             if (
                 name in outputs_requested_in_parent_coordinates
                 and data_contains_sv_detections(data=data_piece)

--- a/inference/core/workflows/execution_engine/v1/executor/utils.py
+++ b/inference/core/workflows/execution_engine/v1/executor/utils.py
@@ -1,6 +1,8 @@
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from typing import Any, Callable, Generator, Iterable, List, Optional, TypeVar
 
+from inference.core.env import WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT
+from inference.core.workflows.errors import ExecutionEngineRuntimeError
 from inference.core.workflows.execution_engine.entities.base import Batch
 
 T = TypeVar("T")
@@ -39,24 +41,56 @@ def _run(fun: Callable[[], T]) -> T:
     return fun()
 
 
+def resolve_future_result(
+    future: Future,
+    *,
+    context: str,
+    timeout: float = WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
+) -> Any:
+    try:
+        return future.result(timeout=timeout)
+    except TimeoutError as error:
+        raise ExecutionEngineRuntimeError(
+            public_message=(
+                "Timed out while resolving an asynchronous workflow future."
+            ),
+            context=context,
+            inner_error=error,
+        ) from error
+
+
 def resolve_futures(
     value: Any,
+    timeout: float = WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
     context: str = "workflow_execution | future_resolution",
 ) -> Any:
     if isinstance(value, Future):
-        return resolve_futures(value.result(), context=context)
+        return resolve_futures(
+            resolve_future_result(value, context=context, timeout=timeout),
+            timeout=timeout,
+            context=context,
+        )
     if isinstance(value, Batch):
         return Batch.init(
-            content=[resolve_futures(element, context=context) for element in value],
+            content=[
+                resolve_futures(element, timeout=timeout, context=context)
+                for element in value
+            ],
             indices=value.indices,
         )
     if isinstance(value, list):
-        return [resolve_futures(element, context=context) for element in value]
+        return [
+            resolve_futures(element, timeout=timeout, context=context)
+            for element in value
+        ]
     if isinstance(value, tuple):
-        return tuple(resolve_futures(element, context=context) for element in value)
+        return tuple(
+            resolve_futures(element, timeout=timeout, context=context)
+            for element in value
+        )
     if isinstance(value, dict):
         return {
-            key: resolve_futures(element, context=context)
+            key: resolve_futures(element, timeout=timeout, context=context)
             for key, element in value.items()
         }
     return value
@@ -76,8 +110,9 @@ def contains_future(value: Any) -> bool:
 
 def maybe_resolve_futures(
     value: Any,
+    timeout: float = WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
     context: str = "workflow_execution | future_resolution",
 ) -> Any:
     if not contains_future(value):
         return value
-    return resolve_futures(value=value, context=context)
+    return resolve_futures(value=value, timeout=timeout, context=context)

--- a/inference/core/workflows/execution_engine/v1/executor/utils.py
+++ b/inference/core/workflows/execution_engine/v1/executor/utils.py
@@ -1,5 +1,9 @@
-from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, Generator, Iterable, List, Optional, TypeVar
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
+from typing import Any, Callable, Generator, Iterable, List, Optional, TypeVar
+
+from inference.core.env import WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT
+from inference.core.workflows.errors import ExecutionEngineRuntimeError
+from inference.core.workflows.execution_engine.entities.base import Batch
 
 T = TypeVar("T")
 
@@ -35,3 +39,71 @@ def create_batches(
 
 def _run(fun: Callable[[], T]) -> T:
     return fun()
+
+
+def resolve_futures(
+    value: Any,
+    timeout: float = WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
+    context: str = "workflow_execution | future_resolution",
+) -> Any:
+    if isinstance(value, Future):
+        try:
+            return resolve_futures(
+                value.result(timeout=timeout),
+                timeout=timeout,
+                context=context,
+            )
+        except TimeoutError as error:
+            raise ExecutionEngineRuntimeError(
+                public_message=(
+                    "Timed out while resolving an asynchronous workflow future."
+                ),
+                context=context,
+                inner_error=error,
+            ) from error
+    if isinstance(value, Batch):
+        return Batch.init(
+            content=[
+                resolve_futures(element, timeout=timeout, context=context)
+                for element in value
+            ],
+            indices=value.indices,
+        )
+    if isinstance(value, list):
+        return [
+            resolve_futures(element, timeout=timeout, context=context)
+            for element in value
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            resolve_futures(element, timeout=timeout, context=context)
+            for element in value
+        )
+    if isinstance(value, dict):
+        return {
+            key: resolve_futures(element, timeout=timeout, context=context)
+            for key, element in value.items()
+        }
+    return value
+
+
+def contains_future(value: Any) -> bool:
+    if isinstance(value, Future):
+        return True
+    if isinstance(value, Batch):
+        return any(contains_future(element) for element in value)
+    if isinstance(value, (list, tuple)):
+        return any(contains_future(element) for element in value)
+    if isinstance(value, dict):
+        return any(contains_future(element) for element in value.values())
+    return False
+
+
+def maybe_resolve_futures(
+    value: Any,
+    timeout: float = WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
+    context: str = "workflow_execution | future_resolution",
+) -> Any:
+    if not contains_future(value):
+        return value
+    return resolve_futures(value=value, timeout=timeout, context=context)

--- a/inference/core/workflows/execution_engine/v1/executor/utils.py
+++ b/inference/core/workflows/execution_engine/v1/executor/utils.py
@@ -1,5 +1,7 @@
-from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, Generator, Iterable, List, Optional, TypeVar
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Callable, Generator, Iterable, List, Optional, TypeVar
+
+from inference.core.workflows.execution_engine.entities.base import Batch
 
 T = TypeVar("T")
 
@@ -35,3 +37,47 @@ def create_batches(
 
 def _run(fun: Callable[[], T]) -> T:
     return fun()
+
+
+def resolve_futures(
+    value: Any,
+    context: str = "workflow_execution | future_resolution",
+) -> Any:
+    if isinstance(value, Future):
+        return resolve_futures(value.result(), context=context)
+    if isinstance(value, Batch):
+        return Batch.init(
+            content=[resolve_futures(element, context=context) for element in value],
+            indices=value.indices,
+        )
+    if isinstance(value, list):
+        return [resolve_futures(element, context=context) for element in value]
+    if isinstance(value, tuple):
+        return tuple(resolve_futures(element, context=context) for element in value)
+    if isinstance(value, dict):
+        return {
+            key: resolve_futures(element, context=context)
+            for key, element in value.items()
+        }
+    return value
+
+
+def contains_future(value: Any) -> bool:
+    if isinstance(value, Future):
+        return True
+    if isinstance(value, Batch):
+        return any(contains_future(element) for element in value)
+    if isinstance(value, (list, tuple)):
+        return any(contains_future(element) for element in value)
+    if isinstance(value, dict):
+        return any(contains_future(element) for element in value.values())
+    return False
+
+
+def maybe_resolve_futures(
+    value: Any,
+    context: str = "workflow_execution | future_resolution",
+) -> Any:
+    if not contains_future(value):
+        return value
+    return resolve_futures(value=value, context=context)

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -3,11 +3,23 @@
 
 ## `0.29.2`
 
+### Added
+
+- Opt-in Triton RF-DETR instance-segmentation RLE post-processing. Set
+  `INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED=True` to generate COCO RLE
+  masks directly from sparse interpolated mask regions on supported CUDA
+  inputs.
+- Opt-in Triton RF-DETR instance-segmentation preprocessing for the TensorRT
+  backend. Set `INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=True` to run the
+  supported resize and normalize path on CUDA.
+- Opt-in Triton RF-DETR instance-segmentation pipelining. Set
+  `RFDETR_PIPELINE_DEPTH=2`.
+
 ### Fixed
 
 - Transitive dependency vulnerability patched - `idna>=3.15` required by the package
 
-
+---
 ## `0.29.1`
 
 ### Fixed

--- a/inference_models/inference_models/configuration.py
+++ b/inference_models/inference_models/configuration.py
@@ -1,8 +1,10 @@
 import os
 import warnings
+from typing import Optional
 
 import torch
 
+from inference_models.errors import InvalidEnvVariable
 from inference_models.utils.environment import (
     get_boolean_from_env,
     get_comma_separated_list_of_integers_from_env,
@@ -289,10 +291,70 @@ INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE = get_float_from_env(
     variable_name="INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE",
     default=INFERENCE_MODELS_DEFAULT_CONFIDENCE,
 )
+DEFAULT_INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED = False
+INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED = get_boolean_from_env(
+    variable_name="INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED",
+    default=DEFAULT_INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED,
+)
+INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_MAX_PIXELS = get_integer_from_env(
+    variable_name="INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_MAX_PIXELS",
+    default=4096 * 2160,
+)
+INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_MAX_RUNS = get_integer_from_env(
+    variable_name="INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_MAX_RUNS",
+    default=32768,
+)
 INFERENCE_MODELS_RFDETR_DEFAULT_KEY_POINTS_THRESHOLD = get_float_from_env(
     variable_name="INFERENCE_MODELS_DETR_DEFAULT_KEY_POINTS_THRESHOLD",
     default=0.3,
 )
+DEFAULT_INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED = False
+INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED = get_boolean_from_env(
+    variable_name="INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED",
+    default=DEFAULT_INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED,
+)
+RFDETR_PIPELINE_DEPTH_ENV_NAME = "RFDETR_PIPELINE_DEPTH"
+DEFAULT_RFDETR_PIPELINE_DEPTH = 1
+MIN_RFDETR_PIPELINE_DEPTH = 1
+
+
+def parse_rfdetr_pipeline_depth(value: Optional[str]) -> int:
+    """Parse and validate the RF-DETR streaming pipeline depth.
+
+    Depth is the number of in-flight CPU/GPU stages the stream adapter may keep
+    alive. ``1`` preserves the original synchronous behavior; values greater
+    than one enable delayed response finalization. Zero, negative, and
+    non-integer values are rejected instead of being silently clamped.
+    """
+    if value is None:
+        return DEFAULT_RFDETR_PIPELINE_DEPTH
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise InvalidEnvVariable(
+            message=(
+                f"Expected environment variable `{RFDETR_PIPELINE_DEPTH_ENV_NAME}` "
+                f"to be an integer but got '{value}'"
+            ),
+            help_url="https://inference-models.roboflow.com/errors/runtime-environment/#invalidenvvariable",
+        )
+    if parsed < MIN_RFDETR_PIPELINE_DEPTH:
+        raise InvalidEnvVariable(
+            message=(
+                f"Expected environment variable `{RFDETR_PIPELINE_DEPTH_ENV_NAME}` "
+                f"to be >= {MIN_RFDETR_PIPELINE_DEPTH} but got '{value}'"
+            ),
+            help_url="https://inference-models.roboflow.com/errors/runtime-environment/#invalidenvvariable",
+        )
+    return parsed
+
+
+def get_rfdetr_pipeline_depth() -> int:
+    """Read and validate ``RFDETR_PIPELINE_DEPTH`` from the environment."""
+    return parse_rfdetr_pipeline_depth(os.getenv(RFDETR_PIPELINE_DEPTH_ENV_NAME))
+
+
+RFDETR_PIPELINE_DEPTH = get_rfdetr_pipeline_depth()
 INFERENCE_MODELS_ROBOFLOW_INSTANT_DEFAULT_CONFIDENCE = get_float_from_env(
     variable_name="INFERENCE_MODELS_ROBOFLOW_INSTANT_DEFAULT_CONFIDENCE",
     default=0.99,

--- a/inference_models/inference_models/models/base/async_handoff.py
+++ b/inference_models/inference_models/models/base/async_handoff.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Optional
 
 _ADAPTER_CONTEXT_ATTR = "_inference_adapter_future_context"
 _ASYNC_RESPONSE_FUTURE_ATTR = "_async_response_future"
+_ASYNC_RESPONSE_CONTEXT_ID_ATTR = "_async_response_context_id"
 _DEFERRED_POSTPROCESS_ATTR = "_inference_deferred_postprocess_handoff"
 
 
@@ -80,14 +81,28 @@ def get_adapter_gpu_submit_generation(future: Any) -> Optional[int]:
     return context.gpu_submit_generation
 
 
-def attach_async_response_future(response: Any, response_future: Any) -> None:
+def attach_async_response_future(
+    response: Any,
+    response_future: Any,
+    context_id: Optional[str] = None,
+) -> None:
     """Attach a CPU response future to a placeholder workflow response."""
     setattr(response, _ASYNC_RESPONSE_FUTURE_ATTR, response_future)
+    if context_id is not None:
+        setattr(response, _ASYNC_RESPONSE_CONTEXT_ID_ATTR, context_id)
 
 
 def get_async_response_future(response: Any) -> Any:
     """Return the CPU response future attached to a workflow response."""
     return getattr(response, _ASYNC_RESPONSE_FUTURE_ATTR, None)
+
+
+def get_async_response_context_id(response: Any) -> Optional[str]:
+    """Return the stream context id attached to a placeholder response."""
+    context_id = getattr(response, _ASYNC_RESPONSE_CONTEXT_ID_ATTR, None)
+    if isinstance(context_id, str):
+        return context_id
+    return None
 
 
 def attach_deferred_postprocess_handoff(

--- a/inference_models/inference_models/models/base/async_handoff.py
+++ b/inference_models/inference_models/models/base/async_handoff.py
@@ -12,7 +12,11 @@ from typing import Any, Callable, Optional
 
 _ADAPTER_CONTEXT_ATTR = "_inference_adapter_future_context"
 _ASYNC_RESPONSE_FUTURE_ATTR = "_async_response_future"
+_ASYNC_RESPONSE_CONTEXT_ID_ATTR = "_async_response_context_id"
 _DEFERRED_POSTPROCESS_ATTR = "_inference_deferred_postprocess_handoff"
+
+
+STREAM_PIPELINE_CONTEXT_ID_KWARG = "stream_pipeline_context_id"
 
 
 @dataclass(frozen=True)
@@ -20,6 +24,7 @@ class AdapterFutureContext:
     """State the inference adapter keeps on an in-flight model future."""
 
     mapped_kwargs: dict
+    stream_pipeline_context_id: Optional[str] = None
     gpu_work_submitted: bool = False
     gpu_submit_generation: Optional[int] = None
 
@@ -33,12 +38,19 @@ class DeferredPostprocessHandoff:
     finalize: Callable[[], Any]
 
 
-def attach_adapter_mapped_kwargs(future: Any, mapped_kwargs: dict) -> None:
+def attach_adapter_mapped_kwargs(
+    future: Any,
+    mapped_kwargs: dict,
+    stream_pipeline_context_id: Optional[str] = None,
+) -> None:
     """Store mapped inference kwargs on a model future."""
     setattr(
         future,
         _ADAPTER_CONTEXT_ATTR,
-        AdapterFutureContext(mapped_kwargs=dict(mapped_kwargs)),
+        AdapterFutureContext(
+            mapped_kwargs=dict(mapped_kwargs),
+            stream_pipeline_context_id=stream_pipeline_context_id,
+        ),
     )
 
 
@@ -48,6 +60,17 @@ def get_adapter_mapped_kwargs(future: Any) -> dict:
     if not isinstance(context, AdapterFutureContext):
         return {}
     return context.mapped_kwargs
+
+
+def get_adapter_stream_pipeline_context_id(future: Any) -> Optional[str]:
+    """Return the stream-pipeline context id stored on a model future."""
+    context = getattr(future, _ADAPTER_CONTEXT_ATTR, None)
+    if not isinstance(context, AdapterFutureContext):
+        return None
+    context_id = context.stream_pipeline_context_id
+    if isinstance(context_id, str):
+        return context_id
+    return None
 
 
 def adapter_gpu_work_submitted(future: Any) -> bool:
@@ -80,14 +103,28 @@ def get_adapter_gpu_submit_generation(future: Any) -> Optional[int]:
     return context.gpu_submit_generation
 
 
-def attach_async_response_future(response: Any, response_future: Any) -> None:
+def attach_async_response_future(
+    response: Any,
+    response_future: Any,
+    context_id: Optional[str] = None,
+) -> None:
     """Attach a CPU response future to a placeholder workflow response."""
     setattr(response, _ASYNC_RESPONSE_FUTURE_ATTR, response_future)
+    if context_id is not None:
+        setattr(response, _ASYNC_RESPONSE_CONTEXT_ID_ATTR, context_id)
 
 
 def get_async_response_future(response: Any) -> Any:
     """Return the CPU response future attached to a workflow response."""
     return getattr(response, _ASYNC_RESPONSE_FUTURE_ATTR, None)
+
+
+def get_async_response_context_id(response: Any) -> Optional[str]:
+    """Return the stream context id attached to a placeholder response."""
+    context_id = getattr(response, _ASYNC_RESPONSE_CONTEXT_ID_ATTR, None)
+    if isinstance(context_id, str):
+        return context_id
+    return None
 
 
 def attach_deferred_postprocess_handoff(

--- a/inference_models/inference_models/models/base/async_handoff.py
+++ b/inference_models/inference_models/models/base/async_handoff.py
@@ -1,0 +1,142 @@
+"""Explicit handoff state shared by async inference pipeline components.
+
+The RF-DETR stream pipeline crosses package boundaries: inference-models owns
+CUDA execution and sparse postprocess, while inference owns workflow response
+assembly. This module centralizes the small amount of per-request state passed
+between those layers so call sites do not depend on scattered private attribute
+names.
+"""
+
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Optional
+
+_ADAPTER_CONTEXT_ATTR = "_inference_adapter_future_context"
+_ASYNC_RESPONSE_FUTURE_ATTR = "_async_response_future"
+_DEFERRED_POSTPROCESS_ATTR = "_inference_deferred_postprocess_handoff"
+
+
+@dataclass(frozen=True)
+class AdapterFutureContext:
+    """State the inference adapter keeps on an in-flight model future."""
+
+    mapped_kwargs: dict
+    gpu_work_submitted: bool = False
+    gpu_submit_generation: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class DeferredPostprocessHandoff:
+    """CUDA/postprocess state consumed later by response finalization."""
+
+    done_event: Any
+    trt_outputs_consumed_event: Any
+    finalize: Callable[[], Any]
+
+
+def attach_adapter_mapped_kwargs(future: Any, mapped_kwargs: dict) -> None:
+    """Store mapped inference kwargs on a model future."""
+    setattr(
+        future,
+        _ADAPTER_CONTEXT_ATTR,
+        AdapterFutureContext(mapped_kwargs=dict(mapped_kwargs)),
+    )
+
+
+def get_adapter_mapped_kwargs(future: Any) -> dict:
+    """Return mapped inference kwargs stored on a model future."""
+    context = getattr(future, _ADAPTER_CONTEXT_ATTR, None)
+    if not isinstance(context, AdapterFutureContext):
+        return {}
+    return context.mapped_kwargs
+
+
+def adapter_gpu_work_submitted(future: Any) -> bool:
+    """Return whether eager GPU postprocess was submitted for a future."""
+    context = getattr(future, _ADAPTER_CONTEXT_ATTR, None)
+    return isinstance(context, AdapterFutureContext) and context.gpu_work_submitted
+
+
+def mark_adapter_gpu_work_submitted(future: Any, generation: int) -> None:
+    """Mark a future's eager GPU postprocess submission generation."""
+    context = getattr(future, _ADAPTER_CONTEXT_ATTR, None)
+    if not isinstance(context, AdapterFutureContext):
+        context = AdapterFutureContext(mapped_kwargs={})
+    setattr(
+        future,
+        _ADAPTER_CONTEXT_ATTR,
+        replace(
+            context,
+            gpu_work_submitted=True,
+            gpu_submit_generation=generation,
+        ),
+    )
+
+
+def get_adapter_gpu_submit_generation(future: Any) -> Optional[int]:
+    """Return the generation when eager GPU postprocess was submitted."""
+    context = getattr(future, _ADAPTER_CONTEXT_ATTR, None)
+    if not isinstance(context, AdapterFutureContext):
+        return None
+    return context.gpu_submit_generation
+
+
+def attach_async_response_future(response: Any, response_future: Any) -> None:
+    """Attach a CPU response future to a placeholder workflow response."""
+    setattr(response, _ASYNC_RESPONSE_FUTURE_ATTR, response_future)
+
+
+def get_async_response_future(response: Any) -> Any:
+    """Return the CPU response future attached to a workflow response."""
+    return getattr(response, _ASYNC_RESPONSE_FUTURE_ATTR, None)
+
+
+def attach_deferred_postprocess_handoff(
+    detections: Any,
+    done_event: Any,
+    trt_outputs_consumed_event: Any,
+    finalize: Callable[[], Any],
+) -> None:
+    """Attach deferred sparse postprocess completion state to detections."""
+    setattr(
+        detections,
+        _DEFERRED_POSTPROCESS_ATTR,
+        DeferredPostprocessHandoff(
+            done_event=done_event,
+            trt_outputs_consumed_event=trt_outputs_consumed_event,
+            finalize=finalize,
+        ),
+    )
+
+
+def get_deferred_postprocess_handoff(
+    detections: Any,
+) -> Optional[DeferredPostprocessHandoff]:
+    """Return deferred postprocess state attached to detections, if present."""
+    handoff = getattr(detections, _DEFERRED_POSTPROCESS_ATTR, None)
+    if not isinstance(handoff, DeferredPostprocessHandoff):
+        return None
+    return handoff
+
+
+def get_deferred_postprocess_finalizer(detections: Any) -> Optional[Callable[[], Any]]:
+    """Return a callable that materializes deferred detections, if present."""
+    handoff = get_deferred_postprocess_handoff(detections)
+    if handoff is None:
+        return None
+    return handoff.finalize
+
+
+def get_deferred_postprocess_done_event(detections: Any) -> Any:
+    """Return the CUDA event recorded after deferred postprocess DtoH copies."""
+    handoff = get_deferred_postprocess_handoff(detections)
+    if handoff is None:
+        return None
+    return handoff.done_event
+
+
+def get_trt_outputs_consumed_event(detections: Any) -> Any:
+    """Return the event proving TensorRT graph outputs are safe to reuse."""
+    handoff = get_deferred_postprocess_handoff(detections)
+    if handoff is None:
+        return None
+    return handoff.trt_outputs_consumed_event

--- a/inference_models/inference_models/models/base/instance_segmentation.py
+++ b/inference_models/inference_models/models/base/instance_segmentation.py
@@ -1,6 +1,17 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, List, Literal, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    Union,
+    runtime_checkable,
+)
 
 import numpy as np
 import supervision as sv
@@ -15,6 +26,109 @@ from inference_models.models.base.types import (
 from inference_models.models.common.rle_utils import coco_rle_masks_to_numpy_mask
 
 InstanceSegmentationMaskFormat = Literal["dense", "rle"]
+
+
+_MISSING = object()
+
+
+@runtime_checkable
+class InferenceFuture(Protocol):
+    """Future-like handle over an in-flight inference request.
+
+    The returned object lets a caller start a subsequent ``infer_async`` call
+    while the GPU is still executing the previous one. Calling ``result()``
+    materializes the post-processing result for that request; backends may
+    either block there or return a deferred result whose own consumers perform
+    the final CUDA synchronization. ``done()`` is a non-blocking probe of the
+    forward completion event.
+    """
+
+    def result(self) -> List["InstanceDetections"]: ...
+
+    def done(self) -> bool: ...
+
+
+class _DirectInferenceFuture:
+    """Concrete ``InferenceFuture`` backed by a single ``torch.cuda.Event``.
+
+    Holds the raw forward output plus the preprocessing metadata needed by
+    ``post_process``. The event is recorded on the stream that produced the
+    raw output. ``result()`` runs or returns the model's post-processing result;
+    optimized backends order post-processing with CUDA events and defer host
+    synchronization until CPU-visible tensors are copied. Post-process output is
+    memoised so ``result()`` may be called repeatedly.
+    """
+
+    # No __slots__: adapters attach per-request context through
+    # `models.base.async_handoff` so postprocess can rebuild the decode call
+    # for an older frame even when the original submit site had no metadata.
+    # The Future is short-lived, so the per-instance dict overhead is negligible.
+
+    def __init__(
+        self,
+        model: "InstanceSegmentationModel",
+        raw: Any,
+        meta: Any,
+        evt: Optional[torch.cuda.Event],
+        kwargs: dict,
+    ) -> None:
+        self._model = model
+        self._raw = raw
+        self._meta = meta
+        self._evt = evt
+        self._kwargs = kwargs
+        self._cached: Any = _MISSING
+
+    @property
+    def preprocess_metadata(self) -> Any:
+        """The metadata captured at ``pre_process`` time for this request."""
+        return self._meta
+
+    def done(self) -> bool:
+        if self._cached is not _MISSING:
+            return True
+        if self._evt is None:
+            return True
+        return self._evt.query()
+
+    def submit_gpu_work(self, meta: Any = None) -> None:
+        """Enqueue the ``post_process`` GPU work eagerly.
+
+        Under depth>=2 pipelining ``result()`` is intentionally delayed so the
+        source loop can prepare later frames. Without eager submission, the
+        postproc kernels are also delayed until that future is finalized,
+        leaving a bubble between the TensorRT produce event and postproc.
+
+        Calling ``submit_gpu_work`` from the adapter before it launches the
+        next frame's forward keeps the reused TRT outputs correct while moving
+        this host-side submission work out of the current frame's postprocess
+        call. The host still does not block here, and ``result()`` later
+        reuses the enqueued postproc result.
+
+        Idempotent: calling it once is enough; subsequent calls to
+        ``result()`` reuse the enqueued postproc result.
+        """
+        if self._cached is not _MISSING:
+            return
+        if meta is None:
+            meta = self._meta
+        else:
+            self._meta = meta
+        # `post_process` is expected to be non-blocking: it enqueues its
+        # CUDA kernels on a private stream and returns a handle/structure
+        # that the caller reads later. The host does NOT block here.
+        self._cached = self._model.post_process(self._raw, meta, **self._kwargs)
+
+    def result(self) -> List["InstanceDetections"]:
+        # No host sync here: post_process() enqueues its GPU work on a
+        # dedicated stream and uses stream.wait_event() internally to order
+        # itself after the forward stream. The final host sync happens where
+        # CPU-visible results are actually needed (DtoH copies in the adapter).
+        if self._cached is _MISSING:
+            self._cached = self._model.post_process(
+                self._raw, self._meta, **self._kwargs
+            )
+        return self._cached
 
 
 @dataclass
@@ -108,14 +222,85 @@ class InstanceSegmentationModel(
     def supported_mask_formats(self) -> Set[InstanceSegmentationMaskFormat]:
         pass
 
+    @property
+    def supports_stream_pipeline(self) -> bool:
+        """Whether this model can safely use adapter-level stream pipelining.
+
+        The default async future only defers ``post_process`` to ``result()`` and
+        does not guarantee the non-blocking deferred GPU handoff that the stream
+        adapter relies on for depth>1 scheduling. Models that implement that
+        contract, such as RF-DETR TensorRT with CUDA graph output handoff, opt in
+        by overriding this property.
+        """
+        return False
+
     def infer(
         self,
         images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
         **kwargs,
     ) -> List[InstanceDetections]:
+        # Synchronous direct path: pre_process → forward → post_process in
+        # sequence, with no per-call output cloning. The async variant
+        # (``infer_async``) exists for pipelined callers that need to
+        # submit frame N+1 before frame N's output buffers have been read
+        # — cloning makes those callers safe. Here, ``post_process``
+        # consumes the raw forward output immediately, so no clone is
+        # needed and we avoid the ~80µs of DtoD copies on the inference
+        # stream. This keeps the ``infer()`` entry point at maximum
+        # throughput for single-thread, single-model users.
         pre_processed_images, pre_processing_meta = self.pre_process(images, **kwargs)
         model_results = self.forward(pre_processed_images, **kwargs)
         return self.post_process(model_results, pre_processing_meta, **kwargs)
+
+    def infer_async(
+        self,
+        images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
+        **kwargs,
+    ) -> InferenceFuture:
+        """Submit an inference request and return a future.
+
+        The default implementation performs ``pre_process`` and ``forward``
+        synchronously, records a CUDA event on the current stream, and defers
+        ``post_process`` until ``result()`` is called on the returned future.
+        Subclasses that run ``forward`` on a dedicated stream should override
+        this to record the event on that stream (see the TRT model).
+        """
+        pre_processed_images, pre_processing_meta = self.pre_process(images, **kwargs)
+        return self.forward_async(pre_processed_images, pre_processing_meta, **kwargs)
+
+    def forward_async(
+        self,
+        pre_processed_images: PreprocessedInputs,
+        pre_processing_meta: PreprocessingMetadata,
+        **kwargs,
+    ) -> InferenceFuture:
+        """Run ``forward`` only and return a future pinned to that launch.
+
+        Separating this from ``infer_async`` lets the adapter interleave
+        preprocessing for frame N+1 with the forward pass for frame N on a
+        dedicated stream while holding a future whose ``result()`` will
+        decode frame N once its outputs are ready.
+        """
+        model_results = self.forward(pre_processed_images, **kwargs)
+        # Prefer a produce-event already recorded on the forward stream (eg.
+        # the TRT graph stream) so `done()` reflects true GPU completion
+        # without straddling a stream boundary. Fall back to recording on
+        # the current stream for models that don't expose one.
+        evt: Optional[torch.cuda.Event] = None
+        first = (
+            model_results[0]
+            if isinstance(model_results, (tuple, list))
+            else model_results
+        )
+        existing = getattr(first, "_trt_produce_event", None)
+        if existing is not None:
+            evt = existing
+        elif torch.cuda.is_available():
+            evt = torch.cuda.Event()
+            evt.record()
+        return _DirectInferenceFuture(
+            self, model_results, pre_processing_meta, evt, kwargs
+        )
 
     @abstractmethod
     def pre_process(

--- a/inference_models/inference_models/models/common/trt.py
+++ b/inference_models/inference_models/models/common/trt.py
@@ -78,6 +78,7 @@ class TRTCudaGraphState:
     input_buffer: torch.Tensor
     output_buffers: List[torch.Tensor]
     execution_context: trt.IExecutionContext
+    consumer_done_event: Optional[torch.cuda.Event] = None
 
 
 class TRTCudaGraphCache:
@@ -435,6 +436,7 @@ def infer_from_trt_engine(
     outputs: List[str],
     stream: Optional[torch.cuda.Stream] = None,
     trt_cuda_graph_cache: Optional[TRTCudaGraphCache] = None,
+    synchronize: bool = True,
 ) -> List[torch.Tensor]:
     """Run inference using a TensorRT engine, optionally with CUDA graph acceleration.
 
@@ -570,8 +572,10 @@ def infer_from_trt_engine(
             input_name=input_name,
             outputs=outputs,
             trt_cuda_graph_cache=trt_cuda_graph_cache,
+            synchronize=synchronize,
         )
-    stream.synchronize()
+    if synchronize:
+        stream.synchronize()
     return results
 
 
@@ -584,6 +588,7 @@ def _infer_from_trt_engine(
     input_name: str,
     outputs: List[str],
     trt_cuda_graph_cache: Optional[TRTCudaGraphCache] = None,
+    synchronize: bool = True,
 ) -> List[torch.Tensor]:
     if trt_config.static_batch_size is not None:
         min_batch_size = trt_config.static_batch_size
@@ -601,6 +606,7 @@ def _infer_from_trt_engine(
         min_batch_size=min_batch_size,
         max_batch_size=max_batch_size,
         trt_cuda_graph_cache=trt_cuda_graph_cache,
+        synchronize=synchronize,
     )
 
 
@@ -614,6 +620,7 @@ def _infer_from_trt_engine_with_batch_size_boundaries(
     min_batch_size: int,
     max_batch_size: int,
     trt_cuda_graph_cache: Optional[TRTCudaGraphCache] = None,
+    synchronize: bool = True,
 ) -> List[torch.Tensor]:
     if pre_processed_images.shape[0] <= max_batch_size:
         reminder = min_batch_size - pre_processed_images.shape[0]
@@ -637,6 +644,7 @@ def _infer_from_trt_engine_with_batch_size_boundaries(
             input_name=input_name,
             outputs=outputs,
             trt_cuda_graph_cache=trt_cuda_graph_cache,
+            synchronize=synchronize,
         )
         if reminder > 0:
             results = [r[:-reminder] for r in results]
@@ -667,6 +675,7 @@ def _infer_from_trt_engine_with_batch_size_boundaries(
             input_name=input_name,
             outputs=outputs,
             trt_cuda_graph_cache=trt_cuda_graph_cache,
+            synchronize=synchronize,
         )
         if reminder > 0:
             results = [r[:-reminder] for r in results]
@@ -683,6 +692,7 @@ def _execute_trt_engine(
     input_name: str,
     outputs: List[str],
     trt_cuda_graph_cache: Optional[TRTCudaGraphCache] = None,
+    synchronize: bool = True,
 ) -> List[torch.Tensor]:
     if trt_cuda_graph_cache is not None:
         input_shape = tuple(pre_processed_images.shape)
@@ -692,12 +702,17 @@ def _execute_trt_engine(
         if cache_key not in trt_cuda_graph_cache:
             LOGGER.debug("Capturing CUDA graph for shape %s", input_shape)
 
+            use_external = getattr(
+                pre_processed_images, "_trt_reuse_as_input_buffer", False
+            )
             results, trt_cuda_graph = _capture_cuda_graph(
                 pre_processed_images=pre_processed_images,
                 engine=engine,
                 device=device,
                 input_name=input_name,
                 outputs=outputs,
+                use_pre_processed_images_as_input_buffer=bool(use_external),
+                clone_outputs=synchronize,
             )
             trt_cuda_graph_cache[cache_key] = trt_cuda_graph
             return results
@@ -705,11 +720,48 @@ def _execute_trt_engine(
         else:
             trt_cuda_graph_state = trt_cuda_graph_cache[cache_key]
             stream = trt_cuda_graph_state.cuda_stream
+            consumer_done = trt_cuda_graph_state.consumer_done_event
+            if consumer_done is not None:
+                stream.wait_event(consumer_done)
+            input_ready = getattr(pre_processed_images, "_trt_ready_event", None)
             with torch.cuda.stream(stream):
-                trt_cuda_graph_state.input_buffer.copy_(pre_processed_images)
+                if input_ready is not None:
+                    stream.wait_event(input_ready)
+                if (
+                    trt_cuda_graph_state.input_buffer.data_ptr()
+                    != pre_processed_images.data_ptr()
+                ):
+                    trt_cuda_graph_state.input_buffer.copy_(pre_processed_images)
+                    input_consumed_event = torch.cuda.Event()
+                    input_consumed_event.record(stream)
+                    pre_processed_images._trt_consumed_event = (  # type: ignore[attr-defined]
+                        input_consumed_event
+                    )
                 trt_cuda_graph_state.cuda_graph.replay()
-                results = [buf.clone() for buf in trt_cuda_graph_state.output_buffers]
-            stream.synchronize()
+                if (
+                    trt_cuda_graph_state.input_buffer.data_ptr()
+                    == pre_processed_images.data_ptr()
+                ):
+                    input_consumed_event = torch.cuda.Event()
+                    input_consumed_event.record(stream)
+                    pre_processed_images._trt_consumed_event = (  # type: ignore[attr-defined]
+                        input_consumed_event
+                    )
+                if synchronize:
+                    results = [
+                        buf.clone() for buf in trt_cuda_graph_state.output_buffers
+                    ]
+                else:
+                    results = list(trt_cuda_graph_state.output_buffers)
+                produce_event = torch.cuda.Event()
+                produce_event.record(stream)
+            if synchronize:
+                stream.synchronize()
+            _attach_trt_graph_metadata(
+                results=results,
+                trt_cuda_graph_state=trt_cuda_graph_state,
+                produce_event=produce_event,
+            )
             return results
 
     else:
@@ -752,14 +804,24 @@ def _capture_cuda_graph(
     device: torch.device,
     input_name: str,
     outputs: List[str],
+    use_pre_processed_images_as_input_buffer: bool = False,
+    clone_outputs: bool = True,
 ) -> Tuple[List[torch.Tensor], TRTCudaGraphState]:
     # Each CUDA graph needs its own execution context. Sharing a single context
     # across graphs for different input shapes causes TRT to reallocate internal
     # workspace buffers, invalidating GPU addresses baked into earlier graphs.
     graph_context = engine.create_execution_context()
 
-    input_buffer = torch.empty_like(pre_processed_images, device=device)
-    input_buffer.copy_(pre_processed_images)
+    stream = torch.cuda.Stream(device=device)
+    input_ready = getattr(pre_processed_images, "_trt_ready_event", None)
+    if use_pre_processed_images_as_input_buffer:
+        input_buffer = pre_processed_images
+    else:
+        input_buffer = torch.empty_like(pre_processed_images, device=device)
+        with torch.cuda.stream(stream):
+            if input_ready is not None:
+                stream.wait_event(input_ready)
+            input_buffer.copy_(pre_processed_images)
 
     status = graph_context.set_input_shape(
         input_name, tuple(pre_processed_images.shape)
@@ -788,7 +850,9 @@ def _capture_cuda_graph(
         graph_context.set_tensor_address(output, output_buffer.data_ptr())
         output_buffers.append(output_buffer)
 
-    stream = torch.cuda.Stream(device=device)
+    if use_pre_processed_images_as_input_buffer and input_ready is not None:
+        with torch.cuda.stream(stream):
+            stream.wait_event(input_ready)
     with torch.cuda.stream(stream):
         status = graph_context.execute_async_v3(stream_handle=stream.cuda_stream)
         if not status:
@@ -813,7 +877,12 @@ def _capture_cuda_graph(
     # in order to avoid drift of results - it's better to replay to get the results
     with torch.cuda.stream(stream):
         cuda_graph.replay()
-        results = [buf.clone() for buf in output_buffers]
+        if clone_outputs:
+            results = [buf.clone() for buf in output_buffers]
+        else:
+            results = list(output_buffers)
+        produce_event = torch.cuda.Event()
+        produce_event.record(stream)
     stream.synchronize()
 
     trt_cuda_graph_state = TRTCudaGraphState(
@@ -823,8 +892,23 @@ def _capture_cuda_graph(
         output_buffers=output_buffers,
         execution_context=graph_context,
     )
+    _attach_trt_graph_metadata(
+        results=results,
+        trt_cuda_graph_state=trt_cuda_graph_state,
+        produce_event=produce_event,
+    )
 
     return results, trt_cuda_graph_state
+
+
+def _attach_trt_graph_metadata(
+    results: List[torch.Tensor],
+    trt_cuda_graph_state: TRTCudaGraphState,
+    produce_event: torch.cuda.Event,
+) -> None:
+    for result in results:
+        result._trt_graph_state = trt_cuda_graph_state  # type: ignore[attr-defined]
+        result._trt_produce_event = produce_event  # type: ignore[attr-defined]
 
 
 def _trt_dtype_to_torch(trt_dtype):

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -3,7 +3,12 @@ from typing import List, Optional, Tuple, Union
 import torch
 from torchvision.transforms import functional
 
-from inference_models import Detections, InstanceDetections, InstancesRLEMasks, KeyPoints
+from inference_models import (
+    Detections,
+    InstanceDetections,
+    InstancesRLEMasks,
+    KeyPoints,
+)
 from inference_models.configuration import (
     INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED,
 )
@@ -444,8 +449,8 @@ def cxcywh_to_xyxy(boxes):
 
 
 def post_process_keypoint_detection_results(
-    bboxes: torch.Tensor,     # [B, N_q, 4] cxcywh, normalized [0, 1]
-    out_logits: torch.Tensor,     # [B, N_q, C]
+    bboxes: torch.Tensor,  # [B, N_q, 4] cxcywh, normalized [0, 1]
+    out_logits: torch.Tensor,  # [B, N_q, C]
     out_keypoints: torch.Tensor,  # [B, N_q, K_padded, D]
     pre_processing_meta: List[PreProcessingMetadata],
     threshold: Union[float, torch.Tensor],
@@ -472,7 +477,7 @@ def post_process_keypoint_detection_results(
     topk_values, topk_indexes = torch.topk(flat_scores, num_select, dim=1)
     scores = topk_values
     topk_boxes = topk_indexes // C  # [B, num_select] query indices
-    labels = topk_indexes % C       # [B, num_select] class indices
+    labels = topk_indexes % C  # [B, num_select] class indices
 
     bboxes = torch.gather(bboxes, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
     bboxes = cxcywh_to_xyxy(bboxes)
@@ -481,13 +486,21 @@ def post_process_keypoint_detection_results(
     # Keep all D=8 dims: [x, y, findable_logit, visible_logit, log_l11, l21, log_l22, class_logit]
     # The model trains a 2D Gaussian per keypoint with precision matrix P = L L^T;
     # log(sqrt(det P)) = log_l11 + log_l22 — the model's own predicted localization sharpness.
-    kp_gather_idx = topk_boxes.unsqueeze(-1).unsqueeze(-1).expand(B, num_select, K_padded, D)
-    keypoints_g = torch.gather(out_keypoints, 1, kp_gather_idx)  # [B, num_select, K_padded, D]
+    kp_gather_idx = (
+        topk_boxes.unsqueeze(-1).unsqueeze(-1).expand(B, num_select, K_padded, D)
+    )
+    keypoints_g = torch.gather(
+        out_keypoints, 1, kp_gather_idx
+    )  # [B, num_select, K_padded, D]
     keypoints_g = keypoints_g.view(B, num_select, C, K_per_class, D)
 
     batch_idx = torch.arange(B, device=labels.device).unsqueeze(-1).expand_as(labels)
-    query_idx = torch.arange(num_select, device=labels.device).unsqueeze(0).expand_as(labels)
-    keypoints_sel = keypoints_g[batch_idx, query_idx, labels]  # [B, num_select, K_per_class, D=8]
+    query_idx = (
+        torch.arange(num_select, device=labels.device).unsqueeze(0).expand_as(labels)
+    )
+    keypoints_sel = keypoints_g[
+        batch_idx, query_idx, labels
+    ]  # [B, num_select, K_per_class, D=8]
 
     keypoints_xy = keypoints_sel[..., :2]
     keypoints_conf = keypoints_sel[..., 2:3].sigmoid()  # findable [0,1] per kp
@@ -499,23 +512,29 @@ def post_process_keypoint_detection_results(
     # Note: σ_k (COCO bandwidths) NOT used — model's L already encodes per-kp difficulty
     # implicitly. Sigma-free form transfers to any keypoint domain. α=0.20 seems to work well.
     log_l11 = keypoints_sel[..., 4]
-    l21     = keypoints_sel[..., 5]
+    l21 = keypoints_sel[..., 5]
     log_l22 = keypoints_sel[..., 6]
     # log(trace) per kp via logsumexp over the three log-terms (numerical stability)
-    log_t1 = -2.0 * log_l11                                                   # log(1/l11²)
-    log_t2 = -2.0 * log_l22                                                   # log(1/l22²)
-    log_t3 = 2.0 * torch.log(l21.abs().clamp(min=1e-12)) + log_t1 + log_t2    # log(l21²/(l11·l22)²)
+    log_t1 = -2.0 * log_l11  # log(1/l11²)
+    log_t2 = -2.0 * log_l22  # log(1/l22²)
+    log_t3 = (
+        2.0 * torch.log(l21.abs().clamp(min=1e-12)) + log_t1 + log_t2
+    )  # log(l21²/(l11·l22)²)
     log_trace = torch.logsumexp(torch.stack([log_t1, log_t2, log_t3], dim=-1), dim=-1)
     # Findable-weighted arithmetic mean of trace, in log space
     w_find = keypoints_conf.squeeze(-1)
     log_w = torch.log(w_find.clamp(min=1e-12))
-    log_mean_trace = torch.logsumexp(log_trace + log_w, dim=-1) - torch.logsumexp(log_w, dim=-1)
+    log_mean_trace = torch.logsumexp(log_trace + log_w, dim=-1) - torch.logsumexp(
+        log_w, dim=-1
+    )
     scores = scores * torch.exp(-0.20 * log_mean_trace)
 
     # normalize
     scores = scores / (1 + scores)
 
-    keypoints_final = torch.cat([keypoints_xy, keypoints_conf], dim=-1)  # [B, num_select, K_per_class, 3]
+    keypoints_final = torch.cat(
+        [keypoints_xy, keypoints_conf], dim=-1
+    )  # [B, num_select, K_per_class, 3]
 
     # iterate over batch and collect detections above thresholds
     all_key_points, detections = [], []
@@ -551,14 +570,14 @@ def post_process_keypoint_detection_results(
         predicted_confidence = predicted_confidence[confidence_mask]
         top_classes = top_classes[confidence_mask]
         selected_boxes = image_bboxes[confidence_mask]
-        selected_keypoints = image_keypoints[confidence_mask] 
+        selected_keypoints = image_keypoints[confidence_mask]
         predicted_confidence, sorted_indices = torch.sort(
             predicted_confidence, descending=True
         )
         top_classes = top_classes[sorted_indices]
         selected_boxes_xyxy_pct = selected_boxes[sorted_indices]
         selected_keypoints_xy_pct_conf = selected_keypoints[sorted_indices]
-        selected_keypoints_xy_pct = selected_keypoints_xy_pct_conf[:, :, :2] 
+        selected_keypoints_xy_pct = selected_keypoints_xy_pct_conf[:, :, :2]
         selected_keypoints_conf = selected_keypoints_xy_pct_conf[:, :, 2]
 
         denorm_size = (
@@ -588,13 +607,15 @@ def post_process_keypoint_detection_results(
             )
         )
 
-        # Similar to rescale_image_detections function, for keypoints. 
-        offsets = torch.as_tensor([image_meta.pad_left, image_meta.pad_top],
+        # Similar to rescale_image_detections function, for keypoints.
+        offsets = torch.as_tensor(
+            [image_meta.pad_left, image_meta.pad_top],
             dtype=selected_keypoints_xy.dtype,
             device=selected_keypoints_xy.device,
         )
         selected_keypoints_xy.sub_(offsets)
-        scale = torch.as_tensor([image_meta.scale_width, image_meta.scale_height],
+        scale = torch.as_tensor(
+            [image_meta.scale_width, image_meta.scale_height],
             dtype=selected_keypoints_xy.dtype,
             device=selected_keypoints_xy.device,
         )
@@ -628,7 +649,9 @@ def post_process_keypoint_detection_results(
             .to(device=selected_keypoints_xy.device)
         )
         invalid_slot_keypoints = (
-            torch.arange(key_points_slots_in_prediction, device=selected_keypoints_xy.device)
+            torch.arange(
+                key_points_slots_in_prediction, device=selected_keypoints_xy.device
+            )
             .unsqueeze(0)
             .repeat(selected_keypoints_xy.shape[0], 1)
             >= key_points_classes_for_instance_class
@@ -639,7 +662,7 @@ def post_process_keypoint_detection_results(
         selected_keypoints_conf[mask] = 0.0
         all_key_points.append(
             KeyPoints(
-                xy=selected_keypoints_xy.round().int(), 
+                xy=selected_keypoints_xy.round().int(),
                 class_id=top_classes.int(),
                 confidence=selected_keypoints_conf,
             )

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -4,11 +4,13 @@ import torch
 from torchvision.transforms import functional
 
 from inference_models import Detections, InstanceDetections, InstancesRLEMasks, KeyPoints
+from inference_models.configuration import (
+    INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED,
+)
 from inference_models.entities import ImageDimensions
 from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.roboflow.model_packages import (
     PreProcessingMetadata,
-    StaticCropOffset,
 )
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
@@ -17,7 +19,12 @@ from inference_models.models.common.roboflow.post_processing import (
 )
 from inference_models.models.rfdetr.class_remapping import ClassesReMapping
 from inference_models.models.rfdetr.post_processor import select_topk_predictions
+from inference_models.models.rfdetr.triton_postprocess import (
+    post_process_single_instance_segmentation_result_to_rle_masks_triton,
+)
 from inference_models.utils.file_system import read_json
+
+_TRITON_POSTPROC_ENABLED = INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED
 
 
 def parse_model_type(config_path: str) -> str:
@@ -218,6 +225,140 @@ def post_process_instance_segmentation_results(
     return results
 
 
+def _post_process_single_instance_segmentation_result_to_rle_masks_with_triton(
+    image_bboxes: torch.Tensor,
+    image_logits: torch.Tensor,
+    image_masks: torch.Tensor,
+    image_meta: PreProcessingMetadata,
+    threshold: Union[float, torch.Tensor],
+    num_classes: int,
+    classes_re_mapping: Optional[ClassesReMapping],
+    defer_postprocess_sync: bool = False,
+) -> InstanceDetections:
+    triton_result = (
+        post_process_single_instance_segmentation_result_to_rle_masks_triton(
+            image_bboxes=image_bboxes,
+            image_scores=image_logits,
+            image_masks=image_masks,
+            image_meta=image_meta,
+            threshold=threshold,
+            classes_re_mapping=classes_re_mapping,
+            defer_postprocess_sync=defer_postprocess_sync,
+        )
+    )
+    if triton_result is not None:
+        return triton_result
+
+    return _post_process_single_instance_segmentation_result_to_rle_masks(
+        image_bboxes=image_bboxes,
+        image_logits=image_logits,
+        image_masks=image_masks,
+        image_meta=image_meta,
+        threshold=threshold,
+        num_classes=num_classes,
+        classes_re_mapping=classes_re_mapping,
+    )
+
+
+def _post_process_single_instance_segmentation_result_to_rle_masks(
+    image_bboxes: torch.Tensor,
+    image_logits: torch.Tensor,
+    image_masks: torch.Tensor,
+    image_meta: PreProcessingMetadata,
+    threshold: Union[float, torch.Tensor],
+    num_classes: int,
+    classes_re_mapping: Optional[ClassesReMapping],
+) -> InstanceDetections:
+    num_queries, num_logits_classes = image_logits.shape
+    flat_scores = image_logits.reshape(-1)
+    confidence, topk_indexes = torch.topk(flat_scores, num_queries)
+    query_indices = topk_indexes // num_logits_classes
+    top_classes = topk_indexes % num_logits_classes
+    if classes_re_mapping is not None:
+        if classes_re_mapping.class_mapping.shape[0] >= num_logits_classes:
+            top_classes = classes_re_mapping.class_mapping[top_classes]
+        else:
+            mapped_classes = torch.full_like(top_classes, -1)
+            mappable_classes = top_classes < classes_re_mapping.class_mapping.shape[0]
+            mapped_classes[mappable_classes] = classes_re_mapping.class_mapping[
+                top_classes[mappable_classes]
+            ]
+            top_classes = mapped_classes
+        remapping_mask = top_classes >= 0
+    else:
+        named = top_classes < num_classes
+        remapping_mask = named
+    confidence_mask = confidence > (
+        threshold[top_classes.clamp(min=0, max=threshold.shape[0] - 1).long()]
+        if isinstance(threshold, torch.Tensor)
+        else threshold
+    )
+    keep_mask = remapping_mask & confidence_mask
+    confidence = confidence[keep_mask]
+    top_classes = top_classes[keep_mask]
+    query_indices = query_indices[keep_mask]
+    confidence, sorted_indices = torch.sort(confidence, descending=True)
+    top_classes = top_classes[sorted_indices]
+    query_indices = query_indices[sorted_indices]
+    selected_boxes = image_bboxes[query_indices]
+    selected_masks = image_masks[query_indices]
+    cxcy = selected_boxes[:, :2]
+    wh = selected_boxes[:, 2:]
+    xy_min = cxcy - 0.5 * wh
+    xy_max = cxcy + 0.5 * wh
+    selected_boxes_xyxy_pct = torch.cat([xy_min, xy_max], dim=-1)
+    denorm_size = image_meta.nonsquare_intermediate_size or image_meta.inference_size
+    denorm_size_whwh = torch.tensor(
+        [
+            denorm_size.width,
+            denorm_size.height,
+            denorm_size.width,
+            denorm_size.height,
+        ],
+        device=image_bboxes.device,
+    )
+    padding = (
+        image_meta.pad_left,
+        image_meta.pad_top,
+        image_meta.pad_right,
+        image_meta.pad_bottom,
+    )
+    selected_boxes_xyxy = selected_boxes_xyxy_pct * denorm_size_whwh
+    aligned_boxes, rle_masks = [], []
+    for bbox, mask in align_instance_segmentation_results_to_rle_masks(
+        image_bboxes=selected_boxes_xyxy,
+        masks=selected_masks,
+        padding=padding,
+        scale_height=image_meta.scale_height,
+        scale_width=image_meta.scale_width,
+        original_size=image_meta.original_size,
+        size_after_pre_processing=image_meta.size_after_pre_processing,
+        inference_size=denorm_size,
+        static_crop_offset=image_meta.static_crop_offset,
+    ):
+        aligned_boxes.append(bbox)
+        rle_masks.append(mask)
+    instances_masks = InstancesRLEMasks.from_coco_rle_masks(
+        image_size=(
+            image_meta.original_size.height,
+            image_meta.original_size.width,
+        ),
+        masks=rle_masks,
+    )
+    if len(aligned_boxes) > 0:
+        aligned_boxes_tensor = torch.stack(aligned_boxes, dim=0)
+    else:
+        aligned_boxes_tensor = torch.empty(
+            (0, 4), dtype=torch.int32, device=image_bboxes.device
+        )
+    return InstanceDetections(
+        xyxy=aligned_boxes_tensor.round().int(),
+        confidence=confidence,
+        class_id=top_classes.int(),
+        mask=instances_masks,
+    )
+
+
 def post_process_instance_segmentation_results_to_rle_masks(
     bboxes: torch.Tensor,
     logits: torch.Tensor,
@@ -226,115 +367,48 @@ def post_process_instance_segmentation_results_to_rle_masks(
     threshold: Union[float, torch.Tensor],
     num_classes: int,
     classes_re_mapping: Optional[ClassesReMapping],
+    defer_postprocess_sync: bool = False,
 ) -> List[InstanceDetections]:
     logits_sigmoid = torch.nn.functional.sigmoid(logits)
-    final_results = []
     device = bboxes.device
     if isinstance(threshold, torch.Tensor):
         threshold = threshold.to(device=device, dtype=logits_sigmoid.dtype)
-    for image_bboxes, image_logits, image_masks, image_meta in zip(
-        bboxes, logits_sigmoid, masks, pre_processing_meta
-    ):
-        confidence, top_classes, image_bboxes, query_indices = select_topk_predictions(
-            logits_sigmoid=image_logits,
-            bboxes_cxcywh=image_bboxes,
-        )
-        image_masks = image_masks[query_indices]
-        if classes_re_mapping is not None:
-            remapping_mask = torch.isin(
-                top_classes, classes_re_mapping.remaining_class_ids
+    if _TRITON_POSTPROC_ENABLED:
+        return [
+            _post_process_single_instance_segmentation_result_to_rle_masks_with_triton(
+                image_bboxes=image_bboxes,
+                image_logits=image_logits,
+                image_masks=image_masks,
+                image_meta=image_meta,
+                threshold=threshold,
+                num_classes=num_classes,
+                classes_re_mapping=classes_re_mapping,
+                defer_postprocess_sync=defer_postprocess_sync,
             )
-            top_classes = classes_re_mapping.class_mapping[top_classes[remapping_mask]]
-            confidence = confidence[remapping_mask]
-            image_bboxes = image_bboxes[remapping_mask]
-            image_masks = image_masks[remapping_mask]
-        else:
-            # drop DETR no-object rows
-            named = top_classes < num_classes
-            confidence = confidence[named]
-            top_classes = top_classes[named]
-            image_bboxes = image_bboxes[named]
-            image_masks = image_masks[named]
-        confidence_mask = confidence > (
-            threshold[top_classes.long()]
-            if isinstance(threshold, torch.Tensor)
-            else threshold
-        )
-        confidence = confidence[confidence_mask]
-        top_classes = top_classes[confidence_mask]
-        selected_boxes = image_bboxes[confidence_mask]
-        selected_masks = image_masks[confidence_mask]
-        confidence, sorted_indices = torch.sort(confidence, descending=True)
-        top_classes = top_classes[sorted_indices]
-        selected_boxes = selected_boxes[sorted_indices]
-        selected_masks = selected_masks[sorted_indices]
-        cxcy = selected_boxes[:, :2]
-        wh = selected_boxes[:, 2:]
-        xy_min = cxcy - 0.5 * wh
-        xy_max = cxcy + 0.5 * wh
-        selected_boxes_xyxy_pct = torch.cat([xy_min, xy_max], dim=-1)
-        denorm_size = (
-            image_meta.nonsquare_intermediate_size or image_meta.inference_size
-        )
-        denorm_size_whwh = torch.tensor(
-            [
-                denorm_size.width,
-                denorm_size.height,
-                denorm_size.width,
-                denorm_size.height,
-            ],
-            device=device,
-        )
-        padding = (
-            image_meta.pad_left,
-            image_meta.pad_top,
-            image_meta.pad_right,
-            image_meta.pad_bottom,
-        )
-        selected_boxes_xyxy = selected_boxes_xyxy_pct * denorm_size_whwh
-        aligned_boxes, rle_masks = [], []
-        for bbox, mask in align_instance_segmentation_results_to_rle_masks(
-            image_bboxes=selected_boxes_xyxy,
-            masks=selected_masks,
-            padding=padding,
-            scale_height=image_meta.scale_height,
-            scale_width=image_meta.scale_width,
-            original_size=image_meta.original_size,
-            size_after_pre_processing=image_meta.size_after_pre_processing,
-            inference_size=denorm_size,
-            static_crop_offset=image_meta.static_crop_offset,
-        ):
-            aligned_boxes.append(bbox)
-            rle_masks.append(mask)
-        instances_masks = InstancesRLEMasks.from_coco_rle_masks(
-            image_size=(
-                image_meta.original_size.height,
-                image_meta.original_size.width,
-            ),
-            masks=rle_masks,
-        )
-        if len(aligned_boxes) > 0:
-            aligned_boxes_tensor = torch.stack(aligned_boxes, dim=0)
-            final_results.append(
-                InstanceDetections(
-                    xyxy=aligned_boxes_tensor.round().int(),
-                    confidence=confidence,
-                    class_id=top_classes.int(),
-                    mask=instances_masks,
-                )
+            for image_bboxes, image_logits, image_masks, image_meta in zip(
+                bboxes,
+                logits_sigmoid,
+                masks,
+                pre_processing_meta,
             )
-        else:
-            final_results.append(
-                InstanceDetections(
-                    xyxy=torch.empty(
-                        (0, 4), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    class_id=top_classes.int(),
-                    confidence=confidence,
-                    mask=instances_masks,
-                )
-            )
-    return final_results
+        ]
+    return [
+        _post_process_single_instance_segmentation_result_to_rle_masks(
+            image_bboxes=image_bboxes,
+            image_logits=image_logits,
+            image_masks=image_masks,
+            image_meta=image_meta,
+            threshold=threshold,
+            num_classes=num_classes,
+            classes_re_mapping=classes_re_mapping,
+        )
+        for image_bboxes, image_logits, image_masks, image_meta in zip(
+            bboxes,
+            logits_sigmoid,
+            masks,
+            pre_processing_meta,
+        )
+    ]
 
 
 def cxcywh_to_xyxy(boxes):

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -19,12 +19,18 @@ from inference_models.models.common.roboflow.post_processing import (
 )
 from inference_models.models.rfdetr.class_remapping import ClassesReMapping
 from inference_models.models.rfdetr.post_processor import select_topk_predictions
+from inference_models.models.rfdetr.triton_jit_fallback import (
+    is_triton_jit_failure,
+    warn_triton_jit_fallback,
+)
 from inference_models.models.rfdetr.triton_postprocess import (
     post_process_single_instance_segmentation_result_to_rle_masks_triton,
 )
 from inference_models.utils.file_system import read_json
 
 _TRITON_POSTPROC_ENABLED = INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED
+_TRITON_POSTPROC_JIT_DISABLED = False
+_TRITON_POSTPROC_JIT_WARNED_REASONS: set[str] = set()
 
 
 def parse_model_type(config_path: str) -> str:
@@ -235,17 +241,34 @@ def _post_process_single_instance_segmentation_result_to_rle_masks_with_triton(
     classes_re_mapping: Optional[ClassesReMapping],
     defer_postprocess_sync: bool = False,
 ) -> InstanceDetections:
-    triton_result = (
-        post_process_single_instance_segmentation_result_to_rle_masks_triton(
-            image_bboxes=image_bboxes,
-            image_scores=image_logits,
-            image_masks=image_masks,
-            image_meta=image_meta,
-            threshold=threshold,
-            classes_re_mapping=classes_re_mapping,
-            defer_postprocess_sync=defer_postprocess_sync,
-        )
-    )
+    global _TRITON_POSTPROC_JIT_DISABLED
+
+    triton_result = None
+    if not _TRITON_POSTPROC_JIT_DISABLED:
+        try:
+            triton_result = (
+                post_process_single_instance_segmentation_result_to_rle_masks_triton(
+                    image_bboxes=image_bboxes,
+                    image_scores=image_logits,
+                    image_masks=image_masks,
+                    image_meta=image_meta,
+                    threshold=threshold,
+                    classes_re_mapping=classes_re_mapping,
+                    defer_postprocess_sync=defer_postprocess_sync,
+                )
+            )
+        except Exception as exc:
+            if not is_triton_jit_failure(exc):
+                raise
+            _TRITON_POSTPROC_JIT_DISABLED = True
+            warn_triton_jit_fallback(
+                path="postprocess",
+                exc=exc,
+                warned_reasons=_TRITON_POSTPROC_JIT_WARNED_REASONS,
+                stacklevel=3,
+            )
+            triton_result = None
+
     if triton_result is not None:
         return triton_result
 

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -14,9 +14,7 @@ from inference_models.configuration import (
 )
 from inference_models.entities import ImageDimensions
 from inference_models.errors import CorruptedModelPackageError
-from inference_models.models.common.roboflow.model_packages import (
-    PreProcessingMetadata,
-)
+from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
     align_instance_segmentation_results_to_rle_masks,
@@ -396,12 +394,18 @@ def post_process_instance_segmentation_results_to_rle_masks(
     num_classes: int,
     classes_re_mapping: Optional[ClassesReMapping],
     defer_postprocess_sync: bool = False,
+    use_triton_postprocess: Optional[bool] = None,
 ) -> List[InstanceDetections]:
     logits_sigmoid = torch.nn.functional.sigmoid(logits)
     device = bboxes.device
     if isinstance(threshold, torch.Tensor):
         threshold = threshold.to(device=device, dtype=logits_sigmoid.dtype)
-    if _TRITON_POSTPROC_ENABLED:
+    triton_postprocess_enabled = (
+        _TRITON_POSTPROC_ENABLED
+        if use_triton_postprocess is None
+        else use_triton_postprocess
+    )
+    if triton_postprocess_enabled:
         return [
             _post_process_single_instance_segmentation_result_to_rle_masks_with_triton(
                 image_bboxes=image_bboxes,

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
@@ -13,6 +13,8 @@ from inference_models import (
 from inference_models.configuration import (
     DEFAULT_DEVICE,
     INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE,
+    INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED,
+    get_rfdetr_pipeline_depth,
 )
 from inference_models.entities import ColorFormat, Confidence
 from inference_models.errors import (
@@ -21,6 +23,15 @@ from inference_models.errors import (
     ModelInputError,
     ModelRuntimeError,
 )
+from inference_models.models.base.async_handoff import (
+    get_deferred_postprocess_done_event,
+    get_trt_outputs_consumed_event,
+)
+
+# Hoisted to module scope to avoid per-call `from ... import` inside the hot
+# forward_async path. Re-import inside the function added ~13µs/frame in the
+# instrumented run on Jetson Orin. Import here is a no-op on every call.
+from inference_models.models.base.instance_segmentation import _DirectInferenceFuture
 from inference_models.models.common.cuda import (
     use_cuda_context,
     use_primary_cuda_context,
@@ -52,6 +63,9 @@ from inference_models.models.rfdetr.common import (
     post_process_instance_segmentation_results_to_rle_masks,
 )
 from inference_models.models.rfdetr.pre_processing import pre_process_network_input
+from inference_models.models.rfdetr.triton_preprocess_runtime import (
+    FastPreprocessRuntime,
+)
 from inference_models.weights_providers.entities import RecommendedParameters
 
 try:
@@ -220,6 +234,13 @@ class RFDetrForInstanceSegmentationTRT(
         self._inference_stream = torch.cuda.Stream(device=self._device)
         self._thread_local_storage = threading.local()
         self.recommended_parameters = recommended_parameters
+        self._stream_pipeline_enabled = get_rfdetr_pipeline_depth() > 1
+        self._fast_preprocess_enabled = INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED
+        if self._stream_pipeline_enabled:
+            self._pre_process_cuda_stream = torch.cuda.Stream(device=self._device)
+            self._post_process_cuda_stream = torch.cuda.Stream(device=self._device)
+        if self._fast_preprocess_enabled:
+            self._fast_preprocess_runtime = FastPreprocessRuntime(device=self._device)
 
     @property
     def class_names(self) -> List[str]:
@@ -229,6 +250,10 @@ class RFDetrForInstanceSegmentationTRT(
     def supported_mask_formats(self) -> Set[InstanceSegmentationMaskFormat]:
         return {"dense", "rle"}
 
+    @property
+    def supports_stream_pipeline(self) -> bool:
+        return self._trt_cuda_graph_cache is not None
+
     def pre_process(
         self,
         images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
@@ -237,6 +262,19 @@ class RFDetrForInstanceSegmentationTRT(
         pre_processing_overrides: Optional[PreProcessingOverrides] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
+        fast = None
+        if self._fast_preprocess_enabled:
+            fast = self._fast_preprocess_runtime.try_preprocess(
+                images=images,
+                input_color_format=input_color_format,
+                image_size=image_size,
+                image_pre_processing=self._inference_config.image_pre_processing,
+                network_input=self._inference_config.network_input,
+                stream=self._pre_process_stream,
+            )
+        if fast is not None:
+            self._fast_preproc_event = fast.ready_event
+            return fast.tensor, fast.metadata
         with torch.cuda.stream(self._pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
@@ -248,6 +286,12 @@ class RFDetrForInstanceSegmentationTRT(
                 pre_processing_overrides=pre_processing_overrides,
             )
         self._pre_process_stream.synchronize()
+        if self._stream_pipeline_enabled:
+            setattr(
+                pre_processed_images,
+                "_pre_processing_meta",
+                pre_processing_meta,
+            )
         return pre_processed_images, pre_processing_meta
 
     def forward(
@@ -257,6 +301,13 @@ class RFDetrForInstanceSegmentationTRT(
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         cache = self._trt_cuda_graph_cache if not disable_cuda_graphs else None
+        preproc_event = getattr(self, "_fast_preproc_event", None)
+        if preproc_event is not None:
+            # The Triton preprocess fast path runs on a separate CUDA stream.
+            # TensorRT consumes that tensor on `_inference_stream`, so record an
+            # explicit stream dependency instead of synchronizing the host.
+            self._inference_stream.wait_event(preproc_event)
+            self._fast_preproc_event = None
         with self._lock:
             with use_cuda_context(context=self._cuda_context):
                 detections, labels, masks = infer_from_trt_engine(
@@ -271,6 +322,101 @@ class RFDetrForInstanceSegmentationTRT(
                     trt_cuda_graph_cache=cache,
                 )
                 return detections, labels, masks
+
+    def forward_async(
+        self,
+        pre_processed_images: torch.Tensor,
+        pre_processing_meta,
+        **kwargs,
+    ):
+        """Submit CUDA-graph inference without waiting for completion."""
+        if self._trt_cuda_graph_cache is None:
+            return super().forward_async(
+                pre_processed_images, pre_processing_meta, **kwargs
+            )
+
+        preproc_event = getattr(self, "_fast_preproc_event", None)
+        if preproc_event is not None:
+            self._inference_stream.wait_event(preproc_event)
+            self._fast_preproc_event = None
+        with self._lock:
+            with use_cuda_context(context=self._cuda_context):
+                raw = infer_from_trt_engine(
+                    pre_processed_images=pre_processed_images,
+                    trt_config=self._trt_config,
+                    engine=self._engine,
+                    context=self._execution_context,
+                    device=self._device,
+                    input_name=self._input_name,
+                    outputs=self._output_names,
+                    stream=self._inference_stream,
+                    trt_cuda_graph_cache=self._trt_cuda_graph_cache,
+                    synchronize=False,
+                )
+        graph_state = getattr(raw[0], "_trt_graph_state", None)
+        if graph_state is None:
+            # Dynamic TensorRT execution does not expose graph-owned output
+            # buffers, so the future must wait for inference completion before
+            # handing outputs to postprocess.
+            self._inference_stream.synchronize()
+            return _DirectInferenceFuture(self, raw, pre_processing_meta, None, kwargs)
+        produce_event = getattr(raw[0], "_trt_produce_event", None)
+        if kwargs.get("reuse_trt_graph_outputs", False):
+            # The stream pipeline schedules postprocess before launching the
+            # next graph replay. That ordering lets postprocess read TensorRT's
+            # graph output buffers directly and avoids the DtoD clone below.
+            future_kwargs = dict(kwargs)
+            future_kwargs["defer_postprocess_sync"] = True
+            return _DirectInferenceFuture(
+                self, raw, pre_processing_meta, produce_event, future_kwargs
+            )
+
+        stream = graph_state.cuda_stream
+
+        tls = self._thread_local_storage
+        clone_sets = getattr(tls, "clone_sets", None)
+        if clone_sets is None:
+            raw0, raw1, raw2 = raw
+            clone_sets = [
+                (
+                    torch.empty_like(raw0),
+                    torch.empty_like(raw1),
+                    torch.empty_like(raw2),
+                )
+                for _ in range(3)
+            ]
+            tls.clone_sets = clone_sets
+            tls.clone_idx = 0
+        idx = tls.clone_idx
+        clones = clone_sets[idx]
+        tls.clone_idx = (idx + 1) % len(clone_sets)
+
+        prev_stream = torch.cuda.current_stream(self._device)
+        torch.cuda.set_stream(stream)
+        try:
+            raw0, raw1, raw2 = raw
+            # Non-pipelined async callers may launch the next graph replay
+            # before this future is consumed. Clone into a small ring so the
+            # next TensorRT run can safely reuse its graph output buffers.
+            clones[0].copy_(raw0, non_blocking=True)
+            clones[1].copy_(raw1, non_blocking=True)
+            clones[2].copy_(raw2, non_blocking=True)
+            produce_event = torch.cuda.Event()
+            produce_event.record(stream)
+            consumer_done = graph_state.consumer_done_event
+            if consumer_done is None:
+                consumer_done = torch.cuda.Event()
+                graph_state.consumer_done_event = consumer_done
+            consumer_done.record(stream)
+        finally:
+            torch.cuda.set_stream(prev_stream)
+
+        clones[0]._trt_produce_event = produce_event  # type: ignore[attr-defined]
+        future_kwargs = dict(kwargs)
+        future_kwargs["defer_postprocess_sync"] = True
+        return _DirectInferenceFuture(
+            self, clones, pre_processing_meta, produce_event, future_kwargs
+        )
 
     def post_process(
         self,
@@ -295,7 +441,11 @@ class RFDetrForInstanceSegmentationTRT(
             recommended_parameters=self.recommended_parameters,
             default_confidence=INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE,
         )
+        produce_event = getattr(model_results[0], "_trt_produce_event", None)
+        graph_state = getattr(model_results[0], "_trt_graph_state", None)
         with torch.cuda.stream(self._post_process_stream):
+            if produce_event is not None:
+                self._post_process_stream.wait_event(produce_event)
             for result_element in model_results:
                 result_element.record_stream(self._post_process_stream)
             bboxes, logits, masks = model_results
@@ -318,12 +468,36 @@ class RFDetrForInstanceSegmentationTRT(
                     threshold=confidence_filter.get_threshold(self.class_names),
                     num_classes=len(self.class_names),
                     classes_re_mapping=self._classes_re_mapping,
+                    defer_postprocess_sync=kwargs.get("defer_postprocess_sync", False),
                 )
-        self._post_process_stream.synchronize()
+            if graph_state is not None:
+                output_consumed_events = [
+                    get_trt_outputs_consumed_event(result) for result in results
+                ]
+                if output_consumed_events and all(
+                    event is not None for event in output_consumed_events
+                ):
+                    graph_state.consumer_done_event = output_consumed_events[-1]
+                else:
+                    consumer_done = graph_state.consumer_done_event
+                    if consumer_done is None:
+                        consumer_done = torch.cuda.Event()
+                        graph_state.consumer_done_event = consumer_done
+                    consumer_done.record(self._post_process_stream)
+        should_sync = True
+        if kwargs.get("defer_postprocess_sync", False):
+            should_sync = not all(
+                get_deferred_postprocess_done_event(result) is not None
+                for result in results
+            )
+        if should_sync:
+            self._post_process_stream.synchronize()
         return results
 
     @property
     def _pre_process_stream(self) -> torch.cuda.Stream:
+        if self._stream_pipeline_enabled:
+            return self._pre_process_cuda_stream
         if not hasattr(self._thread_local_storage, "pre_process_stream"):
             self._thread_local_storage.pre_process_stream = torch.cuda.Stream(
                 device=self._device
@@ -332,6 +506,8 @@ class RFDetrForInstanceSegmentationTRT(
 
     @property
     def _post_process_stream(self) -> torch.cuda.Stream:
+        if self._stream_pipeline_enabled:
+            return self._post_process_cuda_stream
         if not hasattr(self._thread_local_storage, "post_process_stream"):
             self._thread_local_storage.post_process_stream = torch.cuda.Stream(
                 device=self._device

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
@@ -99,6 +99,12 @@ except ImportError as import_error:
     ) from import_error
 
 
+def _supports_fast_preprocess_batch(
+    images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
+) -> bool:
+    return not isinstance(images, list) or len(images) == 1
+
+
 class RFDetrForInstanceSegmentationTRT(
     InstanceSegmentationModel[
         torch.Tensor,
@@ -263,7 +269,7 @@ class RFDetrForInstanceSegmentationTRT(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         fast = None
-        if self._fast_preprocess_enabled:
+        if self._fast_preprocess_enabled and _supports_fast_preprocess_batch(images):
             fast = self._fast_preprocess_runtime.try_preprocess(
                 images=images,
                 input_color_format=input_color_format,
@@ -469,6 +475,7 @@ class RFDetrForInstanceSegmentationTRT(
                     num_classes=len(self.class_names),
                     classes_re_mapping=self._classes_re_mapping,
                     defer_postprocess_sync=kwargs.get("defer_postprocess_sync", False),
+                    use_triton_postprocess=kwargs.get("use_triton_postprocess"),
                 )
             if graph_state is not None:
                 output_consumed_events = [

--- a/inference_models/inference_models/models/rfdetr/triton_jit_fallback.py
+++ b/inference_models/inference_models/models/rfdetr/triton_jit_fallback.py
@@ -8,13 +8,23 @@ from typing import Set
 
 logger = logging.getLogger(__name__)
 
+_triton_jit_exception_types: list[type[BaseException]] = []
+
 try:
     from triton.runtime.errors import OutOfResources as _OutOfResources
+
+    _triton_jit_exception_types.append(_OutOfResources)
+except ImportError:  # pragma: no cover - optional at import time
+    pass
+
+try:
     from triton.runtime.errors import PTXASError as _PTXASError
 
-    _TRITON_JIT_EXCEPTION_TYPES = (_PTXASError, _OutOfResources)
+    _triton_jit_exception_types.append(_PTXASError)
 except ImportError:  # pragma: no cover - optional at import time
-    _TRITON_JIT_EXCEPTION_TYPES = ()
+    pass
+
+_TRITON_JIT_EXCEPTION_TYPES = tuple(_triton_jit_exception_types)
 
 _RUNTIME_ERROR_MARKERS = (
     "c compiler",

--- a/inference_models/inference_models/models/rfdetr/triton_jit_fallback.py
+++ b/inference_models/inference_models/models/rfdetr/triton_jit_fallback.py
@@ -1,0 +1,62 @@
+"""Detect Triton JIT failures and fall back to reference RF-DETR paths."""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import Set
+
+logger = logging.getLogger(__name__)
+
+try:
+    from triton.runtime.errors import OutOfResources as _OutOfResources
+    from triton.runtime.errors import PTXASError as _PTXASError
+
+    _TRITON_JIT_EXCEPTION_TYPES = (_PTXASError, _OutOfResources)
+except ImportError:  # pragma: no cover - optional at import time
+    _TRITON_JIT_EXCEPTION_TYPES = ()
+
+_RUNTIME_ERROR_MARKERS = (
+    "c compiler",
+    "ptxas",
+    "ptx codegen",
+    "triton ptx",
+    "out of resource",
+)
+
+
+def is_triton_jit_failure(exc: BaseException) -> bool:
+    """Return whether ``exc`` looks like a Triton compile-time failure."""
+    if _TRITON_JIT_EXCEPTION_TYPES and isinstance(exc, _TRITON_JIT_EXCEPTION_TYPES):
+        return True
+    if isinstance(exc, RuntimeError):
+        message = str(exc).lower()
+        return any(marker in message for marker in _RUNTIME_ERROR_MARKERS)
+    return False
+
+
+def warn_triton_jit_fallback(
+    *,
+    path: str,
+    exc: BaseException,
+    warned_reasons: Set[str],
+    stacklevel: int = 4,
+) -> None:
+    """Log and warn once per distinct JIT failure reason."""
+    reason = f"{type(exc).__name__}: {exc}"
+    if reason in warned_reasons:
+        return
+    warned_reasons.add(reason)
+    logger.error(
+        "RF-DETR Triton %s JIT compilation failed; falling back to reference path: %s",
+        path,
+        exc,
+        exc_info=exc,
+    )
+    warnings.warn(
+        "RF-DETR Triton "
+        f"{path} path failed during JIT compilation; using reference "
+        f"implementation ({exc})",
+        RuntimeWarning,
+        stacklevel=stacklevel,
+    )

--- a/inference_models/inference_models/models/rfdetr/triton_postprocess.py
+++ b/inference_models/inference_models/models/rfdetr/triton_postprocess.py
@@ -1,0 +1,1935 @@
+"""Sparse Triton RF-DETR instance-segmentation post-processing.
+
+The normal PyTorch path upsamples every selected mask to image resolution and
+then immediately converts that dense boolean tensor to COCO RLE. For 1080p
+frames that dense intermediate is the expensive part. This module keeps the
+same RF-DETR selection semantics, but asks Triton to interpolate only the
+active mask region and emit sparse RLE run records directly.
+
+The CUDA side writes two buffers:
+
+* ``metadata``: one fixed-width row per output detection candidate containing
+  active flag, mapped class id, score, clipped xyxy box, source query id, sort
+  key, and debug ROI bounds.
+* ``records``: a flat list of ``(rank, run_start, run_end)`` triples in COCO's
+  column-major order. ``records[0, 0]`` is the run count and ``records[0, 1]``
+  is an overflow / retry flag.
+
+CPU code then performs only the small ordered assembly step: copy metadata and
+run records back, sort detections by score, convert each candidate's runs into
+compressed COCO RLE counts, and wrap them in ``InstanceDetections``.
+"""
+
+import warnings
+from collections import OrderedDict
+from threading import Lock
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from pycocotools import mask as mask_utils
+
+from inference_models.configuration import (
+    INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_MAX_PIXELS,
+    INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_MAX_RUNS,
+)
+from inference_models.models.base.async_handoff import (
+    attach_deferred_postprocess_handoff,
+)
+from inference_models.models.base.instance_segmentation import InstanceDetections
+from inference_models.models.base.types import InstancesRLEMasks
+from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
+from inference_models.models.rfdetr.class_remapping import ClassesReMapping
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # pragma: no cover - depends on optional GPU package
+    triton = None
+    tl = None
+
+
+_HEADER_SIZE = 16
+# One Triton program scans this many output rows per column tile. Keeping this
+# bounded avoids materializing a full HxW mask while still amortizing per-tile
+# interpolation setup.
+_BLOCK_ROI_H = 512
+# RLE flat positions are stored as int32 and converted exactly through fp32
+# metadata fields. Keep H*W below the fp32 exact-integer range.
+_MAX_EXACT_FLAT_INDEX = 1 << 24
+# The sparse RLE kernel processes columns in bands. The common case has small
+# active mask bounds, but the while loop below can advance through wider ROIs.
+_SPARSE_MAX_ROI_WIDTH = 512
+_SPARSE_BLOCK_COLS = 8
+_SPARSE_MAX_TOTAL_RUNS = INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_MAX_RUNS
+_SPARSE_MAX_CLASSES_PER_QUERY = 4
+_SPARSE_TOPK_MAX_TOTAL_RUNS = _SPARSE_MAX_TOTAL_RUNS * _SPARSE_MAX_CLASSES_PER_QUERY
+# RF-DETR Seg 2XLarge emits 192x192 masks with 300 queries and COCO class
+# logits. The sparse path supports that shape by scanning source-mask support
+# in fixed tiles instead of one giant Triton vector.
+_SPARSE_SOURCE_BOUNDS_BLOCK_PIXELS = 1024
+_MAX_RFDETR_SEG_2XLARGE_MASK_PIXELS = 192 * 192
+_MAX_QUERY_CLASS_PRODUCTS = 65536
+_MAX_INTERPOLATION_WEIGHT_CACHE_ENTRIES = 16
+_INTERPOLATION_WEIGHT_CACHE = OrderedDict()
+_INTERPOLATION_WEIGHT_CACHE_LOCK = Lock()
+_MAX_PINNED_HOST_POOL_BUFFERS = 8
+_PINNED_HOST_POOL = OrderedDict()
+_PINNED_HOST_POOL_LOCK = Lock()
+_PINNED_HOST_POOL_SIZE = 0
+
+
+def _get_interpolation_weights(
+    src_size: int,
+    output_size: int,
+    device: torch.device,
+    axis: str,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return sparse two-tap bilinear interpolation tables for one axis.
+
+    The Triton RLE kernel needs to reproduce ``torchvision.functional.resize``
+    with bilinear antialiasing, but it cannot call PyTorch's resize from inside
+    a kernel. We build the interpolation matrix once by resizing an identity
+    basis, keep only the non-zero source index and weight pairs for each output
+    coordinate, and cache those small tables per device/shape/axis.
+    """
+    device_key = _interpolation_cache_key(src_size, output_size, device, axis)
+    with _INTERPOLATION_WEIGHT_CACHE_LOCK:
+        cached = _INTERPOLATION_WEIGHT_CACHE.get(device_key)
+        if cached is not None:
+            _INTERPOLATION_WEIGHT_CACHE.move_to_end(device_key)
+            return cached
+
+    # Resize an identity basis so PyTorch gives us exactly the interpolation
+    # coefficients used by the reference path. This keeps the Triton path tied
+    # to PyTorch semantics instead of maintaining a second resize formula.
+    if axis == "height":
+        basis = torch.eye(src_size, device=device).reshape(src_size, 1, src_size, 1)
+        weights = F.interpolate(
+            basis,
+            size=(output_size, 1),
+            mode="bilinear",
+            align_corners=False,
+            antialias=True,
+        )[:, 0, :, 0].T.contiguous()
+    else:
+        basis = torch.eye(src_size, device=device).reshape(src_size, 1, 1, src_size)
+        weights = F.interpolate(
+            basis,
+            size=(1, output_size),
+            mode="bilinear",
+            align_corners=False,
+            antialias=True,
+        )[:, 0, 0, :].T.contiguous()
+
+    nonzero = weights != 0
+    if int(nonzero.sum(dim=1).max().item()) > 2:
+        raise ValueError("Expected antialiased bilinear interpolation to use 2 taps")
+    indices = torch.zeros((output_size, 2), dtype=torch.int32, device=device)
+    values = torch.zeros((output_size, 2), dtype=torch.float32, device=device)
+    for output_index in range(output_size):
+        source_indices = nonzero[output_index].nonzero(as_tuple=True)[0]
+        indices[output_index, : source_indices.numel()] = source_indices.to(
+            dtype=torch.int32
+        )
+        values[output_index, : source_indices.numel()] = weights[
+            output_index, source_indices
+        ]
+
+    cached_value = (indices, values)
+    with _INTERPOLATION_WEIGHT_CACHE_LOCK:
+        cached = _INTERPOLATION_WEIGHT_CACHE.get(device_key)
+        if cached is not None:
+            _INTERPOLATION_WEIGHT_CACHE.move_to_end(device_key)
+            return cached
+        _INTERPOLATION_WEIGHT_CACHE[device_key] = cached_value
+        while (
+            len(_INTERPOLATION_WEIGHT_CACHE) > _MAX_INTERPOLATION_WEIGHT_CACHE_ENTRIES
+        ):
+            _INTERPOLATION_WEIGHT_CACHE.popitem(last=False)
+    return cached_value
+
+
+def _interpolation_cache_key(
+    src_size: int,
+    output_size: int,
+    device: torch.device,
+    axis: str,
+) -> Tuple[str, int, int, int, int, str]:
+    """Build the LRU key for interpolation tables.
+
+    CUDA tensors may have ``device.index is None`` when they refer to the
+    current device, so the key also includes ``torch.cuda.current_device()`` to
+    avoid reusing tables across devices in multi-GPU processes.
+    """
+    return (
+        device.type,
+        -1 if device.index is None else device.index,
+        src_size,
+        output_size,
+        torch.cuda.current_device() if device.type == "cuda" else -1,
+        axis,
+    )
+
+
+def _allocate_source_bounds(
+    rows: int,
+    mask_height: int,
+    mask_width: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Allocate source-mask positive-support bounds for sparse RLE kernels."""
+    bounds = torch.empty((rows, 4), dtype=torch.int32, device=device)
+    bounds[:, 0].fill_(mask_height)
+    bounds[:, 1].fill_(-1)
+    bounds[:, 2].fill_(mask_width)
+    bounds[:, 3].fill_(-1)
+    return bounds
+
+
+def _acquire_pinned_host_buffer(source: torch.Tensor) -> torch.Tensor:
+    """Return a pinned CPU tensor matching ``source`` for async DtoH copies."""
+    global _PINNED_HOST_POOL_SIZE
+    key = (tuple(source.shape), source.dtype)
+    with _PINNED_HOST_POOL_LOCK:
+        buffers = _PINNED_HOST_POOL.get(key)
+        if buffers:
+            _PINNED_HOST_POOL.move_to_end(key)
+            _PINNED_HOST_POOL_SIZE -= 1
+            return buffers.pop()
+    # Pinned memory is required for ``non_blocking=True`` GPU-to-CPU copies to
+    # overlap with later GPU work; allocating it per frame is expensive.
+    return torch.empty(key[0], dtype=key[1], pin_memory=True)
+
+
+def _release_pinned_host_buffer(buffer: torch.Tensor) -> None:
+    """Return a pinned host buffer to the bounded shape/dtype reuse pool."""
+    global _PINNED_HOST_POOL_SIZE
+    key = (tuple(buffer.shape), buffer.dtype)
+    with _PINNED_HOST_POOL_LOCK:
+        if _PINNED_HOST_POOL_SIZE >= _MAX_PINNED_HOST_POOL_BUFFERS:
+            return
+        buffers = _PINNED_HOST_POOL.setdefault(key, [])
+        buffers.append(buffer)
+        _PINNED_HOST_POOL.move_to_end(key)
+        _PINNED_HOST_POOL_SIZE += 1
+def post_process_single_instance_segmentation_result_to_rle_masks_triton(
+    image_bboxes: torch.Tensor,
+    image_scores: torch.Tensor,
+    image_masks: torch.Tensor,
+    image_meta: PreProcessingMetadata,
+    threshold: Union[float, torch.Tensor],
+    classes_re_mapping: Optional[ClassesReMapping],
+    defer_postprocess_sync: bool = False,
+) -> Optional[InstanceDetections]:
+    """Run the sparse Triton RF-DETR RLE postprocess path for one image.
+
+    Returns an ``InstanceDetections`` object when the input shape and metadata
+    are supported. Returns ``None`` when the caller should use the reference
+    PyTorch/RLE implementation instead.
+
+    The fast path first emits one candidate per query. If any query has more
+    than one class above threshold, the first pass asks for a retry and the
+    second pass emits up to ``_SPARSE_MAX_CLASSES_PER_QUERY`` query-class
+    candidates per query.
+
+    When ``defer_postprocess_sync`` is set, the function enqueues the metadata,
+    sparse RLE, and DtoH copies, then returns a placeholder whose finalizer does
+    CPU assembly later. That is used by the streaming pipeline to keep the next
+    frame's GPU work moving while Python handles previous detections.
+    """
+    unsupported_reason = _unsupported_triton_postprocess_reason(
+        image_bboxes=image_bboxes,
+        image_scores=image_scores,
+        image_masks=image_masks,
+        image_meta=image_meta,
+        threshold=threshold,
+        classes_re_mapping=classes_re_mapping,
+    )
+    if unsupported_reason is not None:
+        warnings.warn(
+            f"RF-DETR Triton postprocess path is unsupported: {unsupported_reason}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
+
+    image_scores = image_scores.contiguous()
+    image_bboxes = image_bboxes.contiguous()
+    image_masks = image_masks.contiguous()
+    class_mapping = classes_re_mapping.class_mapping.contiguous()
+    num_queries, num_classes = image_scores.shape
+    mask_height, mask_width = image_masks.shape[-2:]
+    output_height = image_meta.original_size.height
+    output_width = image_meta.original_size.width
+    confidence_threshold = float(threshold)
+
+    # Precompute resize tables outside the hot kernel. The tables are tiny
+    # compared with the full-resolution masks and can be reused across frames.
+    y_idx, y_weight = _get_interpolation_weights(
+        src_size=mask_height,
+        output_size=output_height,
+        device=image_masks.device,
+        axis="height",
+    )
+    x_idx, x_weight = _get_interpolation_weights(
+        src_size=mask_width,
+        output_size=output_width,
+        device=image_masks.device,
+        axis="width",
+    )
+
+    if defer_postprocess_sync:
+        # Deferred pipeline mode separates class metadata from query mask RLE:
+        # every class candidate can reuse the one sparse mask generated for its
+        # source query, so GPU work remains bounded by the number of queries.
+        topk_metadata_rows = num_queries * _SPARSE_MAX_CLASSES_PER_QUERY
+        query_metadata = torch.empty(
+            (num_queries, _HEADER_SIZE),
+            dtype=torch.float32,
+            device=image_scores.device,
+        )
+        class_metadata = torch.empty(
+            (topk_metadata_rows, _HEADER_SIZE),
+            dtype=torch.float32,
+            device=image_scores.device,
+        )
+        records = torch.empty(
+            (_SPARSE_MAX_TOTAL_RUNS + 1, 3),
+            dtype=torch.int32,
+            device=image_scores.device,
+        )
+        source_bounds = _allocate_source_bounds(
+            rows=num_queries,
+            mask_height=mask_height,
+            mask_width=mask_width,
+            device=image_scores.device,
+        )
+        _select_topk_query_class_metadata_kernel[(num_queries,)](
+            image_scores,
+            image_bboxes,
+            class_mapping,
+            class_metadata,
+            query_metadata,
+            records,
+            confidence_threshold,
+            num_queries,
+            num_classes,
+            class_mapping.shape[0],
+            output_height,
+            output_width,
+            BLOCK_CLASSES=triton.next_power_of_2(num_classes),
+            METADATA_STRIDE=_HEADER_SIZE,
+            MAX_CLASSES_PER_QUERY=_SPARSE_MAX_CLASSES_PER_QUERY,
+            FLAG_WRITE_QUERY_METADATA=True,
+            FLAG_OVERFLOW_CLASSES=False,
+        )
+        _positive_source_bounds_kernel[
+            (
+                num_queries,
+                triton.cdiv(
+                    mask_height * mask_width,
+                    _SPARSE_SOURCE_BOUNDS_BLOCK_PIXELS,
+                ),
+            )
+        ](
+            image_masks,
+            query_metadata,
+            source_bounds,
+            mask_height,
+            mask_width,
+            image_masks.stride(0),
+            image_masks.stride(1),
+            image_masks.stride(2),
+            BLOCK_PIXELS=_SPARSE_SOURCE_BOUNDS_BLOCK_PIXELS,
+            METADATA_STRIDE=_HEADER_SIZE,
+        )
+        _sparse_atomic_rle_from_metadata_kernel[
+            (num_queries, triton.cdiv(_SPARSE_MAX_ROI_WIDTH, _SPARSE_BLOCK_COLS))
+        ](
+            image_masks,
+            source_bounds,
+            y_idx,
+            y_weight,
+            x_idx,
+            x_weight,
+            query_metadata,
+            records,
+            num_queries,
+            mask_height,
+            mask_width,
+            output_height,
+            output_width,
+            image_masks.stride(0),
+            image_masks.stride(1),
+            image_masks.stride(2),
+            BLOCK_OUT_H=triton.next_power_of_2(output_height),
+            BLOCK_OUT_W=triton.next_power_of_2(output_width),
+            BLOCK_ROI_H=_BLOCK_ROI_H,
+            MAX_ROI_WIDTH=_SPARSE_MAX_ROI_WIDTH,
+            MAX_TOTAL_RUNS=_SPARSE_MAX_TOTAL_RUNS,
+            METADATA_STRIDE=_HEADER_SIZE,
+            BLOCK_COLS=_SPARSE_BLOCK_COLS,
+        )
+        outputs_consumed_event = torch.cuda.Event()
+        outputs_consumed_event.record(torch.cuda.current_stream(image_scores.device))
+        class_metadata_host = _acquire_pinned_host_buffer(class_metadata)
+        records_host = _acquire_pinned_host_buffer(records)
+        # Pinned buffers let the DtoH copies follow the postprocess kernel on
+        # the CUDA stream while Python starts preparing later frames.
+        class_metadata_host.copy_(class_metadata, non_blocking=True)
+        records_host.copy_(records, non_blocking=True)
+        done_event = torch.cuda.Event()
+        done_event.record(torch.cuda.current_stream(image_scores.device))
+        return _deferred_instance_detections_from_sparse_query_records(
+            class_metadata_host=class_metadata_host,
+            records_host=records_host,
+            keepalive_tensors=(query_metadata, class_metadata, source_bounds, records),
+            done_event=done_event,
+            outputs_consumed_event=outputs_consumed_event,
+            max_total_runs=_SPARSE_MAX_TOTAL_RUNS,
+            height=output_height,
+            width=output_width,
+            max_detections=num_queries,
+        )
+
+    # First pass: keep the common case small by selecting only the best class
+    # for each query and emitting sparse RLE runs for those query masks.
+    metadata = torch.empty(
+        (num_queries, _HEADER_SIZE),
+        dtype=torch.float32,
+        device=image_scores.device,
+    )
+    records = torch.empty(
+        (_SPARSE_MAX_TOTAL_RUNS + 1, 3),
+        dtype=torch.int32,
+        device=image_scores.device,
+    )
+    source_bounds = _allocate_source_bounds(
+        rows=num_queries,
+        mask_height=mask_height,
+        mask_width=mask_width,
+        device=image_scores.device,
+    )
+    _select_best_query_metadata_kernel[(num_queries,)](
+        image_scores,
+        image_bboxes,
+        class_mapping,
+        metadata,
+        records,
+        confidence_threshold,
+        num_queries,
+        num_classes,
+        class_mapping.shape[0],
+        output_height,
+        output_width,
+        BLOCK_CLASSES=triton.next_power_of_2(num_classes),
+        METADATA_STRIDE=_HEADER_SIZE,
+        FLAG_MULTICLASS=True,
+    )
+    _positive_source_bounds_kernel[
+        (
+            num_queries,
+            triton.cdiv(mask_height * mask_width, _SPARSE_SOURCE_BOUNDS_BLOCK_PIXELS),
+        )
+    ](
+        image_masks,
+        metadata,
+        source_bounds,
+        mask_height,
+        mask_width,
+        image_masks.stride(0),
+        image_masks.stride(1),
+        image_masks.stride(2),
+        BLOCK_PIXELS=_SPARSE_SOURCE_BOUNDS_BLOCK_PIXELS,
+        METADATA_STRIDE=_HEADER_SIZE,
+    )
+    _sparse_atomic_rle_from_metadata_kernel[
+        (num_queries, triton.cdiv(_SPARSE_MAX_ROI_WIDTH, _SPARSE_BLOCK_COLS))
+    ](
+        image_masks,
+        source_bounds,
+        y_idx,
+        y_weight,
+        x_idx,
+        x_weight,
+        metadata,
+        records,
+        num_queries,
+        mask_height,
+        mask_width,
+        output_height,
+        output_width,
+        image_masks.stride(0),
+        image_masks.stride(1),
+        image_masks.stride(2),
+        BLOCK_OUT_H=triton.next_power_of_2(output_height),
+        BLOCK_OUT_W=triton.next_power_of_2(output_width),
+        BLOCK_ROI_H=_BLOCK_ROI_H,
+        MAX_ROI_WIDTH=_SPARSE_MAX_ROI_WIDTH,
+        MAX_TOTAL_RUNS=_SPARSE_MAX_TOTAL_RUNS,
+        METADATA_STRIDE=_HEADER_SIZE,
+        BLOCK_COLS=_SPARSE_BLOCK_COLS,
+    )
+
+    metadata_host = metadata.cpu().numpy()
+    result = _instance_detections_from_sparse_records(
+        metadata_host=metadata_host,
+        records=records,
+        max_total_runs=_SPARSE_MAX_TOTAL_RUNS,
+        height=output_height,
+        width=output_width,
+    )
+    if result is not None:
+        return result
+    if not _should_retry_sparse_topk_metadata(
+        metadata_host=metadata_host,
+        records=records,
+        max_total_runs=_SPARSE_MAX_TOTAL_RUNS,
+    ):
+        return None
+
+    # Retry only when the first pass detected multiple passing classes for a
+    # query. This preserves RF-DETR's flat top-k query-class semantics without
+    # paying the expanded metadata/RLE cost on the usual one-class-per-query
+    # path.
+    topk_metadata_rows = num_queries * _SPARSE_MAX_CLASSES_PER_QUERY
+    metadata = torch.empty(
+        (topk_metadata_rows, _HEADER_SIZE),
+        dtype=torch.float32,
+        device=image_scores.device,
+    )
+    records = torch.empty(
+        (_SPARSE_TOPK_MAX_TOTAL_RUNS + 1, 3),
+        dtype=torch.int32,
+        device=image_scores.device,
+    )
+    source_bounds = _allocate_source_bounds(
+        rows=topk_metadata_rows,
+        mask_height=mask_height,
+        mask_width=mask_width,
+        device=image_scores.device,
+    )
+    _select_topk_query_class_metadata_kernel[(num_queries,)](
+        image_scores,
+        image_bboxes,
+        class_mapping,
+        metadata,
+        metadata,
+        records,
+        confidence_threshold,
+        num_queries,
+        num_classes,
+        class_mapping.shape[0],
+        output_height,
+        output_width,
+        BLOCK_CLASSES=triton.next_power_of_2(num_classes),
+        METADATA_STRIDE=_HEADER_SIZE,
+        MAX_CLASSES_PER_QUERY=_SPARSE_MAX_CLASSES_PER_QUERY,
+        FLAG_WRITE_QUERY_METADATA=False,
+        FLAG_OVERFLOW_CLASSES=True,
+    )
+    _positive_source_bounds_kernel[
+        (
+            topk_metadata_rows,
+            triton.cdiv(mask_height * mask_width, _SPARSE_SOURCE_BOUNDS_BLOCK_PIXELS),
+        )
+    ](
+        image_masks,
+        metadata,
+        source_bounds,
+        mask_height,
+        mask_width,
+        image_masks.stride(0),
+        image_masks.stride(1),
+        image_masks.stride(2),
+        BLOCK_PIXELS=_SPARSE_SOURCE_BOUNDS_BLOCK_PIXELS,
+        METADATA_STRIDE=_HEADER_SIZE,
+    )
+    _sparse_atomic_rle_from_metadata_kernel[
+        (
+            topk_metadata_rows,
+            triton.cdiv(_SPARSE_MAX_ROI_WIDTH, _SPARSE_BLOCK_COLS),
+        )
+    ](
+        image_masks,
+        source_bounds,
+        y_idx,
+        y_weight,
+        x_idx,
+        x_weight,
+        metadata,
+        records,
+        topk_metadata_rows,
+        mask_height,
+        mask_width,
+        output_height,
+        output_width,
+        image_masks.stride(0),
+        image_masks.stride(1),
+        image_masks.stride(2),
+        BLOCK_OUT_H=triton.next_power_of_2(output_height),
+        BLOCK_OUT_W=triton.next_power_of_2(output_width),
+        BLOCK_ROI_H=_BLOCK_ROI_H,
+        MAX_ROI_WIDTH=_SPARSE_MAX_ROI_WIDTH,
+        MAX_TOTAL_RUNS=_SPARSE_TOPK_MAX_TOTAL_RUNS,
+        METADATA_STRIDE=_HEADER_SIZE,
+        BLOCK_COLS=_SPARSE_BLOCK_COLS,
+    )
+    metadata_host = metadata.cpu().numpy()
+    return _instance_detections_from_sparse_records(
+        metadata_host=metadata_host,
+        records=records,
+        max_total_runs=_SPARSE_TOPK_MAX_TOTAL_RUNS,
+        height=output_height,
+        width=output_width,
+        max_detections=num_queries,
+    )
+
+
+def _instance_detections_from_sparse_records(
+    metadata_host: np.ndarray,
+    records: torch.Tensor,
+    max_total_runs: int,
+    height: int,
+    width: int,
+    max_detections: Optional[int] = None,
+) -> Optional[InstanceDetections]:
+    """Convert sparse device records into ``InstanceDetections``.
+
+    ``metadata_host`` is already on CPU because it is small and needed to decide
+    ordering and retry/fallback. ``records`` may still live on CUDA; this helper
+    copies it only after the metadata indicates at least one active candidate.
+
+    ``None`` means the sparse device result is incomplete or overflowed and the
+    caller should retry or fall back to the reference implementation.
+    """
+    active_ranks = np.flatnonzero(metadata_host[:, 0] > 0.5)
+    if active_ranks.size == 0:
+        return InstanceDetections(
+            xyxy=torch.empty((0, 4), dtype=torch.int32),
+            confidence=torch.empty((0,), dtype=torch.float32),
+            class_id=torch.empty((0,), dtype=torch.int32),
+            mask=InstancesRLEMasks.from_coco_rle_masks(
+                image_size=(height, width),
+                masks=[],
+            ),
+        )
+    if np.any(metadata_host[active_ranks, 8] > 0.5):
+        return None
+    records_host = records.cpu().numpy()
+    total_runs = int(records_host[0, 0])
+    if int(records_host[0, 1]) != 0 or total_runs < 0 or total_runs > max_total_runs:
+        return None
+
+    # Match RF-DETR's descending score order. ``metadata[:, 10]`` gives a
+    # deterministic secondary order for equal scores without touching masks.
+    order = np.lexsort(
+        (
+            -metadata_host[active_ranks, 10],
+            -metadata_host[active_ranks, 2],
+        )
+    )
+    active_ranks = active_ranks[order]
+    if max_detections is not None:
+        active_ranks = active_ranks[:max_detections]
+    records_host = records_host[1 : total_runs + 1] if total_runs else None
+    boxes = torch.from_numpy(metadata_host[active_ranks, 3:7].copy()).round().int()
+    confidence = torch.from_numpy(metadata_host[active_ranks, 2].copy())
+    class_id = torch.from_numpy(metadata_host[active_ranks, 1].copy()).int()
+
+    rle_masks = []
+    rle_counts = []
+    for rank in active_ranks.tolist():
+        if records_host is None:
+            rank_records = np.empty((0, 3), dtype=np.int32)
+        else:
+            rank_records = records_host[records_host[:, 0] == rank]
+        if rank_records.size:
+            starts_array = rank_records[:, 1].astype(np.int64, copy=False)
+            ends_array = rank_records[:, 2].astype(np.int64, copy=False)
+            # Atomic writes from different column tiles are not globally
+            # ordered, so sort runs before converting them into COCO counts.
+            order = np.argsort(starts_array, kind="stable")
+            starts_array = starts_array[order]
+            ends_array = ends_array[order]
+        else:
+            starts_array = np.empty((0,), dtype=np.int64)
+            ends_array = np.empty((0,), dtype=np.int64)
+        counts = _counts_from_runs(
+            starts=starts_array,
+            ends=ends_array,
+            height=height,
+            width=width,
+        )
+        rle_counts.append(counts)
+        rle_masks.append(_rle_from_counts(counts=counts, height=height, width=width))
+
+    instances_masks = InstancesRLEMasks.from_coco_rle_masks(
+        image_size=(height, width),
+        masks=rle_masks,
+    )
+    # The pipeline RLE-to-polygon path consumes uncompressed counts directly, so
+    # keep them beside the pycocotools-compressed masks instead of decoding later.
+    _attach_uncompressed_counts(instances_masks, rle_counts)
+    return InstanceDetections(
+        xyxy=boxes,
+        confidence=confidence,
+        class_id=class_id,
+        mask=instances_masks,
+    )
+
+
+def _instance_detections_from_sparse_query_records(
+    class_metadata_host: np.ndarray,
+    records_host: np.ndarray,
+    max_total_runs: int,
+    height: int,
+    width: int,
+    max_detections: Optional[int] = None,
+) -> Optional[InstanceDetections]:
+    """Assemble detections when class rows share query-level RLE records.
+
+    Deferred pipeline mode emits up to four class candidates per query, but the
+    mask is identical for those class rows. The GPU therefore writes RLE records
+    once per query and this CPU helper fans that query mask out to the selected
+    class detections.
+    """
+    active_ranks = np.flatnonzero(class_metadata_host[:, 0] > 0.5)
+    if active_ranks.size == 0:
+        return InstanceDetections(
+            xyxy=torch.empty((0, 4), dtype=torch.int32),
+            confidence=torch.empty((0,), dtype=torch.float32),
+            class_id=torch.empty((0,), dtype=torch.int32),
+            mask=InstancesRLEMasks.from_coco_rle_masks(
+                image_size=(height, width),
+                masks=[],
+            ),
+        )
+    if np.any(class_metadata_host[active_ranks, 8] > 0.5):
+        return None
+    total_runs = int(records_host[0, 0])
+    if int(records_host[0, 1]) != 0 or total_runs < 0 or total_runs > max_total_runs:
+        return None
+
+    # Sort class candidates by the same score/key order as the eager path. The
+    # RLE records remain keyed by source query and are looked up below.
+    order = np.lexsort(
+        (
+            -class_metadata_host[active_ranks, 10],
+            -class_metadata_host[active_ranks, 2],
+        )
+    )
+    active_ranks = active_ranks[order]
+    if max_detections is not None:
+        active_ranks = active_ranks[:max_detections]
+    if total_runs:
+        records_host = records_host[1 : total_runs + 1]
+        # Group all records once by query and start position. This replaces the
+        # previous per-detection full-record scan while preserving stable order
+        # for duplicate starts within a query.
+        record_order = np.argsort(records_host[:, 1], kind="stable")
+        records_host = records_host[record_order]
+        record_order = np.argsort(records_host[:, 0], kind="stable")
+        records_host = records_host[record_order]
+        record_queries = records_host[:, 0]
+    else:
+        records_host = None
+        record_queries = None
+    boxes = (
+        torch.from_numpy(class_metadata_host[active_ranks, 3:7].copy()).round().int()
+    )
+    confidence = torch.from_numpy(class_metadata_host[active_ranks, 2].copy())
+    class_id = torch.from_numpy(class_metadata_host[active_ranks, 1].copy()).int()
+
+    rle_masks = []
+    rle_counts = []
+    for rank in active_ranks.tolist():
+        query_index = int(class_metadata_host[rank, 9])
+        if records_host is None:
+            rank_records = np.empty((0, 3), dtype=np.int32)
+        else:
+            # ``records_host`` is grouped by query once above, so each detection
+            # pays two binary searches instead of scanning every sparse run.
+            start_index = np.searchsorted(record_queries, query_index, side="left")
+            end_index = np.searchsorted(record_queries, query_index, side="right")
+            rank_records = records_host[start_index:end_index]
+        if rank_records.size:
+            starts_array = rank_records[:, 1].astype(np.int64, copy=False)
+            ends_array = rank_records[:, 2].astype(np.int64, copy=False)
+        else:
+            starts_array = np.empty((0,), dtype=np.int64)
+            ends_array = np.empty((0,), dtype=np.int64)
+        counts = _counts_from_runs(
+            starts=starts_array,
+            ends=ends_array,
+            height=height,
+            width=width,
+        )
+        rle_counts.append(counts)
+        rle_masks.append(_rle_from_counts(counts=counts, height=height, width=width))
+
+    instances_masks = InstancesRLEMasks.from_coco_rle_masks(
+        image_size=(height, width),
+        masks=rle_masks,
+    )
+    # The pipeline RLE-to-polygon path consumes uncompressed counts directly, so
+    # keep them beside the pycocotools-compressed masks instead of decoding later.
+    _attach_uncompressed_counts(instances_masks, rle_counts)
+    return InstanceDetections(
+        xyxy=boxes,
+        confidence=confidence,
+        class_id=class_id,
+        mask=instances_masks,
+    )
+
+
+def _sparse_query_records_failure_reason(
+    class_metadata_host: np.ndarray,
+    records_host: np.ndarray,
+    max_total_runs: int,
+) -> str:
+    active_ranks = np.flatnonzero(class_metadata_host[:, 0] > 0.5)
+    if active_ranks.size == 0:
+        return "no_failure"
+    metadata_overflows = int(np.count_nonzero(class_metadata_host[active_ranks, 8] > 0.5))
+    total_runs = int(records_host[0, 0])
+    overflow_flag = int(records_host[0, 1])
+    reasons = []
+    if metadata_overflows:
+        reasons.append(f"metadata_overflows={metadata_overflows}")
+    if overflow_flag != 0:
+        reasons.append(f"records_overflow_flag={overflow_flag}")
+    if total_runs < 0 or total_runs > max_total_runs:
+        reasons.append(f"total_runs={total_runs} max_total_runs={max_total_runs}")
+    return ", ".join(reasons) if reasons else "unknown_invalid_sparse_records"
+
+
+def _deferred_instance_detections_from_sparse_query_records(
+    class_metadata_host: torch.Tensor,
+    records_host: torch.Tensor,
+    keepalive_tensors: tuple,
+    done_event: torch.cuda.Event,
+    outputs_consumed_event: torch.cuda.Event,
+    max_total_runs: int,
+    height: int,
+    width: int,
+    max_detections: Optional[int],
+) -> InstanceDetections:
+    """Return a placeholder detection object with deferred CPU finalization.
+
+    The CUDA stream already owns the postprocess kernels and async DtoH copies.
+    Returning this placeholder lets the streaming scheduler submit more GPU work
+    before synchronizing on ``done_event`` and converting sparse records to
+    ``InstanceDetections``.
+    """
+
+    def finalize() -> InstanceDetections:
+        """Synchronize the DtoH copies and build the real detections."""
+        try:
+            done_event.synchronize()
+            # Keep device tensors alive until the recorded copies complete; CUDA
+            # does not retain Python references for us.
+            _ = keepalive_tensors
+            result = _instance_detections_from_sparse_query_records(
+                class_metadata_host=class_metadata_host.numpy(),
+                records_host=records_host.numpy(),
+                max_total_runs=max_total_runs,
+                height=height,
+                width=width,
+                max_detections=max_detections,
+            )
+            if result is None:
+                reason = _sparse_query_records_failure_reason(
+                    class_metadata_host=class_metadata_host.numpy(),
+                    records_host=records_host.numpy(),
+                    max_total_runs=max_total_runs,
+                )
+                raise RuntimeError(
+                    f"Deferred RF-DETR Triton RLE postprocess failed: {reason}"
+                )
+            return result
+        finally:
+            _release_pinned_host_buffer(class_metadata_host)
+            _release_pinned_host_buffer(records_host)
+
+    detections = InstanceDetections(
+        xyxy=torch.empty((0, 4), dtype=torch.int32),
+        confidence=torch.empty((0,), dtype=torch.float32),
+        class_id=torch.empty((0,), dtype=torch.int32),
+        mask=InstancesRLEMasks.from_coco_rle_masks(
+            image_size=(height, width),
+            masks=[],
+        ),
+    )
+    attach_deferred_postprocess_handoff(
+        detections=detections,
+        done_event=done_event,
+        trt_outputs_consumed_event=outputs_consumed_event,
+        finalize=finalize,
+    )
+    return detections
+
+
+def _should_retry_sparse_topk_metadata(
+    metadata_host: np.ndarray,
+    records: torch.Tensor,
+    max_total_runs: int,
+) -> bool:
+    """Return whether first-pass sparse metadata needs query-class expansion."""
+    active_ranks = np.flatnonzero(metadata_host[:, 0] > 0.5)
+    if active_ranks.size == 0 or np.any(metadata_host[active_ranks, 8] > 0.5):
+        return False
+    records_host = records.cpu().numpy()
+    total_runs = int(records_host[0, 0])
+    if int(records_host[0, 1]) == 0 or total_runs < 0 or total_runs > max_total_runs:
+        return False
+    return True
+
+
+def _supports_triton_postprocess_path(
+    image_bboxes: torch.Tensor,
+    image_scores: torch.Tensor,
+    image_masks: torch.Tensor,
+    image_meta: PreProcessingMetadata,
+    threshold: Union[float, torch.Tensor],
+    classes_re_mapping: Optional[ClassesReMapping],
+) -> bool:
+    """Return ``True`` when the sparse Triton path can represent this input."""
+    return (
+        _unsupported_triton_postprocess_reason(
+            image_bboxes=image_bboxes,
+            image_scores=image_scores,
+            image_masks=image_masks,
+            image_meta=image_meta,
+            threshold=threshold,
+            classes_re_mapping=classes_re_mapping,
+        )
+        is None
+    )
+
+
+def _unsupported_triton_postprocess_reason(
+    image_bboxes: torch.Tensor,
+    image_scores: torch.Tensor,
+    image_masks: torch.Tensor,
+    image_meta: PreProcessingMetadata,
+    threshold: Union[float, torch.Tensor],
+    classes_re_mapping: Optional[ClassesReMapping],
+) -> Optional[str]:
+    """Explain why the Triton path should not run, or ``None`` when supported."""
+    if triton is None:
+        return "triton_unavailable"
+    if classes_re_mapping is None:
+        return "class_remapping_required"
+    if isinstance(threshold, torch.Tensor):
+        return "tensor_threshold_unsupported"
+    if image_scores.ndim != 2 or image_bboxes.ndim != 2 or image_masks.ndim != 3:
+        return "invalid_tensor_rank"
+    num_queries, num_classes = image_scores.shape
+    if image_bboxes.shape != (num_queries, 4) or image_masks.shape[0] != num_queries:
+        return "shape_mismatch"
+    if classes_re_mapping.class_mapping.shape[0] < num_classes:
+        return "class_mapping_too_small"
+    mask_height, mask_width = image_masks.shape[-2:]
+    output_height = image_meta.original_size.height
+    output_width = image_meta.original_size.width
+    if (
+        num_queries * num_classes > _MAX_QUERY_CLASS_PRODUCTS
+        or mask_height * mask_width > _MAX_RFDETR_SEG_2XLARGE_MASK_PIXELS
+        or output_height <= 0
+        or output_width <= 0
+        or output_height > 4096
+        or output_width > 4096
+        or output_height * output_width
+        > INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_MAX_PIXELS
+        or output_height * output_width >= _MAX_EXACT_FLAT_INDEX
+    ):
+        return "input_size_exceeds_triton_limits"
+    if (
+        image_meta.pad_left != 0
+        or image_meta.pad_top != 0
+        or image_meta.pad_right != 0
+        or image_meta.pad_bottom != 0
+    ):
+        return "padding_unsupported"
+    if (
+        image_meta.static_crop_offset.offset_x != 0
+        or image_meta.static_crop_offset.offset_y != 0
+    ):
+        return "static_crop_unsupported"
+    if (
+        image_meta.size_after_pre_processing.height != output_height
+        or image_meta.size_after_pre_processing.width != output_width
+    ):
+        return "resize_metadata_unsupported"
+    if image_scores.device.type != "cuda":
+        return "cuda_device_required"
+    if (
+        image_bboxes.device != image_scores.device
+        or image_masks.device != image_scores.device
+        or classes_re_mapping.class_mapping.device != image_scores.device
+    ):
+        return "device_mismatch"
+    return None
+
+
+def _counts_from_runs(
+    starts: np.ndarray,
+    ends: np.ndarray,
+    height: int,
+    width: int,
+) -> List[int]:
+    """Build uncompressed COCO RLE counts from sparse column-major runs."""
+    total = height * width
+    if starts.size:
+        starts = starts.astype(np.int64, copy=True)
+        ends = ends.astype(np.int64, copy=True)
+        np.clip(starts, 0, total, out=starts)
+        np.clip(ends, 0, total, out=ends)
+        order = np.lexsort((ends, starts))
+        starts = starts[order]
+        ends = ends[order]
+
+    lengths = ends - starts
+    valid = lengths > 0
+    if starts.size and not np.all(valid):
+        starts = starts[valid]
+        ends = ends[valid]
+        lengths = lengths[valid]
+
+    if starts.size > 1:
+        merged_starts = [int(starts[0])]
+        merged_ends = [int(ends[0])]
+        for start, end in zip(starts[1:], ends[1:]):
+            start = int(start)
+            end = int(end)
+            if start <= merged_ends[-1]:
+                if end > merged_ends[-1]:
+                    merged_ends[-1] = end
+            else:
+                merged_starts.append(start)
+                merged_ends.append(end)
+        starts = np.asarray(merged_starts, dtype=np.int64)
+        ends = np.asarray(merged_ends, dtype=np.int64)
+        lengths = ends - starts
+
+    if starts.size:
+        run_count = starts.size
+        # COCO counts alternate background gaps and foreground lengths. Starts
+        # are absolute flat positions; subtract the prior end in-place to get
+        # each background gap.
+        gaps = starts.astype(np.int64, copy=True)
+        gaps[1:] -= ends[:-1]
+        tail = total - int(ends[-1])
+        if tail > 0:
+            counts = np.empty(run_count * 2 + 1, dtype=np.int64)
+            counts[-1] = tail
+        else:
+            counts = np.empty(run_count * 2, dtype=np.int64)
+        counts[: run_count * 2 : 2] = gaps
+        counts[1 : run_count * 2 : 2] = lengths
+        counts = counts.tolist()
+    else:
+        counts = [total]
+    return counts
+
+
+def _rle_from_counts(counts: List[int], height: int, width: int) -> dict:
+    """Compress uncompressed COCO RLE counts with pycocotools."""
+    return mask_utils.frPyObjects(
+        {"counts": counts, "size": [height, width]}, height, width
+    )
+
+
+def _attach_uncompressed_counts(
+    masks: InstancesRLEMasks,
+    rle_counts: List[List[int]],
+) -> None:
+    """Attach padded uncompressed COCO counts for downstream polygon conversion.
+
+    ``InstancesRLEMasks`` stores compressed pycocotools RLEs for normal API
+    compatibility. The pipeline branch also converts masks to polygons; keeping
+    the uncompressed counts here avoids an extra compressed-RLE decode on that
+    hot CPU path.
+    """
+    max_length = max((len(counts) for counts in rle_counts), default=0)
+    counts_array = np.zeros((len(rle_counts), max_length), dtype=np.int64)
+    lengths_array = np.empty((len(rle_counts),), dtype=np.int32)
+    for index, counts in enumerate(rle_counts):
+        counts_length = len(counts)
+        lengths_array[index] = counts_length
+        counts_array[index, :counts_length] = counts
+    # Private attributes are intentionally used as an optional fast-path cache;
+    # callers without this branch still rely on the standard compressed masks.
+    masks._rle_counts_cpu = counts_array  # type: ignore[attr-defined]
+    masks._rle_lengths_cpu = lengths_array  # type: ignore[attr-defined]
+
+
+if triton is not None:
+
+    @triton.jit
+    def _select_best_query_metadata_kernel(
+        scores,
+        bboxes,
+        class_mapping,
+        metadata,
+        records,
+        threshold: tl.constexpr,
+        num_queries: tl.constexpr,
+        num_classes: tl.constexpr,
+        class_mapping_size: tl.constexpr,
+        output_height: tl.constexpr,
+        output_width: tl.constexpr,
+        BLOCK_CLASSES: tl.constexpr,
+        METADATA_STRIDE: tl.constexpr,
+        FLAG_MULTICLASS: tl.constexpr,
+    ):
+        """Select one query-level detection row from RF-DETR scores.
+
+        Launch grid:
+            ``(num_queries,)``. Program id 0 is also responsible for clearing
+            the two-word ``records`` header before the RLE kernel runs.
+
+        Args:
+            scores: CUDA tensor with shape ``[num_queries, num_classes]`` and
+                dtype float32. Values are sigmoid class probabilities.
+            bboxes: CUDA tensor with shape ``[num_queries, 4]`` and dtype
+                float32. Boxes are normalized ``cx, cy, width, height`` values.
+            class_mapping: CUDA int tensor with at least ``num_classes`` values.
+                ``class_mapping[class_id]`` is the public class id; negative
+                entries mark model classes that should be ignored.
+            metadata: CUDA float32 tensor with shape
+                ``[num_queries, METADATA_STRIDE]``. The kernel writes columns
+                ``0`` active flag, ``1`` mapped class id, ``2`` score, ``3:7``
+                clipped xyxy pixel box, ``8`` unsupported flag, ``9`` source
+                query id, ``10`` flat query-class sort key, and ``11:15`` zeroed
+                ROI/debug fields later filled by the RLE kernel.
+            records: CUDA int32 tensor with shape ``[MAX_TOTAL_RUNS + 1, 3]``.
+                Only ``records[0, 0]`` and ``records[0, 1]`` are touched here:
+                run count and retry/overflow flag.
+            threshold: Confidence threshold applied after the best valid mapped
+                class is selected.
+            num_queries: Number of RF-DETR object queries, matching
+                ``scores.shape[0]`` and ``bboxes.shape[0]``.
+            num_classes: Number of model class columns in ``scores``.
+            class_mapping_size: Number of entries available in
+                ``class_mapping``.
+            output_height: Original image height used to convert normalized box
+                coordinates to pixel coordinates.
+            output_width: Original image width used to convert normalized box
+                coordinates to pixel coordinates.
+            BLOCK_CLASSES: Power-of-two tile width covering ``num_classes``.
+            METADATA_STRIDE: Number of float32 fields per metadata row.
+            FLAG_MULTICLASS: When true, writes ``records[0, 1] = 1`` if more
+                than one mapped class for this query exceeds ``threshold`` so
+                the caller can rerun the top-k query-class path.
+        """
+        rank = tl.program_id(0)
+        meta_base = rank * METADATA_STRIDE
+        if rank == 0:
+            tl.store(records + 0, 0)
+            tl.store(records + 1, 0)
+
+        class_offsets = tl.arange(0, BLOCK_CLASSES)
+        class_active = class_offsets < num_classes
+        mapped_classes = tl.load(
+            class_mapping + class_offsets,
+            mask=class_active & (class_offsets < class_mapping_size),
+            other=-1,
+        ).to(tl.int32)
+        class_scores = tl.load(
+            scores + rank * num_classes + class_offsets,
+            mask=class_active,
+            other=-1.0,
+        )
+        valid_classes = class_active & (mapped_classes >= 0)
+        passing_classes = valid_classes & (class_scores > threshold)
+        passing_class_count = tl.sum(tl.where(passing_classes, 1, 0), axis=0)
+        if FLAG_MULTICLASS and passing_class_count > 1:
+            tl.store(records + 1, 1)
+        # Select over valid mapped classes, not just passing classes. The
+        # threshold is applied after selection so inactive metadata rows still
+        # carry a stable class/score shape.
+        selected_score = tl.max(tl.where(valid_classes, class_scores, -1.0), axis=0)
+        selected_class = tl.max(
+            tl.where(
+                valid_classes & (class_scores == selected_score),
+                class_offsets,
+                -1,
+            ),
+            axis=0,
+        ).to(tl.int32)
+        mapped_class = tl.load(
+            class_mapping + selected_class,
+            mask=(selected_class >= 0) & (selected_class < class_mapping_size),
+            other=-1,
+        ).to(tl.int32)
+        is_valid_detection = (mapped_class >= 0) & (selected_score > threshold)
+        query_index = rank
+        selected_index = rank * num_classes + selected_class
+
+        # Metadata is float32 because Python copies it back as one compact
+        # array; integer-like fields stay below the exact fp32 integer range.
+        tl.store(
+            metadata + meta_base + 0,
+            tl.where(is_valid_detection, 1.0, 0.0),
+        )
+        tl.store(metadata + meta_base + 1, mapped_class.to(tl.float32))
+        tl.store(
+            metadata + meta_base + 2,
+            tl.where(is_valid_detection, selected_score, 0.0),
+        )
+        tl.store(metadata + meta_base + 7, 0.0)
+        tl.store(metadata + meta_base + 8, 0.0)
+        tl.store(metadata + meta_base + 9, query_index.to(tl.float32))
+        tl.store(metadata + meta_base + 10, selected_index.to(tl.float32))
+        tl.store(metadata + meta_base + 11, 0.0)
+        tl.store(metadata + meta_base + 12, 0.0)
+        tl.store(metadata + meta_base + 13, 0.0)
+        tl.store(metadata + meta_base + 14, 0.0)
+        tl.store(metadata + meta_base + 15, 0.0)
+
+        bbox_base = query_index * 4
+        cx = tl.load(bboxes + bbox_base, mask=is_valid_detection, other=0.0)
+        cy = tl.load(bboxes + bbox_base + 1, mask=is_valid_detection, other=0.0)
+        width = tl.load(bboxes + bbox_base + 2, mask=is_valid_detection, other=0.0)
+        height = tl.load(
+            bboxes + bbox_base + 3,
+            mask=is_valid_detection,
+            other=0.0,
+        )
+        x1 = tl.maximum(
+            0.0,
+            tl.minimum((cx - 0.5 * width) * output_width, output_width),
+        )
+        y1 = tl.maximum(
+            0.0,
+            tl.minimum((cy - 0.5 * height) * output_height, output_height),
+        )
+        x2 = tl.maximum(
+            0.0,
+            tl.minimum((cx + 0.5 * width) * output_width, output_width),
+        )
+        y2 = tl.maximum(
+            0.0,
+            tl.minimum((cy + 0.5 * height) * output_height, output_height),
+        )
+        tl.store(metadata + meta_base + 3, x1)
+        tl.store(metadata + meta_base + 4, y1)
+        tl.store(metadata + meta_base + 5, x2)
+        tl.store(metadata + meta_base + 6, y2)
+
+    @triton.jit
+    def _select_topk_query_class_metadata_kernel(
+        scores,
+        bboxes,
+        class_mapping,
+        metadata,
+        query_metadata,
+        records,
+        threshold: tl.constexpr,
+        num_queries: tl.constexpr,
+        num_classes: tl.constexpr,
+        class_mapping_size: tl.constexpr,
+        output_height: tl.constexpr,
+        output_width: tl.constexpr,
+        BLOCK_CLASSES: tl.constexpr,
+        METADATA_STRIDE: tl.constexpr,
+        MAX_CLASSES_PER_QUERY: tl.constexpr,
+        FLAG_WRITE_QUERY_METADATA: tl.constexpr,
+        FLAG_OVERFLOW_CLASSES: tl.constexpr,
+    ):
+        """Emit top passing query-class metadata rows for one RF-DETR query.
+
+        Launch grid:
+            ``(num_queries,)``. Each program scans all class scores for one
+            query and writes up to ``MAX_CLASSES_PER_QUERY`` rows. The current
+            implementation uses a static loop of four iterations, so
+            ``MAX_CLASSES_PER_QUERY`` is expected to be ``4``.
+
+        Args:
+            scores: CUDA float32 tensor with shape
+                ``[num_queries, num_classes]`` containing sigmoid class scores.
+            bboxes: CUDA float32 tensor with shape ``[num_queries, 4]`` in
+                normalized ``cx, cy, width, height`` format.
+            class_mapping: CUDA int tensor with class remap entries. Negative
+                mapped ids are ignored.
+            metadata: CUDA float32 tensor with shape
+                ``[num_queries * MAX_CLASSES_PER_QUERY, METADATA_STRIDE]``.
+                Row ``query_index * MAX_CLASSES_PER_QUERY + class_rank`` holds
+                the ``class_rank``-th highest passing class for that query.
+                Columns have the same layout as
+                ``_select_best_query_metadata_kernel``.
+            query_metadata: CUDA float32 tensor with shape
+                ``[num_queries, METADATA_STRIDE]`` when
+                ``FLAG_WRITE_QUERY_METADATA`` is true. In deferred pipeline
+                mode, class metadata is expanded but the RLE kernel should still
+                run once per query, so class rank 0 is also written to this
+                query-level buffer. When ``FLAG_WRITE_QUERY_METADATA`` is false,
+                callers pass ``metadata`` here and the argument is unused.
+            records: CUDA int32 tensor with shape ``[MAX_TOTAL_RUNS + 1, 3]``.
+                Program 0 resets ``records[0, 0]`` and ``records[0, 1]`` before
+                the RLE kernel appends runs.
+            threshold: Minimum class score required for a metadata row to be
+                marked active.
+            num_queries: Number of query rows in ``scores`` and ``bboxes``.
+            num_classes: Number of class columns in ``scores``.
+            class_mapping_size: Number of valid entries in ``class_mapping``.
+            output_height: Original image height used for xyxy box conversion.
+            output_width: Original image width used for xyxy box conversion.
+            BLOCK_CLASSES: Power-of-two tile width covering all class columns.
+            METADATA_STRIDE: Number of float32 fields per metadata row.
+            MAX_CLASSES_PER_QUERY: Number of metadata rows reserved per query.
+            FLAG_WRITE_QUERY_METADATA: When true, additionally writes the best
+                passing class row for each query into ``query_metadata`` for the
+                deferred pipeline RLE kernel.
+            FLAG_OVERFLOW_CLASSES: When true, writes ``records[0, 1] = 1`` if
+                more than ``MAX_CLASSES_PER_QUERY`` classes pass threshold; the
+                caller treats that as unsupported for exact top-k parity.
+        """
+        query_index = tl.program_id(0)
+        if query_index == 0:
+            tl.store(records + 0, 0)
+            tl.store(records + 1, 0)
+
+        class_offsets = tl.arange(0, BLOCK_CLASSES)
+        class_active = class_offsets < num_classes
+        mapped_classes = tl.load(
+            class_mapping + class_offsets,
+            mask=class_active & (class_offsets < class_mapping_size),
+            other=-1,
+        ).to(tl.int32)
+        class_scores = tl.load(
+            scores + query_index * num_classes + class_offsets,
+            mask=class_active,
+            other=-1.0,
+        )
+        passing_classes = (
+            class_active & (mapped_classes >= 0) & (class_scores > threshold)
+        )
+        passing_class_count = tl.sum(tl.where(passing_classes, 1, 0), axis=0)
+        if FLAG_OVERFLOW_CLASSES and passing_class_count > MAX_CLASSES_PER_QUERY:
+            tl.store(records + 1, 1)
+
+        work_scores = tl.where(passing_classes, class_scores, -1.0)
+        for class_rank in tl.static_range(0, 4):
+            # Repeated max-and-mask avoids sorting all classes and keeps the
+            # register footprint bounded by the configured class block.
+            selected_score = tl.max(work_scores, axis=0)
+            selected_class = tl.max(
+                tl.where(
+                    work_scores == selected_score,
+                    class_offsets,
+                    -1,
+                ),
+                axis=0,
+            ).to(tl.int32)
+            mapped_class = tl.load(
+                class_mapping + selected_class,
+                mask=(selected_class >= 0) & (selected_class < class_mapping_size),
+                other=-1,
+            ).to(tl.int32)
+            is_valid_detection = (mapped_class >= 0) & (selected_score > threshold)
+            metadata_rank = query_index * MAX_CLASSES_PER_QUERY + class_rank
+            meta_base = metadata_rank * METADATA_STRIDE
+            selected_index = query_index * num_classes + selected_class
+
+            tl.store(
+                metadata + meta_base + 0,
+                tl.where(is_valid_detection, 1.0, 0.0),
+            )
+            tl.store(metadata + meta_base + 1, mapped_class.to(tl.float32))
+            tl.store(
+                metadata + meta_base + 2,
+                tl.where(is_valid_detection, selected_score, 0.0),
+            )
+            tl.store(metadata + meta_base + 7, 0.0)
+            tl.store(metadata + meta_base + 8, 0.0)
+            tl.store(metadata + meta_base + 9, query_index.to(tl.float32))
+            tl.store(metadata + meta_base + 10, selected_index.to(tl.float32))
+            tl.store(metadata + meta_base + 11, 0.0)
+            tl.store(metadata + meta_base + 12, 0.0)
+            tl.store(metadata + meta_base + 13, 0.0)
+            tl.store(metadata + meta_base + 14, 0.0)
+            tl.store(metadata + meta_base + 15, 0.0)
+
+            bbox_base = query_index * 4
+            cx = tl.load(bboxes + bbox_base, mask=is_valid_detection, other=0.0)
+            cy = tl.load(bboxes + bbox_base + 1, mask=is_valid_detection, other=0.0)
+            width = tl.load(
+                bboxes + bbox_base + 2,
+                mask=is_valid_detection,
+                other=0.0,
+            )
+            height = tl.load(
+                bboxes + bbox_base + 3,
+                mask=is_valid_detection,
+                other=0.0,
+            )
+            x1 = tl.maximum(
+                0.0,
+                tl.minimum((cx - 0.5 * width) * output_width, output_width),
+            )
+            y1 = tl.maximum(
+                0.0,
+                tl.minimum((cy - 0.5 * height) * output_height, output_height),
+            )
+            x2 = tl.maximum(
+                0.0,
+                tl.minimum((cx + 0.5 * width) * output_width, output_width),
+            )
+            y2 = tl.maximum(
+                0.0,
+                tl.minimum((cy + 0.5 * height) * output_height, output_height),
+            )
+            tl.store(metadata + meta_base + 3, x1)
+            tl.store(metadata + meta_base + 4, y1)
+            tl.store(metadata + meta_base + 5, x2)
+            tl.store(metadata + meta_base + 6, y2)
+            if FLAG_WRITE_QUERY_METADATA and class_rank == 0:
+                # The pipeline path wants best-query metadata for the RLE
+                # kernel while retaining expanded class metadata for CPU
+                # finalization.
+                query_meta_base = query_index * METADATA_STRIDE
+                tl.store(
+                    query_metadata + query_meta_base + 0,
+                    tl.where(is_valid_detection, 1.0, 0.0),
+                )
+                tl.store(
+                    query_metadata + query_meta_base + 1, mapped_class.to(tl.float32)
+                )
+                tl.store(
+                    query_metadata + query_meta_base + 2,
+                    tl.where(is_valid_detection, selected_score, 0.0),
+                )
+                tl.store(query_metadata + query_meta_base + 3, x1)
+                tl.store(query_metadata + query_meta_base + 4, y1)
+                tl.store(query_metadata + query_meta_base + 5, x2)
+                tl.store(query_metadata + query_meta_base + 6, y2)
+                tl.store(query_metadata + query_meta_base + 7, 0.0)
+                tl.store(query_metadata + query_meta_base + 8, 0.0)
+                tl.store(
+                    query_metadata + query_meta_base + 9, query_index.to(tl.float32)
+                )
+                tl.store(
+                    query_metadata + query_meta_base + 10, selected_index.to(tl.float32)
+                )
+                tl.store(query_metadata + query_meta_base + 11, 0.0)
+                tl.store(query_metadata + query_meta_base + 12, 0.0)
+                tl.store(query_metadata + query_meta_base + 13, 0.0)
+                tl.store(query_metadata + query_meta_base + 14, 0.0)
+                tl.store(query_metadata + query_meta_base + 15, 0.0)
+            work_scores = tl.where(class_offsets == selected_class, -1.0, work_scores)
+
+    @triton.jit
+    def _positive_source_bounds_kernel(
+        masks,
+        metadata,
+        source_bounds,
+        mask_height: tl.constexpr,
+        mask_width: tl.constexpr,
+        mask_stride_q: tl.constexpr,
+        mask_stride_h: tl.constexpr,
+        mask_stride_w: tl.constexpr,
+        BLOCK_PIXELS: tl.constexpr,
+        METADATA_STRIDE: tl.constexpr,
+    ):
+        """Compute positive source-mask support bounds for one metadata row.
+
+        The older sparse RLE kernel scanned the whole source mask in a single
+        Triton vector to derive this support. RF-DETR Seg 2XLarge has 192x192
+        masks, so this helper scans the source mask in fixed-size tiles and
+        atomically reduces into ``source_bounds``.
+        """
+        rank = tl.program_id(0)
+        tile = tl.program_id(1)
+        meta_base = rank * METADATA_STRIDE
+        is_valid_detection = tl.load(metadata + meta_base + 0) > 0.5
+        query_index = tl.load(metadata + meta_base + 9).to(tl.int32)
+
+        pixel_offsets = tile * BLOCK_PIXELS + tl.arange(0, BLOCK_PIXELS)
+        mask_active = pixel_offsets < (mask_height * mask_width)
+        source_y = pixel_offsets // mask_width
+        source_x = pixel_offsets - source_y * mask_width
+        mask_values = tl.load(
+            masks
+            + query_index * mask_stride_q
+            + source_y * mask_stride_h
+            + source_x * mask_stride_w,
+            mask=is_valid_detection & mask_active,
+            other=-1.0,
+        )
+        positive_source = is_valid_detection & mask_active & (mask_values > 0.0)
+        local_y_min = tl.min(tl.where(positive_source, source_y, mask_height), axis=0)
+        local_y_max = tl.max(tl.where(positive_source, source_y, -1), axis=0)
+        local_x_min = tl.min(tl.where(positive_source, source_x, mask_width), axis=0)
+        local_x_max = tl.max(tl.where(positive_source, source_x, -1), axis=0)
+        has_positive_source = local_y_max >= 0
+        bounds_base = rank * 4
+        tl.atomic_min(
+            source_bounds + bounds_base + 0,
+            local_y_min,
+            sem="relaxed",
+            mask=has_positive_source,
+        )
+        tl.atomic_max(
+            source_bounds + bounds_base + 1,
+            local_y_max,
+            sem="relaxed",
+            mask=has_positive_source,
+        )
+        tl.atomic_min(
+            source_bounds + bounds_base + 2,
+            local_x_min,
+            sem="relaxed",
+            mask=has_positive_source,
+        )
+        tl.atomic_max(
+            source_bounds + bounds_base + 3,
+            local_x_max,
+            sem="relaxed",
+            mask=has_positive_source,
+        )
+
+    @triton.jit
+    def _sparse_atomic_rle_from_metadata_kernel(
+        masks,
+        source_bounds,
+        y_idx,
+        y_weight,
+        x_idx,
+        x_weight,
+        metadata,
+        records,
+        num_queries: tl.constexpr,
+        mask_height: tl.constexpr,
+        mask_width: tl.constexpr,
+        output_height: tl.constexpr,
+        output_width: tl.constexpr,
+        mask_stride_q: tl.constexpr,
+        mask_stride_h: tl.constexpr,
+        mask_stride_w: tl.constexpr,
+        BLOCK_OUT_H: tl.constexpr,
+        BLOCK_OUT_W: tl.constexpr,
+        BLOCK_ROI_H: tl.constexpr,
+        MAX_ROI_WIDTH: tl.constexpr,
+        MAX_TOTAL_RUNS: tl.constexpr,
+        METADATA_STRIDE: tl.constexpr,
+        BLOCK_COLS: tl.constexpr,
+    ):
+        """Interpolate active mask ROIs and emit COCO-order RLE run records.
+
+        Launch grid:
+            ``(metadata_rows, ceil(MAX_ROI_WIDTH / BLOCK_COLS))``. Program id 0
+            selects a metadata row / output detection rank. Program id 1 selects
+            the starting column tile. If a mask ROI is wider than
+            ``MAX_ROI_WIDTH``, each program advances by ``MAX_ROI_WIDTH`` in a
+            loop so large ROIs are still covered without launching a fallback.
+
+        Args:
+            masks: CUDA float32 tensor with logical shape
+                ``[num_queries, mask_height, mask_width]``. Strides are passed
+                separately because callers may hand in contiguous or view-backed
+                tensors. Values are mask logits already in the RF-DETR mask
+                space; output pixels are positive when bilinear interpolation is
+                greater than zero.
+            y_idx: CUDA int32 tensor with shape ``[output_height, 2]``. For each
+                output row, stores the two source mask rows used by the
+                reference antialiased bilinear resize.
+            y_weight: CUDA float32 tensor with shape ``[output_height, 2]``.
+                Weights matching ``y_idx``.
+            x_idx: CUDA int32 tensor with shape ``[output_width, 2]``. For each
+                output column, stores the two source mask columns used by the
+                reference resize.
+            x_weight: CUDA float32 tensor with shape ``[output_width, 2]``.
+                Weights matching ``x_idx``.
+            metadata: CUDA float32 tensor with shape
+                ``[metadata_rows, METADATA_STRIDE]``. The kernel reads column
+                ``0`` active flag and column ``9`` source query id. It writes
+                columns ``11:15`` with ``roi_y_start, roi_y_end, roi_x_start,
+                roi_x_end`` for diagnostics.
+            source_bounds: CUDA int32 tensor with shape ``[metadata_rows, 4]``
+                containing ``source_y_min, source_y_max, source_x_min,
+                source_x_max`` for positive source logits in the selected mask.
+            records: CUDA int32 tensor with shape ``[MAX_TOTAL_RUNS + 1, 3]``.
+                ``records[0, 0]`` is atomically incremented for every emitted
+                run and ``records[0, 1]`` is set when capacity is exceeded.
+                Data rows are ``(rank, start, end)`` where ``start`` and ``end``
+                are flat COCO/Fortran-order positions ``x * output_height + y``.
+            num_queries: Number of query masks in ``masks``.
+            mask_height: Height of each low-resolution RF-DETR mask.
+            mask_width: Width of each low-resolution RF-DETR mask.
+            output_height: Original image height for the output RLE mask.
+            output_width: Original image width for the output RLE mask.
+            mask_stride_q: Stride between query masks in ``masks``.
+            mask_stride_h: Row stride for ``masks``.
+            mask_stride_w: Column stride for ``masks``.
+            BLOCK_OUT_H: Power-of-two tile covering all output rows.
+            BLOCK_OUT_W: Power-of-two tile covering all output columns.
+            BLOCK_ROI_H: Number of output rows scanned per inner row tile.
+            MAX_ROI_WIDTH: Column band width handled per program before the
+                large-ROI loop advances to the next band.
+            MAX_TOTAL_RUNS: Maximum number of sparse runs that fit in
+                ``records`` excluding the header row.
+            METADATA_STRIDE: Number of float32 fields per metadata row.
+            BLOCK_COLS: Number of output columns scanned together.
+        """
+        rank = tl.program_id(0)
+        tile_x = tl.program_id(1)
+        local_x_offsets = tile_x * BLOCK_COLS + tl.arange(0, BLOCK_COLS)
+        meta_base = rank * METADATA_STRIDE
+        is_valid_detection = tl.load(metadata + meta_base + 0) > 0.5
+        query_index = tl.load(metadata + meta_base + 9).to(tl.int32)
+
+        if not is_valid_detection:
+            return
+
+        # Any output pixel depending only on non-positive source pixels cannot
+        # cross the >0 threshold, so derive the minimal candidate ROI from the
+        # positive source support plus a one-pixel interpolation halo.
+        bounds_base = rank * 4
+        source_y_min = tl.load(source_bounds + bounds_base + 0)
+        source_y_max = tl.load(source_bounds + bounds_base + 1)
+        source_x_min = tl.load(source_bounds + bounds_base + 2)
+        source_x_max = tl.load(source_bounds + bounds_base + 3)
+        has_positive_source = source_y_max >= 0
+        if not has_positive_source:
+            return
+
+        source_y_min = tl.maximum(source_y_min - 1, 0)
+        source_y_max = tl.minimum(source_y_max + 1, mask_height - 1)
+        source_x_min = tl.maximum(source_x_min - 1, 0)
+        source_x_max = tl.minimum(source_x_max + 1, mask_width - 1)
+
+        out_y_offsets = tl.arange(0, BLOCK_OUT_H)
+        y_active = out_y_offsets < output_height
+        interp_y0 = tl.load(y_idx + out_y_offsets * 2, mask=y_active, other=-1)
+        interp_y1 = tl.load(y_idx + out_y_offsets * 2 + 1, mask=y_active, other=-1)
+        interp_y_weight0 = tl.load(
+            y_weight + out_y_offsets * 2,
+            mask=y_active,
+            other=0.0,
+        )
+        interp_y_weight1 = tl.load(
+            y_weight + out_y_offsets * 2 + 1,
+            mask=y_active,
+            other=0.0,
+        )
+        candidate_y = y_active & (
+            (
+                (interp_y0 >= source_y_min)
+                & (interp_y0 <= source_y_max)
+                & (interp_y_weight0 != 0.0)
+            )
+            | (
+                (interp_y1 >= source_y_min)
+                & (interp_y1 <= source_y_max)
+                & (interp_y_weight1 != 0.0)
+            )
+        )
+        roi_y_start = tl.min(
+            tl.where(candidate_y, out_y_offsets, output_height), axis=0
+        )
+        roi_y_end = tl.max(tl.where(candidate_y, out_y_offsets + 1, 0), axis=0)
+
+        out_x_offsets = tl.arange(0, BLOCK_OUT_W)
+        x_active = out_x_offsets < output_width
+        interp_x0 = tl.load(x_idx + out_x_offsets * 2, mask=x_active, other=-1)
+        interp_x1 = tl.load(x_idx + out_x_offsets * 2 + 1, mask=x_active, other=-1)
+        interp_x_weight0 = tl.load(
+            x_weight + out_x_offsets * 2,
+            mask=x_active,
+            other=0.0,
+        )
+        interp_x_weight1 = tl.load(
+            x_weight + out_x_offsets * 2 + 1,
+            mask=x_active,
+            other=0.0,
+        )
+        candidate_x = x_active & (
+            (
+                (interp_x0 >= source_x_min)
+                & (interp_x0 <= source_x_max)
+                & (interp_x_weight0 != 0.0)
+            )
+            | (
+                (interp_x1 >= source_x_min)
+                & (interp_x1 <= source_x_max)
+                & (interp_x_weight1 != 0.0)
+            )
+        )
+        roi_x_start = tl.min(tl.where(candidate_x, out_x_offsets, output_width), axis=0)
+        roi_x_end = tl.max(tl.where(candidate_x, out_x_offsets + 1, 0), axis=0)
+        roi_width = roi_x_end - roi_x_start
+
+        if tile_x == 0:
+            # ROI bounds are diagnostic/fallback metadata; one tile writes them
+            # to avoid redundant stores from every column group.
+            tl.store(metadata + meta_base + 11, roi_y_start.to(tl.float32))
+            tl.store(metadata + meta_base + 12, roi_y_end.to(tl.float32))
+            tl.store(metadata + meta_base + 13, roi_x_start.to(tl.float32))
+            tl.store(metadata + meta_base + 14, roi_x_end.to(tl.float32))
+
+        if (roi_y_start >= roi_y_end) or (roi_x_start >= roi_x_end):
+            return
+
+        x_band_offset = tile_x * BLOCK_COLS
+        rows = tl.arange(0, BLOCK_ROI_H)
+        col_offsets = tl.arange(0, BLOCK_COLS)
+        mask_base = query_index * mask_stride_q
+
+        while x_band_offset < roi_width:
+            local_x_offsets = x_band_offset + col_offsets
+            column_active = local_x_offsets < roi_width
+            output_x = roi_x_start + local_x_offsets
+            output_x_matrix = output_x[None, :]
+            x_base = output_x_matrix * 2
+            source_x0 = tl.load(
+                x_idx + x_base,
+                mask=column_active[None, :],
+                other=0,
+            ).to(tl.int64)
+            source_x1 = tl.load(
+                x_idx + x_base + 1,
+                mask=column_active[None, :],
+                other=0,
+            ).to(tl.int64)
+            x_weight0 = tl.load(
+                x_weight + x_base,
+                mask=column_active[None, :],
+                other=0.0,
+            )
+            x_weight1 = tl.load(
+                x_weight + x_base + 1,
+                mask=column_active[None, :],
+                other=0.0,
+            )
+
+            # Open slots carry a run that began in a prior row tile but has not
+            # ended yet. The slot stores the record index whose end is pending.
+            open_slots = tl.full((BLOCK_COLS,), -1, tl.int32)
+            y_tile_start = roi_y_start
+            while y_tile_start <= roi_y_end:
+                row_y = y_tile_start + rows
+                output_y = row_y[:, None]
+                row_active = row_y[:, None] < roi_y_end
+                boundary_row_active = row_y[:, None] <= roi_y_end
+                active = row_active & column_active[None, :]
+                boundary_active = boundary_row_active & column_active[None, :]
+
+                y_base = output_y * 2
+                # Triton 3.2 requires load masks to match pointer rank exactly;
+                # keep the row-only interpolation tables separate from the
+                # full [rows, cols] mask used for mask-logit sampling.
+                source_y0 = tl.load(y_idx + y_base, mask=row_active, other=0).to(
+                    tl.int64
+                )
+                source_y1 = tl.load(
+                    y_idx + y_base + 1,
+                    mask=row_active,
+                    other=0,
+                ).to(
+                    tl.int64
+                )
+                y_weight0 = tl.load(y_weight + y_base, mask=row_active, other=0.0)
+                y_weight1 = tl.load(
+                    y_weight + y_base + 1,
+                    mask=row_active,
+                    other=0.0,
+                )
+                value00 = tl.load(
+                    masks
+                    + mask_base
+                    + source_y0 * mask_stride_h
+                    + source_x0 * mask_stride_w,
+                    mask=active,
+                    other=0.0,
+                )
+                value10 = tl.load(
+                    masks
+                    + mask_base
+                    + source_y1 * mask_stride_h
+                    + source_x0 * mask_stride_w,
+                    mask=active,
+                    other=0.0,
+                )
+                value01 = tl.load(
+                    masks
+                    + mask_base
+                    + source_y0 * mask_stride_h
+                    + source_x1 * mask_stride_w,
+                    mask=active,
+                    other=0.0,
+                )
+                value11 = tl.load(
+                    masks
+                    + mask_base
+                    + source_y1 * mask_stride_h
+                    + source_x1 * mask_stride_w,
+                    mask=active,
+                    other=0.0,
+                )
+                current_values = (
+                    value00 * y_weight0 + value10 * y_weight1
+                ) * x_weight0 + (value01 * y_weight0 + value11 * y_weight1) * x_weight1
+                current_positive = active & (current_values > 0.0)
+
+                # Starts/ends are transitions along a COCO column-major scan:
+                # current positive after previous background starts a run;
+                # previous positive followed by current background ends it.
+                previous_y = output_y - 1
+                previous_row_active = boundary_row_active & (row_y[:, None] > roi_y_start)
+                previous_active = previous_row_active & column_active[None, :]
+                previous_y_base = previous_y * 2
+                prev_source_y0 = tl.load(
+                    y_idx + previous_y_base,
+                    mask=previous_row_active,
+                    other=0,
+                ).to(tl.int64)
+                prev_source_y1 = tl.load(
+                    y_idx + previous_y_base + 1,
+                    mask=previous_row_active,
+                    other=0,
+                ).to(tl.int64)
+                prev_y_weight0 = tl.load(
+                    y_weight + previous_y_base,
+                    mask=previous_row_active,
+                    other=0.0,
+                )
+                prev_y_weight1 = tl.load(
+                    y_weight + previous_y_base + 1,
+                    mask=previous_row_active,
+                    other=0.0,
+                )
+                prev_value00 = tl.load(
+                    masks
+                    + mask_base
+                    + prev_source_y0 * mask_stride_h
+                    + source_x0 * mask_stride_w,
+                    mask=previous_active,
+                    other=0.0,
+                )
+                prev_value10 = tl.load(
+                    masks
+                    + mask_base
+                    + prev_source_y1 * mask_stride_h
+                    + source_x0 * mask_stride_w,
+                    mask=previous_active,
+                    other=0.0,
+                )
+                prev_value01 = tl.load(
+                    masks
+                    + mask_base
+                    + prev_source_y0 * mask_stride_h
+                    + source_x1 * mask_stride_w,
+                    mask=previous_active,
+                    other=0.0,
+                )
+                prev_value11 = tl.load(
+                    masks
+                    + mask_base
+                    + prev_source_y1 * mask_stride_h
+                    + source_x1 * mask_stride_w,
+                    mask=previous_active,
+                    other=0.0,
+                )
+                previous_values = (
+                    prev_value00 * prev_y_weight0 + prev_value10 * prev_y_weight1
+                ) * x_weight0 + (
+                    prev_value01 * prev_y_weight0 + prev_value11 * prev_y_weight1
+                ) * x_weight1
+                previous_positive = previous_active & (previous_values > 0.0)
+                is_start = current_positive & ~previous_positive
+                is_end = previous_positive & ~current_positive
+                start_prefix = tl.cumsum(tl.where(is_start, 1, 0), 0)
+                end_prefix = tl.cumsum(tl.where(is_end, 1, 0), 0)
+                start_count = tl.max(start_prefix, axis=0)
+                end_count = tl.max(end_prefix, axis=0)
+
+                start_slots = start_prefix - 1
+                run_flat = (output_x_matrix * output_height + output_y).to(tl.int32)
+                for col in tl.static_range(0, BLOCK_COLS):
+                    col_match = col_offsets == col
+                    col_has_starts = (
+                        tl.max(tl.where(col_match & (start_count > 0), 1, 0), axis=0)
+                        != 0
+                    )
+                    col_start_count = tl.max(
+                        tl.where(col_match, start_count, 0), axis=0
+                    ).to(tl.int32)
+                    col_end_count = tl.max(
+                        tl.where(col_match, end_count, 0), axis=0
+                    ).to(tl.int32)
+                    open_slot = tl.max(tl.where(col_match, open_slots, -1), axis=0).to(
+                        tl.int32
+                    )
+                    open_at_start = open_slot >= 0
+                    open_at_start_i = tl.where(open_at_start, 1, 0).to(tl.int32)
+                    # Reserve a contiguous span for this column's new starts.
+                    # Atomic ordering between columns is irrelevant because CPU
+                    # sorts records by flat start before building COCO counts.
+                    col_base = tl.atomic_add(
+                        records + 0,
+                        col_start_count,
+                        sem="relaxed",
+                        mask=col_has_starts,
+                    ).to(tl.int32)
+                    col_base = tl.where(col_has_starts, col_base, 0)
+                    if col_has_starts & ((col_base + col_start_count) > MAX_TOTAL_RUNS):
+                        tl.store(records + 1, 1)
+
+                    start_record_slots = col_base + start_slots
+                    start_store = (
+                        is_start
+                        & col_match[None, :]
+                        & (start_record_slots < MAX_TOTAL_RUNS)
+                    )
+                    tl.store(
+                        records + (start_record_slots + 1) * 3,
+                        tl.full((BLOCK_ROI_H, BLOCK_COLS), rank, tl.int32),
+                        mask=start_store,
+                    )
+                    tl.store(
+                        records + (start_record_slots + 1) * 3 + 1,
+                        run_flat,
+                        mask=start_store,
+                    )
+
+                    current_end_slots = col_base + end_prefix - 1 - open_at_start_i
+                    end_record_slots = tl.where(
+                        open_at_start & (end_prefix == 1),
+                        open_slot,
+                        current_end_slots,
+                    )
+                    end_store = (
+                        is_end
+                        & col_match[None, :]
+                        & (end_record_slots >= 0)
+                        & (end_record_slots < MAX_TOTAL_RUNS)
+                    )
+                    tl.store(
+                        records + (end_record_slots + 1) * 3 + 2,
+                        run_flat,
+                        mask=end_store,
+                    )
+
+                    closed_current_starts = tl.maximum(
+                        col_end_count - open_at_start_i, 0
+                    )
+                    unmatched_current_starts = col_start_count - closed_current_starts
+                    open_after = (open_at_start_i + col_start_count - col_end_count) > 0
+                    next_open_slot = tl.where(
+                        open_after,
+                        tl.where(
+                            unmatched_current_starts > 0,
+                            col_base + col_start_count - 1,
+                            open_slot,
+                        ),
+                        -1,
+                    ).to(tl.int32)
+                    open_slots = tl.where(col_match, next_open_slot, open_slots)
+
+                y_tile_start += BLOCK_ROI_H
+            x_band_offset += MAX_ROI_WIDTH

--- a/inference_models/inference_models/models/rfdetr/triton_postprocess.py
+++ b/inference_models/inference_models/models/rfdetr/triton_postprocess.py
@@ -78,6 +78,7 @@ _MAX_PINNED_HOST_POOL_BUFFERS = 8
 _PINNED_HOST_POOL = OrderedDict()
 _PINNED_HOST_POOL_LOCK = Lock()
 _PINNED_HOST_POOL_SIZE = 0
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
 
 
 def _get_interpolation_weights(
@@ -214,6 +215,8 @@ def _release_pinned_host_buffer(buffer: torch.Tensor) -> None:
         buffers.append(buffer)
         _PINNED_HOST_POOL.move_to_end(key)
         _PINNED_HOST_POOL_SIZE += 1
+
+
 def post_process_single_instance_segmentation_result_to_rle_masks_triton(
     image_bboxes: torch.Tensor,
     image_scores: torch.Tensor,
@@ -607,14 +610,16 @@ def _instance_detections_from_sparse_records(
     """
     active_ranks = np.flatnonzero(metadata_host[:, 0] > 0.5)
     if active_ranks.size == 0:
-        return InstanceDetections(
-            xyxy=torch.empty((0, 4), dtype=torch.int32),
-            confidence=torch.empty((0,), dtype=torch.float32),
-            class_id=torch.empty((0,), dtype=torch.int32),
-            mask=InstancesRLEMasks.from_coco_rle_masks(
-                image_size=(height, width),
-                masks=[],
-            ),
+        return _mark_sparse_rle_postprocess(
+            InstanceDetections(
+                xyxy=torch.empty((0, 4), dtype=torch.int32),
+                confidence=torch.empty((0,), dtype=torch.float32),
+                class_id=torch.empty((0,), dtype=torch.int32),
+                mask=InstancesRLEMasks.from_coco_rle_masks(
+                    image_size=(height, width),
+                    masks=[],
+                ),
+            )
         )
     if np.any(metadata_host[active_ranks, 8] > 0.5):
         return None
@@ -673,11 +678,13 @@ def _instance_detections_from_sparse_records(
     # The pipeline RLE-to-polygon path consumes uncompressed counts directly, so
     # keep them beside the pycocotools-compressed masks instead of decoding later.
     _attach_uncompressed_counts(instances_masks, rle_counts)
-    return InstanceDetections(
-        xyxy=boxes,
-        confidence=confidence,
-        class_id=class_id,
-        mask=instances_masks,
+    return _mark_sparse_rle_postprocess(
+        InstanceDetections(
+            xyxy=boxes,
+            confidence=confidence,
+            class_id=class_id,
+            mask=instances_masks,
+        )
     )
 
 
@@ -698,14 +705,16 @@ def _instance_detections_from_sparse_query_records(
     """
     active_ranks = np.flatnonzero(class_metadata_host[:, 0] > 0.5)
     if active_ranks.size == 0:
-        return InstanceDetections(
-            xyxy=torch.empty((0, 4), dtype=torch.int32),
-            confidence=torch.empty((0,), dtype=torch.float32),
-            class_id=torch.empty((0,), dtype=torch.int32),
-            mask=InstancesRLEMasks.from_coco_rle_masks(
-                image_size=(height, width),
-                masks=[],
-            ),
+        return _mark_sparse_rle_postprocess(
+            InstanceDetections(
+                xyxy=torch.empty((0, 4), dtype=torch.int32),
+                confidence=torch.empty((0,), dtype=torch.float32),
+                class_id=torch.empty((0,), dtype=torch.int32),
+                mask=InstancesRLEMasks.from_coco_rle_masks(
+                    image_size=(height, width),
+                    masks=[],
+                ),
+            )
         )
     if np.any(class_metadata_host[active_ranks, 8] > 0.5):
         return None
@@ -777,12 +786,19 @@ def _instance_detections_from_sparse_query_records(
     # The pipeline RLE-to-polygon path consumes uncompressed counts directly, so
     # keep them beside the pycocotools-compressed masks instead of decoding later.
     _attach_uncompressed_counts(instances_masks, rle_counts)
-    return InstanceDetections(
-        xyxy=boxes,
-        confidence=confidence,
-        class_id=class_id,
-        mask=instances_masks,
+    return _mark_sparse_rle_postprocess(
+        InstanceDetections(
+            xyxy=boxes,
+            confidence=confidence,
+            class_id=class_id,
+            mask=instances_masks,
+        )
     )
+
+
+def _mark_sparse_rle_postprocess(detections: InstanceDetections) -> InstanceDetections:
+    setattr(detections, _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR, True)
+    return detections
 
 
 def _sparse_query_records_failure_reason(
@@ -793,7 +809,9 @@ def _sparse_query_records_failure_reason(
     active_ranks = np.flatnonzero(class_metadata_host[:, 0] > 0.5)
     if active_ranks.size == 0:
         return "no_failure"
-    metadata_overflows = int(np.count_nonzero(class_metadata_host[active_ranks, 8] > 0.5))
+    metadata_overflows = int(
+        np.count_nonzero(class_metadata_host[active_ranks, 8] > 0.5)
+    )
     total_runs = int(records_host[0, 0])
     overflow_flag = int(records_host[0, 1])
     reasons = []
@@ -1730,9 +1748,7 @@ if triton is not None:
                     y_idx + y_base + 1,
                     mask=row_active,
                     other=0,
-                ).to(
-                    tl.int64
-                )
+                ).to(tl.int64)
                 y_weight0 = tl.load(y_weight + y_base, mask=row_active, other=0.0)
                 y_weight1 = tl.load(
                     y_weight + y_base + 1,
@@ -1780,7 +1796,9 @@ if triton is not None:
                 # current positive after previous background starts a run;
                 # previous positive followed by current background ends it.
                 previous_y = output_y - 1
-                previous_row_active = boundary_row_active & (row_y[:, None] > roi_y_start)
+                previous_row_active = boundary_row_active & (
+                    row_y[:, None] > roi_y_start
+                )
                 previous_active = previous_row_active & column_active[None, :]
                 previous_y_base = previous_y * 2
                 prev_source_y0 = tl.load(

--- a/inference_models/inference_models/models/rfdetr/triton_preprocess.py
+++ b/inference_models/inference_models/models/rfdetr/triton_preprocess.py
@@ -1,0 +1,686 @@
+"""Triton preprocessing kernels for RF-DETR.
+
+Byte-exact port of PIL's separable bilinear-antialias resize (the algorithm
+torchvision's `TF.resize(pil, ..., antialias=True)` uses on PIL inputs), with
+the subsequent `/255` + ImageNet normalize fused into the same pass.
+
+PIL's scheme (src/libImaging/Resample.c):
+
+    PRECISION_BITS = 22
+    scale       = in_size / out_size
+    filterscale = max(1.0, scale)
+    support     = 1.0 * filterscale          # triangle radius = 1
+    ksize       = ceil(support) * 2 + 1
+    center(o)   = (o + 0.5) * scale
+    xmin(o)     = int(center - support + 0.5)                  clipped to [0, in]
+    xmax(o)     = int(center + support + 0.5)                  clipped to [0, in]
+    w_f(o, k)   = triangle((k + xmin - center + 0.5) / filterscale)
+    w_f normalised to sum to 1 per output pixel
+    w_i(o, k)   = round(w_f(o, k) * (1 << PRECISION_BITS))      int32
+    out(o)      = clamp((Σ w_i(o, k) * src_u8) + (1 << (PRECISION_BITS-1)) >> PRECISION_BITS, 0, 255)
+
+The runtime implementation is the consolidated two-pass path:
+horizontal PIL-antialias resize into a uint8 CHW scratch buffer, followed by
+the vertical pass plus `/255` + ImageNet normalization into fp32 CHW output.
+
+Tensor contracts:
+
+* ``src`` is a CUDA uint8 HWC image with shape ``(raw_h, raw_w, 3)``. The
+  hot TRT path currently passes a full frame with no static crop, but the
+  kernels also accept crop offsets and logical crop dimensions.
+* ``tmp`` is a CUDA uint8 CHW scratch tensor with shape
+  ``(3, src_h, target_w)``. It stores the horizontally resized image after
+  the same fixed-point rounding PIL applies between its separable passes.
+* ``out`` is a CUDA fp32 NCHW tensor with shape ``(1, 3, target_h, target_w)``
+  in network channel order. Each element is ``(uint8 / 255 - mean) / std``.
+* ``ResampleTables`` owns the per-axis int32 fixed-point start/weight tables
+  that PIL would precompute for this source/target shape pair.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+
+from inference_models.errors import (
+    MissingDependencyError,
+    ModelInputError,
+    ModelRuntimeError,
+)
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    triton = None
+    tl = None
+    TRITON_AVAILABLE = False
+
+
+PRECISION_BITS = 22
+_PREPROC_BLOCK_H_ENV = "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_BLOCK_H"
+_PREPROC_BLOCK_W_ENV = "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_BLOCK_W"
+_PREPROC_HORIZONTAL_BLOCK_H_ENV = (
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_HORIZONTAL_BLOCK_H"
+)
+_PREPROC_HORIZONTAL_BLOCK_W_ENV = (
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_HORIZONTAL_BLOCK_W"
+)
+
+
+def _read_power_of_two_env(name: str, default: int) -> int:
+    """Read an optional Triton block-size override from the environment.
+
+    The preprocess kernels use power-of-two block sizes so Triton can form
+    static tensor shapes for vectorized loads/stores. This helper keeps those
+    launch-shape constraints local to the kernel wrapper and raises a
+    user-facing ``ModelRuntimeError`` for invalid values.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise ModelRuntimeError(
+            message=f"{name} must be an integer, got {raw!r}.",
+            help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+        ) from error
+    if value <= 0 or value & (value - 1) != 0:
+        raise ModelRuntimeError(
+            message=f"{name} must be a positive power of two, got {value}.",
+            help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+        )
+    if value > 512:
+        raise ModelRuntimeError(
+            message=f"{name} must be <= 512, got {value}.",
+            help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+        )
+    return value
+
+
+def _bilinear_antialias_weights_1d_int(
+    in_size: int, out_size: int
+) -> Tuple[np.ndarray, np.ndarray, int]:
+    """Build one axis of PIL-compatible bilinear-antialias tables.
+
+    Args:
+        in_size: Number of pixels along the source axis after static cropping.
+        out_size: Number of pixels along the resized output axis.
+
+    Returns:
+        ``(starts, weights_int, ksize)`` where ``starts`` has shape
+        ``(out_size,)`` and gives the first source sample for each output
+        coordinate, ``weights_int`` has shape ``(out_size, ksize)`` and stores
+        PIL's normalized triangle weights in ``PRECISION_BITS`` fixed-point
+        format, and ``ksize`` is the compile-time convolution width used by the
+        Triton loop for that axis.
+    """
+    scale = in_size / out_size
+    filterscale = max(1.0, scale)
+    support = filterscale
+    ksize = int(math.ceil(support)) * 2 + 1
+
+    starts = np.zeros(out_size, dtype=np.int32)
+    weights_fp = np.zeros((out_size, ksize), dtype=np.float64)
+    inv_fs = 1.0 / filterscale
+
+    for o in range(out_size):
+        center = (o + 0.5) * scale
+        xmin = int(center - support + 0.5)
+        if xmin < 0:
+            xmin = 0
+        xmax = int(center + support + 0.5)
+        if xmax > in_size:
+            xmax = in_size
+        actual = xmax - xmin
+        starts[o] = xmin
+        total = 0.0
+        for k in range(actual):
+            t = (k + xmin - center + 0.5) * inv_fs
+            t_abs = -t if t < 0.0 else t
+            w = 1.0 - t_abs if t_abs < 1.0 else 0.0
+            weights_fp[o, k] = w
+            total += w
+        if total != 0.0:
+            weights_fp[o, :actual] /= total
+
+    weights_int = np.rint(weights_fp * (1 << PRECISION_BITS)).astype(np.int32)
+    return starts, weights_int, ksize
+
+
+if TRITON_AVAILABLE:
+
+    _HALF = 1 << (PRECISION_BITS - 1)
+
+    @triton.jit
+    def horizontal_resize_uint8_all_channels_kernel(
+        src_ptr,
+        tmp_ptr,
+        xmin_ptr,
+        wx_ptr,
+        src_h,
+        src_w,
+        src_stride_h,
+        src_stride_w,
+        crop_offset_y,
+        crop_offset_x,
+        target_w,
+        CH_R: tl.constexpr,
+        CH_G: tl.constexpr,
+        CH_B: tl.constexpr,
+        KSIZE_X: tl.constexpr,
+        PRECISION_BITS_C: tl.constexpr,
+        HALF_C: tl.constexpr,
+        BLOCK_H: tl.constexpr,
+        BLOCK_W: tl.constexpr,
+    ):
+        """Compute PIL's horizontal resize pass for one tile.
+
+        Args:
+            src_ptr: CUDA uint8 HWC source image, shape ``(raw_h, raw_w, 3)``.
+            tmp_ptr: CUDA uint8 CHW scratch output, shape
+                ``(3, src_h, target_w)``.
+            xmin_ptr: CUDA int32 starts table, shape ``(target_w,)``.
+            wx_ptr: CUDA int32 flattened weights table, shape
+                ``(target_w * KSIZE_X,)``.
+            src_h/src_w: Logical source height/width after crop. These drive
+                bounds checks for the resized region.
+            src_stride_h/src_stride_w: Source strides in elements, used so the
+                kernel does not assume contiguous row pitch beyond HWC layout.
+            crop_offset_y/crop_offset_x: Offset into ``src_ptr`` for static
+                crop support. The TRT fast path passes zero.
+            target_w: Width of the resized network input.
+            CH_R/CH_G/CH_B: Source channel indices to emit into network
+                channel order. For BGR input feeding an RGB model this is
+                ``2, 1, 0``.
+
+        Output:
+            Writes the horizontally resized and PIL-rounded uint8 values into
+            ``tmp_ptr`` in CHW order. The vertical kernel consumes this scratch
+            buffer as its input image.
+        """
+        # Program ids tile over logical source rows and target columns. The
+        # y-axis is still source height because this pass only resizes width.
+        pid_y = tl.program_id(0)
+        pid_x = tl.program_id(1)
+
+        offs_y = pid_y * BLOCK_H + tl.arange(0, BLOCK_H)
+        offs_x = pid_x * BLOCK_W + tl.arange(0, BLOCK_W)
+        mask_y = offs_y < src_h
+        mask_x = offs_x < target_w
+        mask_out = mask_y[:, None] & mask_x[None, :]
+
+        # For each output x, PIL precomputes the first contributing source x
+        # and a fixed-width row of int32 fixed-point triangle weights.
+        xmin = tl.load(xmin_ptr + offs_x, mask=mask_x, other=0)
+        sy = offs_y + crop_offset_y
+
+        hacc_r = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+        hacc_g = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+        hacc_b = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+        for kx in tl.static_range(KSIZE_X):
+            sx = xmin + kx
+            sx_c = tl.maximum(tl.minimum(sx, src_w - 1), 0) + crop_offset_x
+            wx = tl.load(wx_ptr + offs_x * KSIZE_X + kx, mask=mask_x, other=0)
+            base = sy[:, None] * src_stride_h + sx_c[None, :] * src_stride_w
+            # Load source pixels in the network's channel order so the channel
+            # swap replaces the original PIL image conversion step.
+            p_r = tl.load(src_ptr + base + CH_R, mask=mask_out, other=0).to(tl.int32)
+            p_g = tl.load(src_ptr + base + CH_G, mask=mask_out, other=0).to(tl.int32)
+            p_b = tl.load(src_ptr + base + CH_B, mask=mask_out, other=0).to(tl.int32)
+            wx_2d = wx[None, :]
+            # Fixed-point horizontal convolution: sum(src * PIL_weight_int).
+            hacc_r += p_r * wx_2d
+            hacc_g += p_g * wx_2d
+            hacc_b += p_b * wx_2d
+
+        # Match PIL's intermediate uint8 rounding before the vertical pass.
+        q_r = (hacc_r + HALF_C) >> PRECISION_BITS_C
+        q_g = (hacc_g + HALF_C) >> PRECISION_BITS_C
+        q_b = (hacc_b + HALF_C) >> PRECISION_BITS_C
+        q_r = tl.minimum(tl.maximum(q_r, 0), 255)
+        q_g = tl.minimum(tl.maximum(q_g, 0), 255)
+        q_b = tl.minimum(tl.maximum(q_b, 0), 255)
+
+        out_row = offs_y[:, None] * target_w + offs_x[None, :]
+        channel_stride = src_h * target_w
+        # CHW scratch keeps the following vertical pass contiguous along x for
+        # one output channel at a time.
+        tl.store(tmp_ptr + 0 * channel_stride + out_row, q_r, mask=mask_out)
+        tl.store(tmp_ptr + 1 * channel_stride + out_row, q_g, mask=mask_out)
+        tl.store(tmp_ptr + 2 * channel_stride + out_row, q_b, mask=mask_out)
+
+    @triton.jit
+    def vertical_normalize_from_horizontal_kernel(
+        tmp_ptr,
+        dst_ptr,
+        ymin_ptr,
+        wy_ptr,
+        src_h,
+        dst_stride_c,
+        dst_stride_h,
+        target_h,
+        target_w,
+        inv_std_255_r,
+        inv_std_255_g,
+        inv_std_255_b,
+        offset_r,
+        offset_g,
+        offset_b,
+        KSIZE_Y: tl.constexpr,
+        PRECISION_BITS_C: tl.constexpr,
+        HALF_C: tl.constexpr,
+        BLOCK_H: tl.constexpr,
+        BLOCK_W: tl.constexpr,
+    ):
+        """Compute PIL's vertical resize pass and torchvision normalization.
+
+        Args:
+            tmp_ptr: CUDA uint8 CHW horizontal scratch, shape
+                ``(3, src_h, target_w)``.
+            dst_ptr: CUDA fp32 NCHW output, shape
+                ``(1, 3, target_h, target_w)``.
+            ymin_ptr: CUDA int32 starts table, shape ``(target_h,)``.
+            wy_ptr: CUDA int32 flattened weights table, shape
+                ``(target_h * KSIZE_Y,)``.
+            src_h: Logical source height after crop and after the horizontal
+                pass. This is the height of ``tmp_ptr``.
+            dst_stride_c/dst_stride_h: Output strides in elements.
+            target_h/target_w: Resized network input shape.
+            inv_std_255_*: Precomputed ``1 / (255 * std[channel])`` values.
+            offset_*: Precomputed ``-mean[channel] / std[channel]`` values.
+
+        Output:
+            Writes normalized fp32 NCHW data into ``dst_ptr``. This is the
+            tensor consumed directly by TensorRT.
+        """
+        # Program ids tile over output rows, output columns, and the three
+        # output channels. Channel-specific normalization is selected by pid_c.
+        pid_y = tl.program_id(0)
+        pid_x = tl.program_id(1)
+        pid_c = tl.program_id(2)
+
+        offs_y = pid_y * BLOCK_H + tl.arange(0, BLOCK_H)
+        offs_x = pid_x * BLOCK_W + tl.arange(0, BLOCK_W)
+        mask_y = offs_y < target_h
+        mask_x = offs_x < target_w
+        mask_out = mask_y[:, None] & mask_x[None, :]
+
+        # For each output y, load the first source row and PIL fixed-point
+        # weights for the vertical half of the separable resize.
+        ymin = tl.load(ymin_ptr + offs_y, mask=mask_y, other=0)
+
+        vacc = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+        for ky in tl.static_range(KSIZE_Y):
+            sy = ymin + ky
+            sy_c = tl.maximum(tl.minimum(sy, src_h - 1), 0)
+            wy = tl.load(wy_ptr + offs_y * KSIZE_Y + ky, mask=mask_y, other=0)
+            base = sy_c[:, None] * target_w + offs_x[None, :]
+            p = tl.load(
+                tmp_ptr + pid_c * src_h * target_w + base, mask=mask_out, other=0
+            ).to(tl.int32)
+            # Fixed-point vertical convolution over the horizontally rounded
+            # scratch buffer, matching PIL's second resample pass.
+            vacc += p * wy[:, None]
+
+        # Final PIL uint8 rounding/clamping before torchvision's to_tensor.
+        q = (vacc + HALF_C) >> PRECISION_BITS_C
+        q = tl.minimum(tl.maximum(q, 0), 255)
+
+        # Fuse TF.to_tensor() (`q / 255`) and TF.normalize().
+        inv_std_255 = tl.where(
+            pid_c == 0,
+            inv_std_255_r,
+            tl.where(pid_c == 1, inv_std_255_g, inv_std_255_b),
+        )
+        offset = tl.where(
+            pid_c == 0,
+            offset_r,
+            tl.where(pid_c == 1, offset_g, offset_b),
+        )
+        out = q.to(tl.float32) * inv_std_255 + offset
+
+        out_row = offs_y[:, None] * dst_stride_h + offs_x[None, :]
+        tl.store(dst_ptr + pid_c * dst_stride_c + out_row, out, mask=mask_out)
+
+
+class ResampleTables:
+    """CUDA cache of PIL fixed-point resize tables for one shape pair.
+
+    Attributes:
+        ymin_gpu: int32 tensor with shape ``(target_h,)``. ``ymin_gpu[y]`` is
+            the first source row contributing to output row ``y``.
+        xmin_gpu: int32 tensor with shape ``(target_w,)``. ``xmin_gpu[x]`` is
+            the first source column contributing to output column ``x``.
+        wy_gpu: int32 flattened tensor with shape ``(target_h * ksize_y,)``.
+            Row ``y`` contains the fixed-point vertical weights for output row
+            ``y``.
+        wx_gpu: int32 flattened tensor with shape ``(target_w * ksize_x,)``.
+            Row ``x`` contains the fixed-point horizontal weights for output
+            column ``x``.
+        ksize_y/ksize_x: Static loop bounds for the vertical and horizontal
+            Triton kernels. They are determined by PIL's antialias support
+            radius for the current source/target scale.
+    """
+
+    __slots__ = (
+        "ymin_gpu",
+        "xmin_gpu",
+        "wy_gpu",
+        "wx_gpu",
+        "ksize_y",
+        "ksize_x",
+    )
+
+    def __init__(
+        self,
+        ymin_gpu: torch.Tensor,
+        xmin_gpu: torch.Tensor,
+        wy_gpu: torch.Tensor,
+        wx_gpu: torch.Tensor,
+        ksize_y: int,
+        ksize_x: int,
+    ) -> None:
+        self.ymin_gpu = ymin_gpu
+        self.xmin_gpu = xmin_gpu
+        self.wy_gpu = wy_gpu
+        self.wx_gpu = wx_gpu
+        self.ksize_y = ksize_y
+        self.ksize_x = ksize_x
+
+
+def resolve_two_pass_launch_config() -> Tuple[int, int, int, int]:
+    """Resolve block sizes for the two-pass Triton implementation.
+
+    Returns:
+        ``(vertical_block_h, vertical_block_w, horizontal_block_h,
+        horizontal_block_w)``. Defaults are tuned for the RF-DETR TRT workload,
+        while environment variables allow microbenchmark sweeps without code
+        changes.
+    """
+    return (
+        _read_power_of_two_env(_PREPROC_BLOCK_H_ENV, 1),
+        _read_power_of_two_env(_PREPROC_BLOCK_W_ENV, 128),
+        _read_power_of_two_env(_PREPROC_HORIZONTAL_BLOCK_H_ENV, 1),
+        _read_power_of_two_env(_PREPROC_HORIZONTAL_BLOCK_W_ENV, 128),
+    )
+
+
+def build_resample_tables(
+    src_h: int,
+    src_w: int,
+    target_h: int,
+    target_w: int,
+    device: torch.device,
+) -> ResampleTables:
+    """Build and upload PIL-compatible resample tables for one resize.
+
+    Args:
+        src_h/src_w: Effective source image dimensions after optional crop.
+        target_h/target_w: Network input dimensions after resize.
+        device: CUDA device where the Triton kernels will run.
+
+    Returns:
+        ``ResampleTables`` with all starts/weights already copied to ``device``.
+        The hot TRT path keeps this object in a shape-keyed cache so table
+        construction is not repeated per frame.
+    """
+    ymin, wy, ksize_y = _bilinear_antialias_weights_1d_int(src_h, target_h)
+    xmin, wx, ksize_x = _bilinear_antialias_weights_1d_int(src_w, target_w)
+    return ResampleTables(
+        ymin_gpu=torch.from_numpy(ymin).to(device=device, non_blocking=True),
+        xmin_gpu=torch.from_numpy(xmin).to(device=device, non_blocking=True),
+        wy_gpu=torch.from_numpy(wy.ravel()).to(device=device, non_blocking=True),
+        wx_gpu=torch.from_numpy(wx.ravel()).to(device=device, non_blocking=True),
+        ksize_y=ksize_y,
+        ksize_x=ksize_x,
+    )
+
+
+def triton_preprocess_rfdetr_stretch_two_pass_preallocated(
+    src: torch.Tensor,
+    out: torch.Tensor,
+    tmp: torch.Tensor,
+    tables: ResampleTables,
+    target_h: int,
+    target_w: int,
+    means: Tuple[float, float, float],
+    stds: Tuple[float, float, float],
+    swap_rb: bool,
+    launch_config: Tuple[int, int, int, int],
+    crop_offset_y: int = 0,
+    crop_offset_x: int = 0,
+    crop_h: Optional[int] = None,
+    crop_w: Optional[int] = None,
+) -> torch.Tensor:
+    """Launch the fast two-pass preprocessor using caller-owned buffers.
+
+    This is the hot path used by the TensorRT adapter. It intentionally assumes
+    the caller already validated shapes, dtypes, device placement, and table
+    compatibility so each frame only pays for the HtoD copy and two Triton
+    kernel launches.
+
+    Args:
+        src: CUDA uint8 HWC source tensor, shape ``(raw_h, raw_w, 3)``.
+        out: CUDA fp32 NCHW output tensor, shape
+            ``(1, 3, target_h, target_w)``.
+        tmp: CUDA uint8 CHW scratch tensor, shape ``(3, src_h, target_w)``.
+        tables: ``ResampleTables`` built for ``(src_h, src_w)`` to
+            ``(target_h, target_w)``.
+        target_h/target_w: Network input dimensions.
+        means/stds: Per-channel normalization constants in output channel
+            order.
+        swap_rb: Whether to swap source red/blue channels while writing
+            network-order output channels.
+        launch_config: Block sizes returned by ``resolve_two_pass_launch_config``.
+        crop_offset_y/crop_offset_x: Optional top-left crop offset in ``src``.
+        crop_h/crop_w: Optional logical source shape after crop. When omitted,
+            the full source tensor shape is used.
+
+    Returns:
+        The same ``out`` tensor after scheduling both kernels on the current
+        CUDA stream.
+    """
+    raw_src_h, raw_src_w = int(src.shape[0]), int(src.shape[1])
+    src_h = crop_h if crop_h is not None else raw_src_h
+    src_w = crop_w if crop_w is not None else raw_src_w
+    src_stride_h = int(src.stride(0))
+    src_stride_w = int(src.stride(1))
+    dst_stride_c = target_h * target_w
+    dst_stride_h = target_w
+
+    if swap_rb:
+        ch_r, ch_g, ch_b = 2, 1, 0
+    else:
+        ch_r, ch_g, ch_b = 0, 1, 2
+
+    inv_std_255_r = 1.0 / (255.0 * stds[0])
+    inv_std_255_g = 1.0 / (255.0 * stds[1])
+    inv_std_255_b = 1.0 / (255.0 * stds[2])
+    offset_r = -means[0] / stds[0]
+    offset_g = -means[1] / stds[1]
+    offset_b = -means[2] / stds[2]
+    block_h, block_w, horizontal_block_h, horizontal_block_w = launch_config
+
+    # First reproduce PIL's horizontal resize into uint8 scratch. This is the
+    # only pass that reads the raw HWC frame.
+    horizontal_grid = (
+        (src_h + horizontal_block_h - 1) // horizontal_block_h,
+        (target_w + horizontal_block_w - 1) // horizontal_block_w,
+    )
+    horizontal_resize_uint8_all_channels_kernel[horizontal_grid](
+        src,
+        tmp,
+        tables.xmin_gpu,
+        tables.wx_gpu,
+        src_h,
+        src_w,
+        src_stride_h,
+        src_stride_w,
+        int(crop_offset_y),
+        int(crop_offset_x),
+        target_w,
+        CH_R=ch_r,
+        CH_G=ch_g,
+        CH_B=ch_b,
+        KSIZE_X=tables.ksize_x,
+        PRECISION_BITS_C=PRECISION_BITS,
+        HALF_C=_HALF,
+        BLOCK_H=horizontal_block_h,
+        BLOCK_W=horizontal_block_w,
+    )
+    # Then reproduce PIL's vertical resize and fuse the torchvision tensor
+    # conversion and normalization into the final fp32 TensorRT input.
+    grid = (
+        (target_h + block_h - 1) // block_h,
+        (target_w + block_w - 1) // block_w,
+    )
+    vertical_normalize_from_horizontal_kernel[(grid[0], grid[1], 3)](
+        tmp,
+        out,
+        tables.ymin_gpu,
+        tables.wy_gpu,
+        src_h,
+        dst_stride_c,
+        dst_stride_h,
+        target_h,
+        target_w,
+        float(inv_std_255_r),
+        float(inv_std_255_g),
+        float(inv_std_255_b),
+        float(offset_r),
+        float(offset_g),
+        float(offset_b),
+        KSIZE_Y=tables.ksize_y,
+        PRECISION_BITS_C=PRECISION_BITS,
+        HALF_C=_HALF,
+        BLOCK_H=block_h,
+        BLOCK_W=block_w,
+    )
+    return out
+
+
+def triton_preprocess_rfdetr_stretch(
+    src: torch.Tensor,
+    tables: ResampleTables,
+    target_h: int,
+    target_w: int,
+    means: Tuple[float, float, float] = (0.485, 0.456, 0.406),
+    stds: Tuple[float, float, float] = (0.229, 0.224, 0.225),
+    swap_rb: bool = True,
+    crop_offset_y: int = 0,
+    crop_offset_x: int = 0,
+    crop_h: Optional[int] = None,
+    crop_w: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    tmp: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """PIL-exact resize + color swap + normalize using the two-pass kernels.
+
+    Args:
+        src: uint8 CUDA tensor, shape ``(raw_h, raw_w, 3)``, HWC layout.
+        tables: precomputed int32 resample tables sized against the *cropped*
+            source ``(crop_h, crop_w)`` to ``(target_h, target_w)``.
+        target_h, target_w: output spatial dims.
+        means, stds: normalization in output channel order (R, G, B for
+            network_input.color_mode == 'rgb').
+        swap_rb: if True, source channel 0 → output B (BGR input, RGB network).
+        crop_offset_y/_x: load-time offset into `src` for a static crop. 0
+            means no crop.
+        crop_h/_w: effective source dims after crop. Defaults to src dims
+            when no crop is configured.
+        out: optional preallocated fp32 ``(1, 3, target_h, target_w)`` CUDA
+            tensor.
+        tmp: optional preallocated uint8 ``(3, crop_h/raw_h, target_w)`` CUDA
+            tensor used by the horizontal pass.
+
+    Returns:
+        fp32 ``(1, 3, target_h, target_w)`` on the same device as ``src``.
+    """
+    if not TRITON_AVAILABLE:
+        raise MissingDependencyError(
+            message="triton is not installed",
+            help_url="https://inference-models.roboflow.com/errors/runtime-environment/#missingdependencyerror",
+        )
+    if not src.is_cuda:
+        raise ModelInputError(
+            message=f"expected CUDA src tensor, got device={src.device}",
+            help_url="https://inference-models.roboflow.com/errors/input-validation/#modelinputerror",
+        )
+    if src.dtype != torch.uint8:
+        raise ModelInputError(
+            message=f"expected uint8 src, got {src.dtype}",
+            help_url="https://inference-models.roboflow.com/errors/input-validation/#modelinputerror",
+        )
+    if src.ndim != 3 or src.shape[2] != 3:
+        raise ModelInputError(
+            message=f"expected HWC 3-channel, got shape={tuple(src.shape)}",
+            help_url="https://inference-models.roboflow.com/errors/input-validation/#modelinputerror",
+        )
+
+    src = src.contiguous()
+    raw_src_h, raw_src_w = int(src.shape[0]), int(src.shape[1])
+    src_h = crop_h if crop_h is not None else raw_src_h
+    src_w = crop_w if crop_w is not None else raw_src_w
+    src_stride_h = int(src.stride(0))
+    src_stride_w = int(src.stride(1))
+
+    if out is None:
+        out = torch.empty(
+            (1, 3, target_h, target_w), dtype=torch.float32, device=src.device
+        )
+    else:
+        if tuple(out.shape) != (1, 3, target_h, target_w):
+            raise ModelRuntimeError(
+                message=(
+                    f"out has shape {tuple(out.shape)}, expected "
+                    f"(1, 3, {target_h}, {target_w})"
+                ),
+                help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+            )
+        if out.dtype != torch.float32 or not out.is_cuda:
+            raise ModelRuntimeError(
+                message="out must be fp32 CUDA tensor",
+                help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+            )
+
+    if tmp is None:
+        tmp = torch.empty((3, src_h, target_w), dtype=torch.uint8, device=src.device)
+    else:
+        if tuple(tmp.shape) != (3, src_h, target_w):
+            raise ModelRuntimeError(
+                message=(
+                    f"tmp has shape {tuple(tmp.shape)}, expected "
+                    f"(3, {src_h}, {target_w})"
+                ),
+                help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+            )
+        if tmp.dtype != torch.uint8 or not tmp.is_cuda:
+            raise ModelRuntimeError(
+                message="tmp must be uint8 CUDA tensor",
+                help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+            )
+
+    return triton_preprocess_rfdetr_stretch_two_pass_preallocated(
+        src=src,
+        out=out,
+        tmp=tmp,
+        tables=tables,
+        target_h=target_h,
+        target_w=target_w,
+        means=means,
+        stds=stds,
+        swap_rb=swap_rb,
+        launch_config=resolve_two_pass_launch_config(),
+        crop_offset_y=crop_offset_y,
+        crop_offset_x=crop_offset_x,
+        crop_h=crop_h,
+        crop_w=crop_w,
+    )

--- a/inference_models/inference_models/models/rfdetr/triton_preprocess_runtime.py
+++ b/inference_models/inference_models/models/rfdetr/triton_preprocess_runtime.py
@@ -1,0 +1,433 @@
+"""Runtime glue for RF-DETR TensorRT Triton preprocessing.
+
+This module owns the pieces that are specific to running the Triton
+preprocessor inside the TensorRT RF-DETR model adapter: fast-path eligibility,
+warning throttling, reusable CUDA buffers, and CUDA event handoff to the TRT
+inference stream. The numerical resize/normalize kernels live in
+``triton_preprocess.py``; this file only decides when and how to launch them.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from inference_models.configuration import (
+    INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED,
+)
+from inference_models.entities import ColorFormat, ImageDimensions
+from inference_models.models.common.roboflow.model_packages import (
+    ColorMode,
+    ImagePreProcessing,
+    NetworkInputDefinition,
+    PreProcessingMetadata,
+    ResizeMode,
+    StaticCropOffset,
+)
+
+try:
+    from inference_models.models.rfdetr.triton_preprocess import (
+        TRITON_AVAILABLE as _TRITON_AVAILABLE,
+        ResampleTables,
+        build_resample_tables,
+        resolve_two_pass_launch_config,
+        triton_preprocess_rfdetr_stretch_two_pass_preallocated,
+    )
+except ImportError:  # pragma: no cover - import-time dependency guard
+    _TRITON_AVAILABLE = False
+    ResampleTables = None
+    build_resample_tables = None
+    resolve_two_pass_launch_config = None
+    triton_preprocess_rfdetr_stretch_two_pass_preallocated = None
+
+
+_FAST_PATH_ENABLED = INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED
+_BUFFER_RING_SIZE = 3
+
+
+@dataclass(frozen=True)
+class FastPreprocessResult:
+    """Result returned after the Triton preprocessing work is enqueued.
+
+    Attributes:
+        tensor: CUDA fp32 tensor with shape ``(1, 3, target_h, target_w)`` in
+            network color order and normalized with the model's mean/std.
+        metadata: Single-item preprocessing metadata list matching the reference
+            RF-DETR TRT preprocessing contract.
+        ready_event: Event recorded on the preprocessing stream after the HtoD
+            copy and both Triton kernels. The TensorRT stream must wait on this
+            event before consuming ``tensor``.
+    """
+
+    tensor: torch.Tensor
+    metadata: List[PreProcessingMetadata]
+    ready_event: torch.cuda.Event
+
+
+class FastPreprocessState:
+    """Reusable buffers for one source shape and one network input shape.
+
+    The state is keyed by ``(src_h, src_w, target_h, target_w)`` because those
+    dimensions define both the PIL fixed-point resample tables and every buffer
+    size used by the Triton kernels.
+
+    Attributes:
+        pinned_hosts: Ring of pinned CPU HWC uint8 staging tensors. The incoming numpy
+            image is copied here first so the following host-to-device copy can
+            be submitted as ``non_blocking=True`` on the preprocessing stream.
+        src_gpus: Ring of CUDA HWC uint8 tensors consumed by the horizontal Triton kernel.
+        out_buffers: Ring of CUDA fp32 ``(1, 3, target_h, target_w)`` outputs.
+            The returned tensor can still be owned by TensorRT or response
+            finalization while Python prepares the next frame, so the ring avoids
+            overwriting an output that downstream work may still read.
+        tmp_buffers: Matching ring of CUDA uint8 ``(3, src_h, target_w)``
+            horizontal-resize scratch buffers. They are paired with output
+            buffers so each in-flight preprocessing submission has independent
+            scratch storage until the vertical kernel finishes.
+        tables: CUDA int32 PIL-compatible resample tables. ``xmin``/``wx`` are
+            used by the horizontal pass and ``ymin``/``wy`` by the vertical pass.
+        launch_config: Tuned block sizes for the two Triton kernels, resolved
+            once from env vars when the shape-specific state is built.
+    """
+
+    __slots__ = (
+        "src_h",
+        "src_w",
+        "target_h",
+        "target_w",
+        "pinned_hosts",
+        "src_gpus",
+        "out_buffers",
+        "tmp_buffers",
+        "out_buffer_index",
+        "tables",
+        "launch_config",
+    )
+
+    def __init__(
+        self,
+        src_h: int,
+        src_w: int,
+        target_h: int,
+        target_w: int,
+        pinned_hosts: List[torch.Tensor],
+        src_gpus: List[torch.Tensor],
+        out_buffers: List[torch.Tensor],
+        tmp_buffers: List[torch.Tensor],
+        tables: ResampleTables,
+        launch_config: Tuple[int, int, int, int],
+    ) -> None:
+        self.src_h = src_h
+        self.src_w = src_w
+        self.target_h = target_h
+        self.target_w = target_w
+        self.pinned_hosts = pinned_hosts
+        self.src_gpus = src_gpus
+        self.out_buffers = out_buffers
+        self.tmp_buffers = tmp_buffers
+        self.out_buffer_index = 0
+        self.tables = tables
+        self.launch_config = launch_config
+
+    @classmethod
+    def build(
+        cls,
+        src_h: int,
+        src_w: int,
+        target_h: int,
+        target_w: int,
+        device: torch.device,
+    ) -> "FastPreprocessState":
+        """Allocate shape-specific buffers and build GPU resample tables."""
+        pinned_hosts = [
+            torch.empty((src_h, src_w, 3), dtype=torch.uint8, pin_memory=True)
+            for _ in range(_BUFFER_RING_SIZE)
+        ]
+        src_gpus = [
+            torch.empty((src_h, src_w, 3), dtype=torch.uint8, device=device)
+            for _ in range(_BUFFER_RING_SIZE)
+        ]
+        out_buffers = [
+            torch.empty((1, 3, target_h, target_w), dtype=torch.float32, device=device)
+            for _ in range(_BUFFER_RING_SIZE)
+        ]
+        tmp_buffers = [
+            torch.empty((3, src_h, target_w), dtype=torch.uint8, device=device)
+            for _ in range(_BUFFER_RING_SIZE)
+        ]
+        tables = build_resample_tables(
+            src_h=src_h,
+            src_w=src_w,
+            target_h=target_h,
+            target_w=target_w,
+            device=device,
+        )
+        return cls(
+            src_h=src_h,
+            src_w=src_w,
+            target_h=target_h,
+            target_w=target_w,
+            pinned_hosts=pinned_hosts,
+            src_gpus=src_gpus,
+            out_buffers=out_buffers,
+            tmp_buffers=tmp_buffers,
+            tables=tables,
+            launch_config=resolve_two_pass_launch_config(),
+        )
+
+    def is_stale(self, src_h: int, src_w: int, target_h: int, target_w: int) -> bool:
+        """Return true when image/network dimensions no longer match state."""
+        return (
+            self.src_h != src_h
+            or self.src_w != src_w
+            or self.target_h != target_h
+            or self.target_w != target_w
+        )
+
+    def next_buffers(
+        self,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return the next output/scratch pair from the ring."""
+        idx = self.out_buffer_index
+        pinned_host = self.pinned_hosts[idx]
+        src_gpu = self.src_gpus[idx]
+        out = self.out_buffers[idx]
+        tmp = self.tmp_buffers[idx]
+        self.out_buffer_index = (idx + 1) % len(self.out_buffers)
+        return pinned_host, src_gpu, out, tmp
+
+
+class FastPreprocessRuntime:
+    """Eligibility, launch, and CUDA handoff manager for Triton preprocessing.
+
+    ``RFDetrForInstanceSegmentationTRT`` owns one runtime instance for the life
+    of the model adapter. The runtime keeps all mutable fast-path state here so
+    the adapter only has to call ``try_preprocess(...)`` and, when a result is
+    returned, make the TensorRT stream wait on ``result.ready_event``.
+
+    Stream lifetime:
+        The caller supplies the preprocessing CUDA stream for each launch. This
+        runtime records the returned event on that stream after the host-to-
+        device copy and both Triton kernels. The output tensor also records the
+        stream so PyTorch's caching allocator cannot reuse its storage before
+        the asynchronous preprocessing work has finished.
+    """
+
+    def __init__(self, device: torch.device) -> None:
+        self._device = device
+        self._state: Optional[FastPreprocessState] = None
+        self._warned_reasons: set[str] = set()
+
+    def try_preprocess(
+        self,
+        images,
+        input_color_format: Optional[ColorFormat],
+        image_size: Optional[Tuple[int, int]],
+        image_pre_processing: ImagePreProcessing,
+        network_input: NetworkInputDefinition,
+        stream: torch.cuda.Stream,
+    ) -> Optional[FastPreprocessResult]:
+        """Enqueue Triton preprocessing when the request is supported.
+
+        Args:
+            images: Single uint8 HWC numpy image, or a single-item list
+                containing one. Batch sizes greater than one use the reference
+                preprocessing path.
+            input_color_format: Caller-provided image color order. ``None`` is
+                treated as BGR, matching the model adapter default.
+            image_size: Per-call size override. Overrides are rejected because
+                the fast path is keyed to the model's configured network input.
+            image_pre_processing: Model package preprocessing config used for
+                fast-path eligibility checks.
+            network_input: Model package network-input config. Its resize mode,
+                color mode, normalization, and target size define the kernel
+                contract.
+            stream: CUDA stream where the HtoD copy and Triton kernels are
+                enqueued. It must be a real stream when the request is eligible.
+
+        Returns:
+            ``FastPreprocessResult`` after the GPU work has been scheduled, or
+            ``None`` when the opt-in flag is disabled or the request falls
+            outside the conservative fast-path contract. In that case the caller
+            should run the reference preprocessing path.
+        """
+        if not _FAST_PATH_ENABLED:
+            return None
+        unsupported_reason = self._unsupported_reason(
+            images=images,
+            image_size=image_size,
+            image_pre_processing=image_pre_processing,
+            network_input=network_input,
+        )
+        if unsupported_reason is not None:
+            self._warn_unsupported(unsupported_reason)
+            return None
+
+        candidate = images[0] if isinstance(images, list) else images
+        caller_mode = (
+            ColorMode(input_color_format)
+            if input_color_format is not None
+            else ColorMode.BGR
+        )
+        swap_rb = caller_mode != network_input.color_mode
+
+        means, stds = network_input.normalization
+        means_t = (float(means[0]), float(means[1]), float(means[2]))
+        stds_t = (float(stds[0]), float(stds[1]), float(stds[2]))
+        target_h = network_input.training_input_size.height
+        target_w = network_input.training_input_size.width
+        orig_h, orig_w = int(candidate.shape[0]), int(candidate.shape[1])
+
+        state = self._state
+        if state is None or state.is_stale(
+            src_h=orig_h,
+            src_w=orig_w,
+            target_h=target_h,
+            target_w=target_w,
+        ):
+            state = FastPreprocessState.build(
+                src_h=orig_h,
+                src_w=orig_w,
+                target_h=target_h,
+                target_w=target_w,
+                device=self._device,
+            )
+            self._state = state
+
+        pinned_host, src_gpu, out_buffer, tmp_buffer = state.next_buffers()
+        preproc_ready_event = getattr(pinned_host, "_preproc_ready_event", None)
+        if preproc_ready_event is not None:
+            preproc_ready_event.synchronize()
+        np.copyto(pinned_host.numpy(), candidate, casting="no")
+
+        with torch.cuda.stream(stream):
+            trt_consumed_event = getattr(out_buffer, "_trt_consumed_event", None)
+            if trt_consumed_event is not None:
+                stream.wait_event(trt_consumed_event)
+            src_gpu.copy_(pinned_host, non_blocking=True)
+            triton_preprocess_rfdetr_stretch_two_pass_preallocated(
+                src=src_gpu,
+                out=out_buffer,
+                tmp=tmp_buffer,
+                tables=state.tables,
+                target_h=target_h,
+                target_w=target_w,
+                means=means_t,
+                stds=stds_t,
+                swap_rb=swap_rb,
+                launch_config=state.launch_config,
+            )
+            ready_event = torch.cuda.Event()
+            ready_event.record(stream)
+            out_buffer._trt_ready_event = ready_event  # type: ignore[attr-defined]
+            pinned_host._preproc_ready_event = ready_event  # type: ignore[attr-defined]
+            out_buffer.record_stream(stream)
+
+        metadata = [
+            PreProcessingMetadata(
+                pad_left=0,
+                pad_top=0,
+                pad_right=0,
+                pad_bottom=0,
+                original_size=ImageDimensions(width=orig_w, height=orig_h),
+                size_after_pre_processing=ImageDimensions(
+                    width=orig_w,
+                    height=orig_h,
+                ),
+                inference_size=ImageDimensions(width=target_w, height=target_h),
+                scale_width=target_w / orig_w,
+                scale_height=target_h / orig_h,
+                static_crop_offset=StaticCropOffset(
+                    offset_x=0,
+                    offset_y=0,
+                    crop_width=orig_w,
+                    crop_height=orig_h,
+                ),
+            )
+        ]
+        out_buffer._pre_processing_meta = metadata  # type: ignore[attr-defined]
+        return FastPreprocessResult(
+            tensor=out_buffer,
+            metadata=metadata,
+            ready_event=ready_event,
+        )
+
+    def _unsupported_reason(
+        self,
+        images,
+        image_size: Optional[Tuple[int, int]],
+        image_pre_processing: ImagePreProcessing,
+        network_input: NetworkInputDefinition,
+    ) -> Optional[str]:
+        """Explain why the request must use the reference preprocessing path."""
+        if not _TRITON_AVAILABLE:
+            return "triton is not installed"
+        if self._device.type != "cuda":
+            return "CUDA device is required"
+        if image_size is not None:
+            return "custom image_size overrides are not supported"
+
+        # Overrides can only disable configured transforms; they cannot enable
+        # transforms. The fast path deliberately rejects model configs that ask
+        # for transforms whose pixel semantics are not implemented in Triton.
+        if (
+            (
+                image_pre_processing.static_crop is not None
+                and image_pre_processing.static_crop.enabled
+            )
+            or (
+                image_pre_processing.contrast is not None
+                and image_pre_processing.contrast.enabled
+            )
+            or (
+                image_pre_processing.grayscale is not None
+                and image_pre_processing.grayscale.enabled
+            )
+        ):
+            return "static crop, contrast, and grayscale preprocessing are unsupported"
+
+        if network_input.dataset_version_resize_dimensions is not None:
+            return "dataset-version resize is unsupported"
+        if network_input.input_channels != 3:
+            return "only 3-channel inputs are supported"
+        if network_input.scaling_factor not in (None, 255):
+            return "only scaling_factor None or 255 is supported"
+        if network_input.normalization is None:
+            return "normalization is required"
+        if network_input.resize_mode not in (
+            ResizeMode.STRETCH_TO,
+            ResizeMode.LETTERBOX,
+            ResizeMode.CENTER_CROP,
+            ResizeMode.LETTERBOX_REFLECT_EDGES,
+        ):
+            return f"resize mode {network_input.resize_mode!r} is unsupported"
+
+        if isinstance(images, list):
+            if len(images) != 1:
+                return "only batch size 1 is supported"
+            candidate = images[0]
+        else:
+            candidate = images
+        if not isinstance(candidate, np.ndarray):
+            return "only numpy ndarray inputs are supported"
+        if (
+            candidate.dtype != np.uint8
+            or candidate.ndim != 3
+            or candidate.shape[2] != 3
+        ):
+            return "input must be uint8 HWC with 3 channels"
+        return None
+
+    def _warn_unsupported(self, reason: str) -> None:
+        if reason in self._warned_reasons:
+            return
+        self._warned_reasons.add(reason)
+        warnings.warn(
+            f"RF-DETR Triton preprocess path is unsupported: {reason}",
+            RuntimeWarning,
+            stacklevel=4,
+        )

--- a/inference_models/inference_models/models/rfdetr/triton_preprocess_runtime.py
+++ b/inference_models/inference_models/models/rfdetr/triton_preprocess_runtime.py
@@ -28,6 +28,10 @@ from inference_models.models.common.roboflow.model_packages import (
     ResizeMode,
     StaticCropOffset,
 )
+from inference_models.models.rfdetr.triton_jit_fallback import (
+    is_triton_jit_failure,
+    warn_triton_jit_fallback,
+)
 
 try:
     from inference_models.models.rfdetr.triton_preprocess import (
@@ -221,6 +225,7 @@ class FastPreprocessRuntime:
         self._device = device
         self._state: Optional[FastPreprocessState] = None
         self._warned_reasons: set[str] = set()
+        self._jit_disabled = False
 
     def try_preprocess(
         self,
@@ -255,8 +260,9 @@ class FastPreprocessRuntime:
             outside the conservative fast-path contract. In that case the caller
             should run the reference preprocessing path.
         """
-        if not _FAST_PATH_ENABLED:
+        if not _FAST_PATH_ENABLED or self._jit_disabled:
             return None
+
         unsupported_reason = self._unsupported_reason(
             images=images,
             image_size=image_size,
@@ -304,28 +310,39 @@ class FastPreprocessRuntime:
             preproc_ready_event.synchronize()
         np.copyto(pinned_host.numpy(), candidate, casting="no")
 
-        with torch.cuda.stream(stream):
-            trt_consumed_event = getattr(out_buffer, "_trt_consumed_event", None)
-            if trt_consumed_event is not None:
-                stream.wait_event(trt_consumed_event)
-            src_gpu.copy_(pinned_host, non_blocking=True)
-            triton_preprocess_rfdetr_stretch_two_pass_preallocated(
-                src=src_gpu,
-                out=out_buffer,
-                tmp=tmp_buffer,
-                tables=state.tables,
-                target_h=target_h,
-                target_w=target_w,
-                means=means_t,
-                stds=stds_t,
-                swap_rb=swap_rb,
-                launch_config=state.launch_config,
+        try:
+            with torch.cuda.stream(stream):
+                trt_consumed_event = getattr(out_buffer, "_trt_consumed_event", None)
+                if trt_consumed_event is not None:
+                    stream.wait_event(trt_consumed_event)
+                src_gpu.copy_(pinned_host, non_blocking=True)
+                triton_preprocess_rfdetr_stretch_two_pass_preallocated(
+                    src=src_gpu,
+                    out=out_buffer,
+                    tmp=tmp_buffer,
+                    tables=state.tables,
+                    target_h=target_h,
+                    target_w=target_w,
+                    means=means_t,
+                    stds=stds_t,
+                    swap_rb=swap_rb,
+                    launch_config=state.launch_config,
+                )
+                ready_event = torch.cuda.Event()
+                ready_event.record(stream)
+                out_buffer._trt_ready_event = ready_event  # type: ignore[attr-defined]
+                pinned_host._preproc_ready_event = ready_event  # type: ignore[attr-defined]
+                out_buffer.record_stream(stream)
+        except Exception as exc:
+            if not is_triton_jit_failure(exc):
+                raise
+            self._jit_disabled = True
+            warn_triton_jit_fallback(
+                path="preprocess",
+                exc=exc,
+                warned_reasons=self._warned_reasons,
             )
-            ready_event = torch.cuda.Event()
-            ready_event.record(stream)
-            out_buffer._trt_ready_event = ready_event  # type: ignore[attr-defined]
-            pinned_host._preproc_ready_event = ready_event  # type: ignore[attr-defined]
-            out_buffer.record_stream(stream)
+            return None
 
         metadata = [
             PreProcessingMetadata(

--- a/inference_models/tests/integration_tests/models/test_rfdetr_seg_predictions_trt.py
+++ b/inference_models/tests/integration_tests/models/test_rfdetr_seg_predictions_trt.py
@@ -1,8 +1,42 @@
+import os
+
 import numpy as np
 import pytest
 import torch
 
+from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.rle_utils import coco_rle_masks_to_torch_mask
+
+
+def _assert_instance_segmentation_predictions_match(actual, expected) -> None:
+    assert len(actual) == len(expected)
+    for actual_element, expected_element in zip(actual, expected):
+        torch.testing.assert_close(
+            actual_element.xyxy.cpu(),
+            expected_element.xyxy.cpu(),
+            atol=1.0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            actual_element.confidence.cpu(),
+            expected_element.confidence.cpu(),
+            atol=1e-4,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            actual_element.class_id.cpu(),
+            expected_element.class_id.cpu(),
+            atol=0,
+            rtol=0,
+        )
+
+        actual_mask = actual_element.mask.detach().to(torch.bool).cpu()
+        expected_mask = expected_element.mask.detach().to(torch.bool).cpu()
+        assert tuple(actual_mask.shape) == tuple(expected_mask.shape)
+        intersection = torch.logical_and(actual_mask, expected_mask).sum().item()
+        union = torch.logical_or(actual_mask, expected_mask).sum().item()
+        assert union > 0
+        assert intersection / union >= 0.999
 
 
 @pytest.mark.slow
@@ -428,6 +462,69 @@ def test_trt_package_torch_batch(
         atol=5,
     )
     assert 16179 <= predictions[1].mask.cpu().sum().item() <= 16229
+
+
+@pytest.mark.slow
+@pytest.mark.trt_extras
+def test_trt_triton_preprocess_output_matches_reference_preprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    rfdetr_seg_asl_trt_package: str,
+    asl_image_numpy: np.ndarray,
+) -> None:
+    pytest.importorskip("triton")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Triton preprocessing parity")
+
+    from inference_models.models.rfdetr import triton_preprocess_runtime
+    from inference_models.models.rfdetr.rfdetr_instance_segmentation_trt import (
+        RFDetrForInstanceSegmentationTRT,
+    )
+
+    model_package = os.getenv(
+        "RFDETR_SEG_TRT_PACKAGE_PATH",
+        rfdetr_seg_asl_trt_package,
+    )
+    try:
+        model = RFDetrForInstanceSegmentationTRT.from_pretrained(
+            model_name_or_path=model_package,
+            engine_host_code_allowed=True,
+        )
+    except CorruptedModelPackageError as error:
+        if "Platform specific tag mismatch" in str(error):
+            pytest.skip("TRT engine package is not compatible with this platform")
+        raise
+
+    # This test exercises the runtime fast path directly; initialize the
+    # adapter-level gate/runtime even when the process default leaves it off.
+    model._fast_preprocess_enabled = True
+    model._fast_preprocess_runtime = triton_preprocess_runtime.FastPreprocessRuntime(
+        device=model._device
+    )
+    monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", False)
+    reference_predictions = model(asl_image_numpy)
+
+    original_triton_preprocess = (
+        triton_preprocess_runtime.triton_preprocess_rfdetr_stretch_two_pass_preallocated
+    )
+    triton_calls = {"count": 0}
+
+    def counting_triton_preprocess(*args, **kwargs):
+        triton_calls["count"] += 1
+        return original_triton_preprocess(*args, **kwargs)
+
+    monkeypatch.setattr(
+        triton_preprocess_runtime,
+        "triton_preprocess_rfdetr_stretch_two_pass_preallocated",
+        counting_triton_preprocess,
+    )
+    monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", True)
+    triton_predictions = model(asl_image_numpy)
+
+    assert triton_calls["count"] == 1
+    _assert_instance_segmentation_predictions_match(
+        actual=triton_predictions,
+        expected=reference_predictions,
+    )
 
 
 @pytest.mark.slow

--- a/inference_models/tests/unit_tests/models/rfdetr/test_triton_jit_fallback.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_triton_jit_fallback.py
@@ -1,4 +1,7 @@
+import importlib
 import logging
+import sys
+from types import ModuleType
 
 import numpy as np
 import pytest
@@ -119,6 +122,67 @@ def test_is_triton_jit_failure_detects_out_of_resources_type() -> None:
     exc = OutOfResources(required=131072, limit=101376, name="shared memory")
 
     assert is_triton_jit_failure(exc)
+
+
+def _reload_triton_jit_fallback_with_fake_errors(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    error_classes: dict[str, type[BaseException]],
+):
+    fake_errors = ModuleType("triton.runtime.errors")
+    for name, cls in error_classes.items():
+        setattr(fake_errors, name, cls)
+
+    fake_runtime = ModuleType("triton.runtime")
+    fake_runtime.errors = fake_errors
+    fake_triton = ModuleType("triton")
+    fake_triton.runtime = fake_runtime
+
+    monkeypatch.setitem(sys.modules, "triton", fake_triton)
+    monkeypatch.setitem(sys.modules, "triton.runtime", fake_runtime)
+    monkeypatch.setitem(sys.modules, "triton.runtime.errors", fake_errors)
+
+    import inference_models.models.rfdetr.triton_jit_fallback as fallback_mod
+
+    reloaded_fallback_mod = importlib.reload(fallback_mod)
+
+    return reloaded_fallback_mod
+
+
+@pytest.fixture
+def triton_jit_fallback_module():
+    import inference_models.models.rfdetr.triton_jit_fallback as fallback_mod
+
+    yield fallback_mod
+
+    importlib.reload(fallback_mod)
+
+
+def test_triton_jit_exception_types_import_independently(
+    monkeypatch: pytest.MonkeyPatch,
+    triton_jit_fallback_module,
+) -> None:
+    class FakeOutOfResources(Exception):
+        pass
+
+    class FakePTXASError(Exception):
+        pass
+
+    fallback_mod = _reload_triton_jit_fallback_with_fake_errors(
+        monkeypatch=monkeypatch,
+        error_classes={"OutOfResources": FakeOutOfResources},
+    )
+
+    assert fallback_mod._TRITON_JIT_EXCEPTION_TYPES == (FakeOutOfResources,)
+    assert fallback_mod.is_triton_jit_failure(FakeOutOfResources())
+
+    fallback_mod = _reload_triton_jit_fallback_with_fake_errors(
+        monkeypatch=monkeypatch,
+        error_classes={"PTXASError": FakePTXASError},
+    )
+
+    assert fallback_mod._TRITON_JIT_EXCEPTION_TYPES == (FakePTXASError,)
+    assert fallback_mod.is_triton_jit_failure(FakePTXASError())
 
 
 def test_warn_triton_jit_fallback_logs_once(caplog: pytest.LogCaptureFixture) -> None:

--- a/inference_models/tests/unit_tests/models/rfdetr/test_triton_jit_fallback.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_triton_jit_fallback.py
@@ -1,0 +1,248 @@
+import logging
+
+import numpy as np
+import pytest
+import torch
+
+from inference_models.entities import ImageDimensions
+from inference_models.models.common.roboflow.model_packages import (
+    ColorMode,
+    ImagePreProcessing,
+    NetworkInputDefinition,
+    PreProcessingMetadata,
+    ResizeMode,
+    StaticCropOffset,
+    TrainingInputSize,
+)
+from inference_models.models.rfdetr import common as rfdetr_common
+from inference_models.models.rfdetr import triton_preprocess_runtime
+from inference_models.models.rfdetr.class_remapping import ClassesReMapping
+from inference_models.models.rfdetr.triton_jit_fallback import (
+    is_triton_jit_failure,
+    warn_triton_jit_fallback,
+)
+
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+def _network_input(target_h: int = 64, target_w: int = 64) -> NetworkInputDefinition:
+    return NetworkInputDefinition(
+        training_input_size=TrainingInputSize(height=target_h, width=target_w),
+        dataset_version_resize_dimensions=None,
+        dynamic_spatial_size_supported=False,
+        color_mode=ColorMode.RGB,
+        resize_mode=ResizeMode.STRETCH_TO,
+        input_channels=3,
+        scaling_factor=255,
+        normalization=[list(_IMAGENET_MEAN), list(_IMAGENET_STD)],
+    )
+
+
+def _metadata() -> PreProcessingMetadata:
+    size = ImageDimensions(height=64, width=64)
+    return PreProcessingMetadata(
+        pad_left=0,
+        pad_top=0,
+        pad_right=0,
+        pad_bottom=0,
+        original_size=size,
+        size_after_pre_processing=size,
+        inference_size=size,
+        scale_width=1.0,
+        scale_height=1.0,
+        static_crop_offset=StaticCropOffset(
+            offset_x=0,
+            offset_y=0,
+            crop_width=64,
+            crop_height=64,
+        ),
+    )
+
+
+def _class_mapping(device: torch.device) -> ClassesReMapping:
+    return ClassesReMapping(
+        remaining_class_ids=torch.arange(2, dtype=torch.int64, device=device),
+        class_mapping=torch.arange(2, dtype=torch.int64, device=device),
+    )
+
+
+def _single_detection_inputs(device: torch.device):
+    bboxes = torch.tensor(
+        [[0.50, 0.50, 0.50, 0.50], [0.25, 0.25, 0.20, 0.20]],
+        dtype=torch.float32,
+        device=device,
+    )
+    logits = torch.tensor(
+        [[4.0, -4.0], [-4.0, -4.0]],
+        dtype=torch.float32,
+        device=device,
+    )
+    masks = torch.ones((2, 8, 8), dtype=torch.float32, device=device)
+    return bboxes, logits, masks
+
+
+def test_is_triton_jit_failure_detects_missing_c_compiler() -> None:
+    exc = RuntimeError(
+        "Failed to find C compiler. Please specify via CC environment variable."
+    )
+
+    assert is_triton_jit_failure(exc)
+
+
+def test_is_triton_jit_failure_detects_ptxas_message() -> None:
+    exc = RuntimeError(
+        "PTXAS error: Internal Triton PTX codegen error\n"
+        "ptxas-blackwell fatal: Value 'sm_110a' is not defined"
+    )
+
+    assert is_triton_jit_failure(exc)
+
+
+def test_is_triton_jit_failure_rejects_unrelated_runtime_error() -> None:
+    assert not is_triton_jit_failure(RuntimeError("CUDA out of memory"))
+
+
+def test_is_triton_jit_failure_detects_out_of_resources_message() -> None:
+    exc = RuntimeError(
+        "out of resource: shared memory, Required: 131072, Hardware limit: 101376. "
+        "Reducing block sizes or `num_stages` may help."
+    )
+
+    assert is_triton_jit_failure(exc)
+
+
+def test_is_triton_jit_failure_detects_out_of_resources_type() -> None:
+    pytest.importorskip("triton")
+    from triton.runtime.errors import OutOfResources
+
+    exc = OutOfResources(required=131072, limit=101376, name="shared memory")
+
+    assert is_triton_jit_failure(exc)
+
+
+def test_warn_triton_jit_fallback_logs_once(caplog: pytest.LogCaptureFixture) -> None:
+    warned_reasons: set[str] = set()
+    exc = RuntimeError("Failed to find C compiler")
+
+    with caplog.at_level(logging.ERROR):
+        warn_triton_jit_fallback(
+            path="preprocess",
+            exc=exc,
+            warned_reasons=warned_reasons,
+        )
+        warn_triton_jit_fallback(
+            path="preprocess",
+            exc=exc,
+            warned_reasons=warned_reasons,
+        )
+
+    matching_records = [
+        record
+        for record in caplog.records
+        if "RF-DETR Triton preprocess JIT compilation failed" in record.message
+    ]
+    assert len(matching_records) == 1
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_try_preprocess_falls_back_on_triton_jit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", True)
+    monkeypatch.setattr(triton_preprocess_runtime, "_TRITON_AVAILABLE", True)
+
+    runtime = triton_preprocess_runtime.FastPreprocessRuntime(
+        device=torch.device("cuda")
+    )
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+    stream = torch.cuda.Stream(device=torch.device("cuda"))
+
+    calls = {"count": 0}
+
+    def failing_kernel(*args, **kwargs):
+        calls["count"] += 1
+        raise RuntimeError(
+            "Failed to find C compiler. Please specify via CC environment variable."
+        )
+
+    monkeypatch.setattr(
+        triton_preprocess_runtime,
+        "triton_preprocess_rfdetr_stretch_two_pass_preallocated",
+        failing_kernel,
+    )
+
+    result = runtime.try_preprocess(
+        images=image,
+        input_color_format="bgr",
+        image_size=None,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=_network_input(target_h=64, target_w=64),
+        stream=stream,
+    )
+
+    assert result is None
+    assert calls["count"] == 1
+    assert runtime._jit_disabled is True
+
+    second_result = runtime.try_preprocess(
+        images=image,
+        input_color_format="bgr",
+        image_size=None,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=_network_input(target_h=64, target_w=64),
+        stream=stream,
+    )
+
+    assert second_result is None
+    assert calls["count"] == 1
+
+
+def test_postproc_falls_back_on_triton_jit_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rfdetr_common, "_TRITON_POSTPROC_ENABLED", True)
+    monkeypatch.setattr(rfdetr_common, "_TRITON_POSTPROC_JIT_DISABLED", False)
+    rfdetr_common._TRITON_POSTPROC_JIT_WARNED_REASONS.clear()
+
+    calls = {"count": 0}
+
+    def failing_triton(**kwargs):
+        calls["count"] += 1
+        raise RuntimeError(
+            "Failed to find C compiler. Please specify via CC environment variable."
+        )
+
+    monkeypatch.setattr(
+        rfdetr_common,
+        "post_process_single_instance_segmentation_result_to_rle_masks_triton",
+        failing_triton,
+    )
+
+    device = torch.device("cpu")
+    bboxes, logits, masks = _single_detection_inputs(device)
+    results = rfdetr_common.post_process_instance_segmentation_results_to_rle_masks(
+        bboxes=bboxes.unsqueeze(0),
+        logits=logits.unsqueeze(0),
+        masks=masks.unsqueeze(0),
+        pre_processing_meta=[_metadata()],
+        threshold=0.4,
+        num_classes=2,
+        classes_re_mapping=_class_mapping(device),
+    )
+
+    assert len(results) == 1
+    assert results[0].confidence.shape == (1,)
+    assert calls["count"] == 1
+    assert rfdetr_common._TRITON_POSTPROC_JIT_DISABLED is True
+
+    second_results = rfdetr_common.post_process_instance_segmentation_results_to_rle_masks(
+        bboxes=bboxes.unsqueeze(0),
+        logits=logits.unsqueeze(0),
+        masks=masks.unsqueeze(0),
+        pre_processing_meta=[_metadata()],
+        threshold=0.4,
+        num_classes=2,
+        classes_re_mapping=_class_mapping(device),
+    )
+
+    assert len(second_results) == 1
+    assert calls["count"] == 1

--- a/inference_models/tests/unit_tests/models/rfdetr/test_triton_postprocess.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_triton_postprocess.py
@@ -1,0 +1,671 @@
+import numpy as np
+import pytest
+import torch
+
+from inference_models.entities import ImageDimensions
+from inference_models.models.common.rle_utils import coco_rle_masks_to_numpy_mask
+from inference_models.models.common.roboflow.model_packages import (
+    PreProcessingMetadata,
+    StaticCropOffset,
+)
+from inference_models.models.rfdetr import common as rfdetr_common
+from inference_models.models.rfdetr import triton_postprocess
+from inference_models.models.rfdetr.class_remapping import ClassesReMapping
+from inference_models.models.rfdetr.common import (
+    _post_process_single_instance_segmentation_result_to_rle_masks,
+    post_process_instance_segmentation_results_to_rle_masks,
+)
+from inference_models.models.rfdetr.triton_postprocess import (
+    _INTERPOLATION_WEIGHT_CACHE,
+    _MAX_INTERPOLATION_WEIGHT_CACHE_ENTRIES,
+    _get_interpolation_weights,
+    _supports_triton_postprocess_path,
+    _unsupported_triton_postprocess_reason,
+    post_process_single_instance_segmentation_result_to_rle_masks_triton,
+)
+
+
+def _metadata(
+    height: int = 64,
+    width: int = 64,
+    padding: tuple = (0, 0, 0, 0),
+    static_crop_offset: tuple = (0, 0),
+    size_after_pre_processing: tuple = None,
+) -> PreProcessingMetadata:
+    size = ImageDimensions(height=height, width=width)
+    pad_left, pad_top, pad_right, pad_bottom = padding
+    offset_x, offset_y = static_crop_offset
+    preprocessed_height, preprocessed_width = size_after_pre_processing or (
+        height,
+        width,
+    )
+    preprocessed_size = ImageDimensions(
+        height=preprocessed_height,
+        width=preprocessed_width,
+    )
+    return PreProcessingMetadata(
+        pad_left=pad_left,
+        pad_top=pad_top,
+        pad_right=pad_right,
+        pad_bottom=pad_bottom,
+        original_size=size,
+        size_after_pre_processing=preprocessed_size,
+        inference_size=size,
+        scale_width=1.0,
+        scale_height=1.0,
+        static_crop_offset=StaticCropOffset(
+            offset_x=offset_x,
+            offset_y=offset_y,
+            crop_width=preprocessed_width,
+            crop_height=preprocessed_height,
+        ),
+        nonsquare_intermediate_size=None,
+    )
+
+
+def _class_mapping(device: torch.device, num_classes: int = 2) -> ClassesReMapping:
+    return ClassesReMapping(
+        remaining_class_ids=torch.arange(num_classes, dtype=torch.int64, device=device),
+        class_mapping=torch.arange(num_classes, dtype=torch.int64, device=device),
+    )
+
+
+def _single_detection_inputs(device: torch.device):
+    bboxes = torch.tensor(
+        [
+            [0.50, 0.50, 0.50, 0.50],
+            [0.25, 0.25, 0.20, 0.20],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    logits = torch.tensor(
+        [
+            [4.0, -4.0],
+            [-4.0, -4.0],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    masks = torch.full((2, 8, 8), -2.0, dtype=torch.float32, device=device)
+    masks[0, 2:6, 2:6] = 2.0
+    return bboxes, logits, masks
+
+
+def _support_kwargs(
+    num_queries: int = 2,
+    num_classes: int = 2,
+    mask_size: tuple = (8, 8),
+) -> dict:
+    device = torch.device("cpu")
+    return {
+        "image_bboxes": torch.full(
+            (num_queries, 4),
+            0.5,
+            dtype=torch.float32,
+            device=device,
+        ),
+        "image_scores": torch.full(
+            (num_queries, num_classes),
+            0.1,
+            dtype=torch.float32,
+            device=device,
+        ),
+        "image_masks": torch.zeros(
+            (num_queries, *mask_size),
+            dtype=torch.float32,
+            device=device,
+        ),
+        "image_meta": _metadata(),
+        "threshold": 0.4,
+        "classes_re_mapping": _class_mapping(device, num_classes=num_classes),
+    }
+
+
+def _assert_detections_equal(actual, expected) -> None:
+    torch.testing.assert_close(actual.xyxy.cpu(), expected.xyxy.cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(
+        actual.confidence.cpu(), expected.confidence.cpu(), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        actual.class_id.cpu(), expected.class_id.cpu(), rtol=0, atol=0
+    )
+    actual_mask = coco_rle_masks_to_numpy_mask(actual.mask)
+    expected_mask = coco_rle_masks_to_numpy_mask(expected.mask)
+    np.testing.assert_array_equal(actual_mask, expected_mask)
+
+
+def _expected_result(
+    bboxes: torch.Tensor,
+    logits: torch.Tensor,
+    masks: torch.Tensor,
+    metadata: PreProcessingMetadata,
+    threshold,
+    classes_re_mapping,
+    num_classes: int = 2,
+):
+    return _post_process_single_instance_segmentation_result_to_rle_masks(
+        image_bboxes=bboxes,
+        image_logits=torch.sigmoid(logits),
+        image_masks=masks,
+        image_meta=metadata,
+        threshold=threshold,
+        num_classes=num_classes,
+        classes_re_mapping=classes_re_mapping,
+    )
+
+
+def _batched_inputs(device: torch.device):
+    bboxes = torch.tensor(
+        [
+            [
+                [0.50, 0.50, 0.50, 0.50],
+                [0.25, 0.25, 0.20, 0.20],
+                [0.75, 0.75, 0.15, 0.15],
+            ],
+            [
+                [0.50, 0.50, 0.40, 0.40],
+                [0.25, 0.25, 0.20, 0.20],
+                [0.75, 0.75, 0.15, 0.15],
+            ],
+            [
+                [0.25, 0.75, 0.20, 0.20],
+                [0.75, 0.25, 0.20, 0.20],
+                [0.50, 0.50, 0.30, 0.30],
+            ],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    logits = torch.full((3, 3, 2), -4.0, dtype=torch.float32, device=device)
+    logits[0, 0, 0] = 4.0
+    logits[0, 1, 1] = 3.0
+    logits[2, 2, 0] = 2.0
+
+    masks = torch.full((3, 3, 8, 8), -2.0, dtype=torch.float32, device=device)
+    masks[0, 0, 2:6, 2:6] = 2.0
+    masks[0, 1, 1:3, 1:3] = 2.0
+    masks[1, 0, 3:5, 3:5] = 2.0
+    masks[2, 2, 3:6, 3:6] = 2.0
+    return bboxes, logits, masks
+
+
+def _assert_batched_results_match_reference(
+    actual,
+    bboxes: torch.Tensor,
+    logits: torch.Tensor,
+    masks: torch.Tensor,
+    metadata,
+    threshold,
+    classes_re_mapping,
+    num_classes: int = 2,
+) -> None:
+    assert len(actual) == bboxes.shape[0]
+    for image_index, actual_detections in enumerate(actual):
+        expected = _expected_result(
+            bboxes=bboxes[image_index],
+            logits=logits[image_index],
+            masks=masks[image_index],
+            metadata=metadata[image_index],
+            threshold=threshold,
+            classes_re_mapping=classes_re_mapping,
+            num_classes=num_classes,
+        )
+        _assert_detections_equal(actual_detections, expected)
+
+
+def test_rfdetr_triton_postproc_flag_false_bypasses_triton(monkeypatch) -> None:
+    monkeypatch.setattr(rfdetr_common, "_TRITON_POSTPROC_ENABLED", False)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("Triton postproc should be disabled")
+
+    monkeypatch.setattr(
+        rfdetr_common,
+        "post_process_single_instance_segmentation_result_to_rle_masks_triton",
+        fail_if_called,
+    )
+
+    bboxes, logits, masks = _single_detection_inputs(torch.device("cpu"))
+    results = post_process_instance_segmentation_results_to_rle_masks(
+        bboxes=bboxes.unsqueeze(0),
+        logits=logits.unsqueeze(0),
+        masks=masks.unsqueeze(0),
+        pre_processing_meta=[_metadata()],
+        threshold=0.4,
+        num_classes=2,
+        classes_re_mapping=_class_mapping(torch.device("cpu")),
+    )
+
+    assert len(results) == 1
+    assert results[0].confidence.shape == (1,)
+
+
+def test_rfdetr_triton_postproc_flag_true_uses_triton_result(monkeypatch) -> None:
+    monkeypatch.setattr(rfdetr_common, "_TRITON_POSTPROC_ENABLED", True)
+    sentinel = object()
+
+    def return_sentinel(*args, **kwargs):
+        return sentinel
+
+    monkeypatch.setattr(
+        rfdetr_common,
+        "post_process_single_instance_segmentation_result_to_rle_masks_triton",
+        return_sentinel,
+    )
+
+    bboxes, logits, masks = _single_detection_inputs(torch.device("cpu"))
+    results = post_process_instance_segmentation_results_to_rle_masks(
+        bboxes=bboxes.unsqueeze(0),
+        logits=logits.unsqueeze(0),
+        masks=masks.unsqueeze(0),
+        pre_processing_meta=[_metadata()],
+        threshold=0.4,
+        num_classes=2,
+        classes_re_mapping=_class_mapping(torch.device("cpu")),
+    )
+
+    assert results == [sentinel]
+
+
+def test_rfdetr_triton_postproc_flag_true_uses_triton_per_image_for_batches(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(rfdetr_common, "_TRITON_POSTPROC_ENABLED", True)
+    sentinels = [object(), object(), object()]
+    calls = []
+
+    def return_sentinel(**kwargs):
+        calls.append(kwargs["image_bboxes"].shape)
+        return sentinels[len(calls) - 1]
+
+    monkeypatch.setattr(
+        rfdetr_common,
+        "post_process_single_instance_segmentation_result_to_rle_masks_triton",
+        return_sentinel,
+    )
+
+    device = torch.device("cpu")
+    bboxes, logits, masks = _batched_inputs(device)
+    results = post_process_instance_segmentation_results_to_rle_masks(
+        bboxes=bboxes,
+        logits=logits,
+        masks=masks,
+        pre_processing_meta=[_metadata(), _metadata(), _metadata()],
+        threshold=0.4,
+        num_classes=2,
+        classes_re_mapping=_class_mapping(device),
+    )
+
+    assert results == sentinels
+    assert calls == [torch.Size([3, 4]), torch.Size([3, 4]), torch.Size([3, 4])]
+
+
+def test_rfdetr_triton_postproc_reports_triton_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(triton_postprocess, "triton", None)
+
+    reason = _unsupported_triton_postprocess_reason(**_support_kwargs())
+
+    assert reason == "triton_unavailable"
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        ("no_class_mapping", "class_remapping_required"),
+        ("tensor_threshold", "tensor_threshold_unsupported"),
+        ("invalid_tensor_rank", "invalid_tensor_rank"),
+        ("shape_mismatch", "shape_mismatch"),
+        ("class_mapping_too_small", "class_mapping_too_small"),
+        ("input_size_exceeds_limits", "input_size_exceeds_triton_limits"),
+        ("padding", "padding_unsupported"),
+        ("static_crop", "static_crop_unsupported"),
+        ("resize_metadata", "resize_metadata_unsupported"),
+        ("cpu_device", "cuda_device_required"),
+    ],
+)
+def test_rfdetr_triton_postproc_unsupported_reason_matrix(
+    monkeypatch,
+    case: str,
+    expected_reason: str,
+) -> None:
+    monkeypatch.setattr(triton_postprocess, "triton", object())
+    kwargs = _support_kwargs()
+
+    if case == "no_class_mapping":
+        kwargs["classes_re_mapping"] = None
+    elif case == "tensor_threshold":
+        kwargs["threshold"] = torch.tensor([0.4, 0.4])
+    elif case == "invalid_tensor_rank":
+        kwargs["image_scores"] = kwargs["image_scores"][None]
+    elif case == "shape_mismatch":
+        kwargs["image_bboxes"] = kwargs["image_bboxes"][:1]
+    elif case == "class_mapping_too_small":
+        kwargs["classes_re_mapping"] = _class_mapping(torch.device("cpu"), 1)
+    elif case == "input_size_exceeds_limits":
+        kwargs = _support_kwargs(mask_size=(193, 193))
+    elif case == "padding":
+        kwargs["image_meta"] = _metadata(padding=(1, 0, 0, 0))
+    elif case == "static_crop":
+        kwargs["image_meta"] = _metadata(static_crop_offset=(1, 0))
+    elif case == "resize_metadata":
+        kwargs["image_meta"] = _metadata(size_after_pre_processing=(32, 64))
+
+    reason = _unsupported_triton_postprocess_reason(**kwargs)
+
+    assert reason == expected_reason
+    assert not _supports_triton_postprocess_path(**kwargs)
+
+
+def test_rfdetr_triton_postproc_accepts_2xlarge_shape_limits(monkeypatch) -> None:
+    monkeypatch.setattr(triton_postprocess, "triton", object())
+    device = torch.device("cpu")
+    num_queries = 300
+    num_classes = 91
+    kwargs = {
+        "image_bboxes": torch.empty(
+            (num_queries, 4),
+            dtype=torch.float32,
+            device=device,
+        ),
+        "image_scores": torch.empty(
+            (num_queries, num_classes),
+            dtype=torch.float32,
+            device=device,
+        ),
+        "image_masks": torch.empty(
+            (num_queries, 192, 192),
+            dtype=torch.float32,
+            device=device,
+        ),
+        "image_meta": _metadata(height=1080, width=1920),
+        "threshold": 0.4,
+        "classes_re_mapping": _class_mapping(device, num_classes=num_classes),
+    }
+
+    reason = _unsupported_triton_postprocess_reason(**kwargs)
+
+    assert reason == "cuda_device_required"
+
+
+@pytest.mark.parametrize("case", ["no_class_mapping", "tensor_threshold", "padding"])
+def test_rfdetr_triton_postproc_unsupported_cases_use_reference_path(
+    monkeypatch,
+    case: str,
+) -> None:
+    monkeypatch.setattr(rfdetr_common, "_TRITON_POSTPROC_ENABLED", True)
+    calls = 0
+    real_triton_postprocess = (
+        rfdetr_common.post_process_single_instance_segmentation_result_to_rle_masks_triton
+    )
+
+    def spy_triton_postprocess(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_triton_postprocess(*args, **kwargs)
+
+    monkeypatch.setattr(
+        rfdetr_common,
+        "post_process_single_instance_segmentation_result_to_rle_masks_triton",
+        spy_triton_postprocess,
+    )
+
+    device = torch.device("cpu")
+    bboxes, logits, masks = _single_detection_inputs(device)
+    metadata = _metadata()
+    threshold = 0.4
+    classes_re_mapping = _class_mapping(device)
+    if case == "no_class_mapping":
+        classes_re_mapping = None
+    elif case == "tensor_threshold":
+        threshold = torch.tensor([0.4, 0.4], dtype=torch.float32, device=device)
+    elif case == "padding":
+        metadata = _metadata(padding=(1, 0, 0, 0))
+
+    expected = _expected_result(
+        bboxes=bboxes,
+        logits=logits,
+        masks=masks,
+        metadata=metadata,
+        threshold=threshold,
+        classes_re_mapping=classes_re_mapping,
+    )
+    actual = post_process_instance_segmentation_results_to_rle_masks(
+        bboxes=bboxes.unsqueeze(0),
+        logits=logits.unsqueeze(0),
+        masks=masks.unsqueeze(0),
+        pre_processing_meta=[metadata],
+        threshold=threshold,
+        num_classes=2,
+        classes_re_mapping=classes_re_mapping,
+    )[0]
+
+    assert calls == 1
+    _assert_detections_equal(actual, expected)
+
+
+def test_rfdetr_batched_rle_postprocess_matches_reference_for_mixed_counts_and_metadata(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(rfdetr_common, "_TRITON_POSTPROC_ENABLED", False)
+    device = torch.device("cpu")
+    bboxes, logits, masks = _batched_inputs(device)
+    metadata = [
+        _metadata(),
+        _metadata(padding=(1, 0, 0, 0)),
+        _metadata(),
+    ]
+    threshold = 0.4
+    classes_re_mapping = _class_mapping(device)
+
+    actual = post_process_instance_segmentation_results_to_rle_masks(
+        bboxes=bboxes,
+        logits=logits,
+        masks=masks,
+        pre_processing_meta=metadata,
+        threshold=threshold,
+        num_classes=2,
+        classes_re_mapping=classes_re_mapping,
+    )
+
+    _assert_batched_results_match_reference(
+        actual=actual,
+        bboxes=bboxes,
+        logits=logits,
+        masks=masks,
+        metadata=metadata,
+        threshold=threshold,
+        classes_re_mapping=classes_re_mapping,
+    )
+    assert [result.confidence.shape[0] for result in actual] == [2, 0, 1]
+
+
+def test_rfdetr_batched_rle_postprocess_matches_reference_for_tensor_threshold_and_unmapped_classes(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(rfdetr_common, "_TRITON_POSTPROC_ENABLED", False)
+    device = torch.device("cpu")
+    bboxes, logits, masks = _batched_inputs(device)
+    logits[2, 0, 1] = 5.0
+    metadata = [
+        _metadata(),
+        _metadata(padding=(1, 0, 0, 0)),
+        _metadata(),
+    ]
+    threshold = torch.tensor([0.4, 0.4], dtype=torch.float32, device=device)
+    classes_re_mapping = ClassesReMapping(
+        remaining_class_ids=torch.tensor([0], dtype=torch.int64, device=device),
+        class_mapping=torch.tensor([0, -1], dtype=torch.int64, device=device),
+    )
+
+    actual = post_process_instance_segmentation_results_to_rle_masks(
+        bboxes=bboxes,
+        logits=logits,
+        masks=masks,
+        pre_processing_meta=metadata,
+        threshold=threshold,
+        num_classes=2,
+        classes_re_mapping=classes_re_mapping,
+    )
+
+    _assert_batched_results_match_reference(
+        actual=actual,
+        bboxes=bboxes,
+        logits=logits,
+        masks=masks,
+        metadata=metadata,
+        threshold=threshold,
+        classes_re_mapping=classes_re_mapping,
+    )
+    assert [result.confidence.shape[0] for result in actual] == [1, 0, 1]
+    assert all(result.class_id.tolist() == [0] for result in (actual[0], actual[2]))
+
+
+def test_rfdetr_triton_postproc_interpolation_weight_cache_is_bounded() -> None:
+    _INTERPOLATION_WEIGHT_CACHE.clear()
+    try:
+        for output_size in range(8, 8 + _MAX_INTERPOLATION_WEIGHT_CACHE_ENTRIES + 3):
+            _get_interpolation_weights(
+                src_size=8,
+                output_size=output_size,
+                device=torch.device("cpu"),
+                axis="height",
+            )
+
+        assert (
+            len(_INTERPOLATION_WEIGHT_CACHE) <= _MAX_INTERPOLATION_WEIGHT_CACHE_ENTRIES
+        )
+    finally:
+        _INTERPOLATION_WEIGHT_CACHE.clear()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or triton_postprocess.triton is None,
+    reason="CUDA and Triton are required",
+)
+def test_rfdetr_triton_postproc_matches_reference_rle_path() -> None:
+    cpu = torch.device("cpu")
+    cuda = torch.device("cuda")
+    bboxes_cpu, logits_cpu, masks_cpu = _single_detection_inputs(cpu)
+    scores_cpu = torch.sigmoid(logits_cpu)
+    metadata = _metadata()
+    expected = _post_process_single_instance_segmentation_result_to_rle_masks(
+        image_bboxes=bboxes_cpu,
+        image_logits=scores_cpu,
+        image_masks=masks_cpu,
+        image_meta=metadata,
+        threshold=0.4,
+        num_classes=2,
+        classes_re_mapping=_class_mapping(cpu),
+    )
+    cuda_kwargs = {
+        "image_bboxes": bboxes_cpu.to(cuda),
+        "image_scores": scores_cpu.to(cuda),
+        "image_masks": masks_cpu.to(cuda),
+        "image_meta": metadata,
+        "threshold": 0.4,
+        "classes_re_mapping": _class_mapping(cuda),
+    }
+
+    assert _unsupported_triton_postprocess_reason(**cuda_kwargs) is None
+    assert _supports_triton_postprocess_path(**cuda_kwargs)
+    actual = post_process_single_instance_segmentation_result_to_rle_masks_triton(
+        **cuda_kwargs
+    )
+
+    assert actual is not None
+    _assert_detections_equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or triton_postprocess.triton is None,
+    reason="CUDA and Triton are required",
+)
+def test_rfdetr_triton_postproc_matches_reference_with_large_source_mask() -> None:
+    cpu = torch.device("cpu")
+    cuda = torch.device("cuda")
+    bboxes_cpu = torch.tensor(
+        [
+            [0.50, 0.50, 0.50, 0.50],
+            [0.25, 0.25, 0.20, 0.20],
+        ],
+        dtype=torch.float32,
+        device=cpu,
+    )
+    logits_cpu = torch.tensor(
+        [
+            [4.0, -4.0],
+            [-4.0, -4.0],
+        ],
+        dtype=torch.float32,
+        device=cpu,
+    )
+    masks_cpu = torch.full((2, 96, 96), -2.0, dtype=torch.float32, device=cpu)
+    masks_cpu[0, 24:72, 24:72] = 2.0
+    scores_cpu = torch.sigmoid(logits_cpu)
+    metadata = _metadata(height=128, width=128)
+    expected = _post_process_single_instance_segmentation_result_to_rle_masks(
+        image_bboxes=bboxes_cpu,
+        image_logits=scores_cpu,
+        image_masks=masks_cpu,
+        image_meta=metadata,
+        threshold=0.4,
+        num_classes=2,
+        classes_re_mapping=_class_mapping(cpu),
+    )
+    cuda_kwargs = {
+        "image_bboxes": bboxes_cpu.to(cuda),
+        "image_scores": scores_cpu.to(cuda),
+        "image_masks": masks_cpu.to(cuda),
+        "image_meta": metadata,
+        "threshold": 0.4,
+        "classes_re_mapping": _class_mapping(cuda),
+    }
+
+    assert _unsupported_triton_postprocess_reason(**cuda_kwargs) is None
+    actual = post_process_single_instance_segmentation_result_to_rle_masks_triton(
+        **cuda_kwargs
+    )
+
+    assert actual is not None
+    _assert_detections_equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or triton_postprocess.triton is None,
+    reason="CUDA and Triton are required",
+)
+def test_rfdetr_triton_postproc_topk_retry_matches_reference_rle_path() -> None:
+    cpu = torch.device("cpu")
+    cuda = torch.device("cuda")
+    bboxes_cpu, logits_cpu, masks_cpu = _single_detection_inputs(cpu)
+    logits_cpu[0, 0] = 5.0
+    logits_cpu[0, 1] = 4.0
+    scores_cpu = torch.sigmoid(logits_cpu)
+    metadata = _metadata()
+    expected = _post_process_single_instance_segmentation_result_to_rle_masks(
+        image_bboxes=bboxes_cpu,
+        image_logits=scores_cpu,
+        image_masks=masks_cpu,
+        image_meta=metadata,
+        threshold=0.4,
+        num_classes=2,
+        classes_re_mapping=_class_mapping(cpu),
+    )
+    cuda_kwargs = {
+        "image_bboxes": bboxes_cpu.to(cuda),
+        "image_scores": scores_cpu.to(cuda),
+        "image_masks": masks_cpu.to(cuda),
+        "image_meta": metadata,
+        "threshold": 0.4,
+        "classes_re_mapping": _class_mapping(cuda),
+    }
+
+    assert expected.confidence.shape == (2,)
+    assert _unsupported_triton_postprocess_reason(**cuda_kwargs) is None
+    actual = post_process_single_instance_segmentation_result_to_rle_masks_triton(
+        **cuda_kwargs
+    )
+
+    assert actual is not None
+    _assert_detections_equal(actual, expected)

--- a/inference_models/tests/unit_tests/models/rfdetr/test_triton_preprocess.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_triton_preprocess.py
@@ -1,0 +1,164 @@
+import numpy as np
+import pytest
+import torch
+import torchvision.transforms.functional as TF
+from PIL import Image
+
+from inference_models.errors import ModelInputError, ModelRuntimeError
+from inference_models.models.rfdetr import triton_preprocess
+from inference_models.models.rfdetr.triton_preprocess import (
+    build_resample_tables,
+    resolve_two_pass_launch_config,
+    triton_preprocess_rfdetr_stretch,
+)
+
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+_PREPROC_ENV_VARS = (
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_BLOCK_H",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_BLOCK_W",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_HORIZONTAL_BLOCK_H",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_HORIZONTAL_BLOCK_W",
+)
+
+
+def _reference_preprocess(image_rgb: np.ndarray, target_h: int, target_w: int):
+    resized = TF.resize(
+        Image.fromarray(image_rgb),
+        (target_h, target_w),
+        antialias=True,
+    )
+    tensor = TF.to_tensor(resized)
+    tensor = TF.normalize(
+        tensor,
+        mean=list(_IMAGENET_MEAN),
+        std=list(_IMAGENET_STD),
+    )
+    return tensor.unsqueeze(0)
+
+
+def test_build_resample_tables_shapes_on_cpu() -> None:
+    tables = build_resample_tables(
+        src_h=11,
+        src_w=13,
+        target_h=7,
+        target_w=5,
+        device=torch.device("cpu"),
+    )
+
+    assert tuple(tables.ymin_gpu.shape) == (7,)
+    assert tuple(tables.xmin_gpu.shape) == (5,)
+    assert tuple(tables.wy_gpu.shape) == (7 * tables.ksize_y,)
+    assert tuple(tables.wx_gpu.shape) == (5 * tables.ksize_x,)
+    assert tables.ymin_gpu.dtype == torch.int32
+    assert tables.wx_gpu.dtype == torch.int32
+
+
+def test_resolve_launch_config_rejects_non_power_of_two(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for env_var in _PREPROC_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setenv("INFERENCE_MODELS_RFDETR_TRITON_PREPROC_BLOCK_W", "96")
+
+    with pytest.raises(ModelRuntimeError, match="positive power of two"):
+        resolve_two_pass_launch_config()
+
+
+@pytest.mark.skipif(
+    not triton_preprocess.TRITON_AVAILABLE,
+    reason="Triton is required for runtime validation",
+)
+def test_triton_preprocess_rejects_cpu_source_tensor() -> None:
+    source = torch.zeros((8, 8, 3), dtype=torch.uint8)
+    tables = build_resample_tables(
+        src_h=8,
+        src_w=8,
+        target_h=8,
+        target_w=8,
+        device=torch.device("cpu"),
+    )
+
+    with pytest.raises(ModelInputError, match="expected CUDA src tensor"):
+        triton_preprocess_rfdetr_stretch(
+            src=source,
+            tables=tables,
+            target_h=8,
+            target_w=8,
+        )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not triton_preprocess.TRITON_AVAILABLE,
+    reason="CUDA and Triton are required",
+)
+def test_triton_preprocess_matches_pil_for_rgb_numpy() -> None:
+    rng = np.random.default_rng(seed=17)
+    image_rgb = rng.integers(0, 256, size=(77, 51, 3), dtype=np.uint8)
+    target_h, target_w = 48, 64
+    device = torch.device("cuda")
+    tables = build_resample_tables(
+        src_h=image_rgb.shape[0],
+        src_w=image_rgb.shape[1],
+        target_h=target_h,
+        target_w=target_w,
+        device=device,
+    )
+
+    actual = triton_preprocess_rfdetr_stretch(
+        src=torch.from_numpy(image_rgb).to(device=device),
+        tables=tables,
+        target_h=target_h,
+        target_w=target_w,
+        means=_IMAGENET_MEAN,
+        stds=_IMAGENET_STD,
+        swap_rb=False,
+    )
+    torch.cuda.synchronize()
+
+    expected = _reference_preprocess(image_rgb, target_h=target_h, target_w=target_w)
+    torch.testing.assert_close(actual.cpu(), expected, atol=1e-6, rtol=0)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not triton_preprocess.TRITON_AVAILABLE,
+    reason="CUDA and Triton are required",
+)
+def test_triton_preprocess_matches_pil_for_bgr_numpy_with_preallocated_buffers() -> (
+    None
+):
+    rng = np.random.default_rng(seed=23)
+    image_rgb = rng.integers(0, 256, size=(63, 85, 3), dtype=np.uint8)
+    image_bgr = image_rgb[:, :, ::-1].copy()
+    target_h, target_w = 64, 64
+    device = torch.device("cuda")
+    tables = build_resample_tables(
+        src_h=image_bgr.shape[0],
+        src_w=image_bgr.shape[1],
+        target_h=target_h,
+        target_w=target_w,
+        device=device,
+    )
+    out = torch.empty((1, 3, target_h, target_w), dtype=torch.float32, device=device)
+    tmp = torch.empty(
+        (3, image_bgr.shape[0], target_w),
+        dtype=torch.uint8,
+        device=device,
+    )
+
+    actual = triton_preprocess_rfdetr_stretch(
+        src=torch.from_numpy(image_bgr).to(device=device),
+        tables=tables,
+        target_h=target_h,
+        target_w=target_w,
+        means=_IMAGENET_MEAN,
+        stds=_IMAGENET_STD,
+        swap_rb=True,
+        out=out,
+        tmp=tmp,
+    )
+    torch.cuda.synchronize()
+
+    expected = _reference_preprocess(image_rgb, target_h=target_h, target_w=target_w)
+    assert actual.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(actual.cpu(), expected, atol=1e-6, rtol=0)

--- a/inference_models/tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py
@@ -1,0 +1,329 @@
+import warnings
+
+import numpy as np
+import pytest
+import torch
+import torchvision.transforms.functional as TF
+from PIL import Image
+
+from inference_models.entities import ImageDimensions
+from inference_models.models.common.roboflow.model_packages import (
+    ColorMode,
+    Contrast,
+    ContrastType,
+    Grayscale,
+    ImagePreProcessing,
+    NetworkInputDefinition,
+    ResizeMode,
+    StaticCrop,
+    TrainingInputSize,
+)
+from inference_models.models.rfdetr import (
+    triton_preprocess,
+    triton_preprocess_runtime,
+)
+from inference_models.models.rfdetr.triton_preprocess_runtime import (
+    FastPreprocessRuntime,
+)
+
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+_DEFAULT_NORMALIZATION = object()
+
+
+def _network_input(
+    target_h: int = 64,
+    target_w: int = 64,
+    dataset_version_resize_dimensions=None,
+    resize_mode: ResizeMode = ResizeMode.STRETCH_TO,
+    input_channels: int = 3,
+    scaling_factor=255,
+    normalization=_DEFAULT_NORMALIZATION,
+) -> NetworkInputDefinition:
+    if normalization is _DEFAULT_NORMALIZATION:
+        normalization = [list(_IMAGENET_MEAN), list(_IMAGENET_STD)]
+    return NetworkInputDefinition(
+        training_input_size=TrainingInputSize(height=target_h, width=target_w),
+        dataset_version_resize_dimensions=dataset_version_resize_dimensions,
+        dynamic_spatial_size_supported=False,
+        color_mode=ColorMode.RGB,
+        resize_mode=resize_mode,
+        input_channels=input_channels,
+        scaling_factor=scaling_factor,
+        normalization=normalization,
+    )
+
+
+def _call_fast_preprocess(
+    runtime: FastPreprocessRuntime,
+    *,
+    images=None,
+    image_size=None,
+    image_pre_processing=None,
+    network_input=None,
+):
+    if images is None:
+        images = np.zeros((8, 8, 3), dtype=np.uint8)
+    if image_pre_processing is None:
+        image_pre_processing = ImagePreProcessing()
+    if network_input is None:
+        network_input = _network_input()
+    return runtime.try_preprocess(
+        images=images,
+        input_color_format="bgr",
+        image_size=image_size,
+        image_pre_processing=image_pre_processing,
+        network_input=network_input,
+        stream=None,
+    )
+
+
+def _reference_preprocess(image_rgb: np.ndarray, target_h: int, target_w: int):
+    resized = TF.resize(
+        Image.fromarray(image_rgb),
+        (target_h, target_w),
+        antialias=True,
+    )
+    tensor = TF.to_tensor(resized)
+    tensor = TF.normalize(
+        tensor,
+        mean=list(_IMAGENET_MEAN),
+        std=list(_IMAGENET_STD),
+    )
+    return tensor.unsqueeze(0)
+
+
+def test_trt_fast_preprocess_warns_once_for_unsupported_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", True)
+    monkeypatch.setattr(triton_preprocess_runtime, "_TRITON_AVAILABLE", True)
+    runtime = FastPreprocessRuntime(device=torch.device("cuda"))
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    with pytest.warns(RuntimeWarning, match="only batch size 1 is supported"):
+        assert (
+            runtime.try_preprocess(
+                images=[image, image],
+                input_color_format="bgr",
+                image_size=None,
+                image_pre_processing=ImagePreProcessing(),
+                network_input=_network_input(),
+                stream=None,
+            )
+            is None
+        )
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        assert (
+            runtime.try_preprocess(
+                images=[image, image],
+                input_color_format="bgr",
+                image_size=None,
+                image_pre_processing=ImagePreProcessing(),
+                network_input=_network_input(),
+                stream=None,
+            )
+            is None
+        )
+    assert recorded == []
+
+
+def test_trt_fast_preprocess_flag_disabled_returns_none_without_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", False)
+    monkeypatch.setattr(triton_preprocess_runtime, "_TRITON_AVAILABLE", True)
+    runtime = FastPreprocessRuntime(device=torch.device("cuda"))
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        assert _call_fast_preprocess(runtime) is None
+    assert recorded == []
+
+
+@pytest.mark.parametrize(
+    ("runtime_device", "kwargs", "reason"),
+    [
+        (
+            torch.device("cuda"),
+            {},
+            "triton is not installed",
+        ),
+    ],
+)
+def test_trt_fast_preprocess_warns_for_unavailable_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_device: torch.device,
+    kwargs,
+    reason: str,
+) -> None:
+    monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", True)
+    monkeypatch.setattr(triton_preprocess_runtime, "_TRITON_AVAILABLE", False)
+    runtime = FastPreprocessRuntime(device=runtime_device)
+
+    with pytest.warns(RuntimeWarning, match=reason):
+        assert _call_fast_preprocess(runtime, **kwargs) is None
+
+
+@pytest.mark.parametrize(
+    ("runtime_device", "kwargs", "reason"),
+    [
+        (
+            torch.device("cpu"),
+            {},
+            "CUDA device is required",
+        ),
+        (
+            torch.device("cuda"),
+            {"image_size": (32, 32)},
+            "custom image_size overrides are not supported",
+        ),
+        (
+            torch.device("cuda"),
+            {
+                "image_pre_processing": ImagePreProcessing.model_validate(
+                    {
+                        "static-crop": StaticCrop(
+                            enabled=True,
+                            x_min=0,
+                            x_max=8,
+                            y_min=0,
+                            y_max=8,
+                        )
+                    }
+                )
+            },
+            "static crop, contrast, and grayscale preprocessing are unsupported",
+        ),
+        (
+            torch.device("cuda"),
+            {
+                "image_pre_processing": ImagePreProcessing(
+                    contrast=Contrast(
+                        enabled=True,
+                        type=ContrastType.CONTRAST_STRETCHING,
+                    )
+                )
+            },
+            "static crop, contrast, and grayscale preprocessing are unsupported",
+        ),
+        (
+            torch.device("cuda"),
+            {
+                "image_pre_processing": ImagePreProcessing(
+                    grayscale=Grayscale(enabled=True)
+                )
+            },
+            "static crop, contrast, and grayscale preprocessing are unsupported",
+        ),
+        (
+            torch.device("cuda"),
+            {
+                "network_input": _network_input(
+                    dataset_version_resize_dimensions=TrainingInputSize(
+                        height=8,
+                        width=8,
+                    )
+                )
+            },
+            "dataset-version resize is unsupported",
+        ),
+        (
+            torch.device("cuda"),
+            {"network_input": _network_input(input_channels=1)},
+            "only 3-channel inputs are supported",
+        ),
+        (
+            torch.device("cuda"),
+            {"network_input": _network_input(scaling_factor=1)},
+            "only scaling_factor None or 255 is supported",
+        ),
+        (
+            torch.device("cuda"),
+            {"network_input": _network_input(normalization=None)},
+            "normalization is required",
+        ),
+        (
+            torch.device("cuda"),
+            {"network_input": _network_input(resize_mode=ResizeMode.FIT_LONGER_EDGE)},
+            "resize mode",
+        ),
+        (
+            torch.device("cuda"),
+            {"images": torch.zeros((8, 8, 3), dtype=torch.uint8)},
+            "only numpy ndarray inputs are supported",
+        ),
+        (
+            torch.device("cuda"),
+            {"images": np.zeros((8, 8, 3), dtype=np.float32)},
+            "input must be uint8 HWC with 3 channels",
+        ),
+        (
+            torch.device("cuda"),
+            {"images": np.zeros((8, 8), dtype=np.uint8)},
+            "input must be uint8 HWC with 3 channels",
+        ),
+        (
+            torch.device("cuda"),
+            {"images": np.zeros((8, 8, 1), dtype=np.uint8)},
+            "input must be uint8 HWC with 3 channels",
+        ),
+    ],
+)
+def test_trt_fast_preprocess_warns_for_unsupported_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_device: torch.device,
+    kwargs,
+    reason: str,
+) -> None:
+    monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", True)
+    monkeypatch.setattr(triton_preprocess_runtime, "_TRITON_AVAILABLE", True)
+    runtime = FastPreprocessRuntime(device=runtime_device)
+
+    with pytest.warns(RuntimeWarning, match=reason):
+        assert _call_fast_preprocess(runtime, **kwargs) is None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not triton_preprocess.TRITON_AVAILABLE,
+    reason="CUDA and Triton are required",
+)
+def test_trt_fast_preprocess_matches_reference_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(triton_preprocess_runtime, "_FAST_PATH_ENABLED", True)
+    monkeypatch.setattr(triton_preprocess_runtime, "_TRITON_AVAILABLE", True)
+    target_h, target_w = 64, 64
+    runtime = FastPreprocessRuntime(device=torch.device("cuda"))
+    stream = torch.cuda.Stream(device=torch.device("cuda"))
+    rng = np.random.default_rng(seed=71)
+    image_rgb = rng.integers(0, 256, size=(96, 80, 3), dtype=np.uint8)
+    image_bgr = image_rgb[:, :, ::-1].copy()
+
+    result = runtime.try_preprocess(
+        images=image_bgr,
+        input_color_format="bgr",
+        image_size=None,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=_network_input(target_h=target_h, target_w=target_w),
+        stream=stream,
+    )
+    assert result is not None
+    result.ready_event.synchronize()
+
+    expected = _reference_preprocess(image_rgb, target_h=target_h, target_w=target_w)
+    torch.testing.assert_close(result.tensor.cpu(), expected, atol=1e-6, rtol=0)
+
+    metadata = result.metadata
+    assert metadata[0].original_size == ImageDimensions(height=96, width=80)
+    assert metadata[0].size_after_pre_processing == ImageDimensions(
+        height=96,
+        width=80,
+    )
+    assert metadata[0].inference_size == ImageDimensions(
+        height=target_h,
+        width=target_w,
+    )
+    assert result.tensor._pre_processing_meta == metadata  # type: ignore[attr-defined]

--- a/inference_models/tests/unit_tests/models/test_instance_segmentation_future.py
+++ b/inference_models/tests/unit_tests/models/test_instance_segmentation_future.py
@@ -1,0 +1,83 @@
+from inference_models.models.base.instance_segmentation import _DirectInferenceFuture
+
+
+class _FakeEvent:
+    def __init__(self, query_result: bool) -> None:
+        self.query_result = query_result
+        self.query_calls = 0
+
+    def query(self) -> bool:
+        self.query_calls += 1
+        return self.query_result
+
+
+class _FakeInstanceSegmentationModel:
+    def __init__(self) -> None:
+        self.calls = []
+        self.result = ["detections"]
+
+    def post_process(self, raw, meta, **kwargs):
+        self.calls.append((raw, meta, dict(kwargs)))
+        return self.result
+
+
+def test_direct_inference_future_result_runs_postprocess_once() -> None:
+    model = _FakeInstanceSegmentationModel()
+    future = _DirectInferenceFuture(
+        model=model,
+        raw="raw-output",
+        meta="metadata",
+        evt=None,
+        kwargs={"confidence": 0.4},
+    )
+
+    first_result = future.result()
+    second_result = future.result()
+
+    assert first_result is model.result
+    assert second_result is model.result
+    assert model.calls == [
+        ("raw-output", "metadata", {"confidence": 0.4}),
+    ]
+    assert future.done() is True
+
+
+def test_direct_inference_future_submit_gpu_work_is_idempotent() -> None:
+    model = _FakeInstanceSegmentationModel()
+    future = _DirectInferenceFuture(
+        model=model,
+        raw="raw-output",
+        meta="initial-metadata",
+        evt=None,
+        kwargs={"mask_format": "rle"},
+    )
+
+    future.submit_gpu_work(meta="submitted-metadata")
+    future.submit_gpu_work(meta="ignored-metadata")
+    result = future.result()
+
+    assert result is model.result
+    assert future.preprocess_metadata == "submitted-metadata"
+    assert model.calls == [
+        ("raw-output", "submitted-metadata", {"mask_format": "rle"}),
+    ]
+
+
+def test_direct_inference_future_done_queries_event_until_cached() -> None:
+    model = _FakeInstanceSegmentationModel()
+    event = _FakeEvent(query_result=False)
+    future = _DirectInferenceFuture(
+        model=model,
+        raw="raw-output",
+        meta="metadata",
+        evt=event,
+        kwargs={},
+    )
+
+    assert future.done() is False
+    assert event.query_calls == 1
+
+    future.result()
+
+    assert future.done() is True
+    assert event.query_calls == 1

--- a/inference_models/tests/unit_tests/test_configuration.py
+++ b/inference_models/tests/unit_tests/test_configuration.py
@@ -1,0 +1,48 @@
+import pytest
+
+from inference_models.configuration import (
+    DEFAULT_RFDETR_PIPELINE_DEPTH,
+    get_rfdetr_pipeline_depth,
+    parse_rfdetr_pipeline_depth,
+)
+from inference_models.errors import InvalidEnvVariable
+
+
+def test_parse_rfdetr_pipeline_depth_uses_default_when_env_missing() -> None:
+    assert parse_rfdetr_pipeline_depth(None) == DEFAULT_RFDETR_PIPELINE_DEPTH
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("1", 1),
+        ("2", 2),
+        (" 3 ", 3),
+    ],
+)
+def test_parse_rfdetr_pipeline_depth_accepts_positive_integers(
+    value: str,
+    expected: int,
+) -> None:
+    assert parse_rfdetr_pipeline_depth(value) == expected
+
+
+@pytest.mark.parametrize("value", ["invalid", "1.5", "", "0", "-1"])
+def test_parse_rfdetr_pipeline_depth_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(InvalidEnvVariable):
+        parse_rfdetr_pipeline_depth(value)
+
+
+def test_get_rfdetr_pipeline_depth_reads_environment(monkeypatch) -> None:
+    monkeypatch.setenv("RFDETR_PIPELINE_DEPTH", "2")
+    assert get_rfdetr_pipeline_depth() == 2
+
+
+@pytest.mark.parametrize("value", ["0", "-4", "invalid"])
+def test_get_rfdetr_pipeline_depth_rejects_invalid_environment(
+    monkeypatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("RFDETR_PIPELINE_DEPTH", value)
+    with pytest.raises(InvalidEnvVariable):
+        get_rfdetr_pipeline_depth()

--- a/tests/inference/hosted_platform_tests/test_workflows.py
+++ b/tests/inference/hosted_platform_tests/test_workflows.py
@@ -129,7 +129,7 @@ def test_get_versions_of_execution_engine(object_detection_service_url: str) -> 
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.10.1"]
+    assert response_data["versions"] == ["1.11.0"]
 
 
 FUNCTION = """

--- a/tests/inference/integration_tests/test_workflow_endpoints.py
+++ b/tests/inference/integration_tests/test_workflow_endpoints.py
@@ -691,7 +691,7 @@ def test_get_versions_of_execution_engine(server_url: str) -> None:
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.10.1"]
+    assert response_data["versions"] == ["1.11.0"]
 
 
 def test_getting_block_schema_using_get_endpoint(server_url) -> None:

--- a/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
+++ b/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
@@ -1,0 +1,83 @@
+from inference.core.entities.responses.inference import (
+    InferenceResponseImage,
+    InferenceResponseImageDC,
+    InstanceSegmentationInferenceResponse,
+    InstanceSegmentationInferenceResponseDC,
+    InstanceSegmentationPrediction,
+    InstanceSegmentationPredictionDC,
+    Point,
+    PointDC,
+    _is_response_dc_to_dict,
+)
+from inference_models.models.base.async_handoff import (
+    attach_async_response_future,
+    get_async_response_context_id,
+    get_async_response_future,
+)
+
+
+def test_instance_segmentation_dc_dump_matches_pydantic_model_dump() -> None:
+    dc_response = InstanceSegmentationInferenceResponseDC(
+        predictions=[
+            InstanceSegmentationPredictionDC(
+                x=1.0,
+                y=2.0,
+                width=3.0,
+                height=4.0,
+                confidence=0.9,
+                class_name="car",
+                class_id=1,
+                points=[PointDC(x=1.0, y=2.0), PointDC(x=3.0, y=4.0)],
+                detection_id="detection-1",
+                parent_id="parent-1",
+                class_confidence=0.8,
+            )
+        ],
+        image=InferenceResponseImageDC(width=640, height=480),
+        inference_id="inference-1",
+        frame_id=1,
+        time=0.01,
+    )
+    pydantic_response = InstanceSegmentationInferenceResponse(
+        predictions=[
+            InstanceSegmentationPrediction(
+                x=1.0,
+                y=2.0,
+                width=3.0,
+                height=4.0,
+                confidence=0.9,
+                class_id=1,
+                points=[Point(x=1.0, y=2.0), Point(x=3.0, y=4.0)],
+                detection_id="detection-1",
+                parent_id="parent-1",
+                class_confidence=0.8,
+                **{"class": "car"},
+            )
+        ],
+        image=InferenceResponseImage(width=640, height=480),
+        inference_id="inference-1",
+        frame_id=1,
+        time=0.01,
+    )
+
+    assert _is_response_dc_to_dict(dc_response) == pydantic_response.model_dump(
+        by_alias=True,
+        exclude_none=True,
+    )
+
+
+def test_instance_segmentation_dc_can_carry_async_response_context() -> None:
+    response = InstanceSegmentationInferenceResponseDC(
+        predictions=[],
+        image=InferenceResponseImageDC(width=640, height=480),
+    )
+    response_future = object()
+
+    attach_async_response_future(
+        response=response,
+        response_future=response_future,
+        context_id="context-1",
+    )
+
+    assert get_async_response_future(response) is response_future
+    assert get_async_response_context_id(response) == "context-1"

--- a/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
+++ b/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
@@ -12,6 +12,11 @@ from inference.core.entities.responses.inference import (
     _is_pred_dc_to_dict,
     _is_response_dc_to_dict,
 )
+from inference_models.models.base.async_handoff import (
+    attach_async_response_future,
+    get_async_response_context_id,
+    get_async_response_future,
+)
 
 
 def _pydantic_prediction(
@@ -157,3 +162,20 @@ def test_workflow_dc_path_emits_mask_format_in_prediction_dicts() -> None:
         prediction["mask_format"] == "polygon"
         for prediction in dumped["predictions"]
     )
+
+
+def test_instance_segmentation_dc_can_carry_async_response_context() -> None:
+    response = InstanceSegmentationInferenceResponseDC(
+        predictions=[],
+        image=InferenceResponseImageDC(width=640, height=480),
+    )
+    response_future = object()
+
+    attach_async_response_future(
+        response=response,
+        response_future=response_future,
+        context_id="context-1",
+    )
+
+    assert get_async_response_future(response) is response_future
+    assert get_async_response_context_id(response) == "context-1"

--- a/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
+++ b/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
@@ -1,0 +1,159 @@
+import pytest
+
+from inference.core.entities.responses.inference import (
+    InferenceResponseImage,
+    InferenceResponseImageDC,
+    InstanceSegmentationInferenceResponse,
+    InstanceSegmentationInferenceResponseDC,
+    InstanceSegmentationPrediction,
+    InstanceSegmentationPredictionDC,
+    Point,
+    PointDC,
+    _is_pred_dc_to_dict,
+    _is_response_dc_to_dict,
+)
+
+
+def _pydantic_prediction(
+    *,
+    class_name: str = "car",
+    detection_id: str = "detection-1",
+    optional_fields: dict | None = None,
+) -> InstanceSegmentationPrediction:
+    fields = {
+        "x": 1.0,
+        "y": 2.0,
+        "width": 3.0,
+        "height": 4.0,
+        "confidence": 0.9,
+        "class_id": 1,
+        "points": [Point(x=1.0, y=2.0), Point(x=3.0, y=4.0)],
+        "detection_id": detection_id,
+        **{"class": class_name},
+    }
+    if optional_fields:
+        fields.update(optional_fields)
+    return InstanceSegmentationPrediction(**fields)
+
+
+def _dc_prediction(
+    *,
+    class_name: str = "car",
+    detection_id: str = "detection-1",
+    optional_fields: dict | None = None,
+) -> InstanceSegmentationPredictionDC:
+    fields = {
+        "x": 1.0,
+        "y": 2.0,
+        "width": 3.0,
+        "height": 4.0,
+        "confidence": 0.9,
+        "class_name": class_name,
+        "class_id": 1,
+        "points": [PointDC(x=1.0, y=2.0), PointDC(x=3.0, y=4.0)],
+        "detection_id": detection_id,
+    }
+    if optional_fields:
+        fields.update(optional_fields)
+    return InstanceSegmentationPredictionDC(**fields)
+
+
+def _pydantic_response(
+    predictions: list[InstanceSegmentationPrediction],
+    *,
+    inference_id: str | None = "inference-1",
+    frame_id: int | None = 1,
+    time: float | None = 0.01,
+) -> InstanceSegmentationInferenceResponse:
+    return InstanceSegmentationInferenceResponse(
+        predictions=predictions,
+        image=InferenceResponseImage(width=640, height=480),
+        inference_id=inference_id,
+        frame_id=frame_id,
+        time=time,
+    )
+
+
+def _dc_response(
+    predictions: list[InstanceSegmentationPredictionDC],
+    *,
+    inference_id: str | None = "inference-1",
+    frame_id: int | None = 1,
+    time: float | None = 0.01,
+) -> InstanceSegmentationInferenceResponseDC:
+    return InstanceSegmentationInferenceResponseDC(
+        predictions=predictions,
+        image=InferenceResponseImageDC(width=640, height=480),
+        inference_id=inference_id,
+        frame_id=frame_id,
+        time=time,
+    )
+
+
+@pytest.mark.parametrize(
+    "optional_prediction_fields",
+    [
+        {},
+        {"parent_id": "parent-1", "class_confidence": 0.8},
+    ],
+    ids=["minimal", "with_optional_fields"],
+)
+def test_instance_segmentation_dc_dump_matches_pydantic_model_dump(
+    optional_prediction_fields: dict,
+) -> None:
+    dc_response = _dc_response(
+        predictions=[_dc_prediction(optional_fields=optional_prediction_fields)]
+    )
+    pydantic_response = _pydantic_response(
+        predictions=[_pydantic_prediction(optional_fields=optional_prediction_fields)]
+    )
+
+    assert _is_response_dc_to_dict(dc_response) == pydantic_response.model_dump(
+        by_alias=True,
+        exclude_none=True,
+    )
+
+
+def test_instance_segmentation_dc_dump_matches_pydantic_empty_predictions() -> None:
+    dc_response = _dc_response(predictions=[])
+    pydantic_response = _pydantic_response(predictions=[])
+
+    assert _is_response_dc_to_dict(dc_response) == pydantic_response.model_dump(
+        by_alias=True,
+        exclude_none=True,
+    )
+
+
+def test_is_pred_dc_to_dict_includes_mask_format_even_when_default() -> None:
+    prediction = _dc_prediction()
+
+    result = _is_pred_dc_to_dict(prediction)
+
+    assert result["mask_format"] == "polygon"
+
+
+def test_workflow_dc_path_emits_mask_format_in_prediction_dicts() -> None:
+    # Mirrors InstanceSegmentationPredictionDC construction in
+    # InferenceModelsInstanceSegmentationAdapter._build_responses_from_detections.
+    response = InstanceSegmentationInferenceResponseDC(
+        predictions=[
+            InstanceSegmentationPredictionDC(
+                x=10.0,
+                y=20.0,
+                width=30.0,
+                height=40.0,
+                confidence=0.95,
+                class_name="person",
+                class_id=0,
+                points=[PointDC(x=1.0, y=2.0), PointDC(x=3.0, y=4.0)],
+            )
+        ],
+        image=InferenceResponseImageDC(width=640, height=480),
+    )
+
+    dumped = _is_response_dc_to_dict(response)
+
+    assert all(
+        prediction["mask_format"] == "polygon"
+        for prediction in dumped["predictions"]
+    )

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from concurrent.futures import Future
 from datetime import datetime
 from functools import partial
 from queue import Queue
@@ -28,8 +29,14 @@ from inference.core.interfaces.camera.video_source import (
     VideoSource,
     lock_state_transition,
 )
-from inference.core.interfaces.stream.entities import ModelConfig
-from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
+from inference.core.interfaces.stream.entities import (
+    InferenceHandlerResult,
+    ModelConfig,
+)
+from inference.core.interfaces.stream.inference_pipeline import (
+    InferencePipeline,
+    _resolve_prediction_futures,
+)
 from inference.core.interfaces.stream.model_handlers.roboflow_models import (
     default_process_frame,
 )
@@ -138,6 +145,84 @@ class ModelStub:
                 image=InferenceResponseImage(width=1920, height=1080),
             )
         ] * len(image)
+
+
+class _PredictionReadyWatchdog:
+    def __init__(self) -> None:
+        self.ready_frames = []
+
+    def on_model_prediction_ready(self, frames):
+        self.ready_frames.append(frames)
+
+
+class _FlushableInferenceHandler:
+    def __init__(self, results):
+        self.results = results
+        self.flush_calls = 0
+        self.close_calls = 0
+
+    def flush(self):
+        self.flush_calls += 1
+        return self.results
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def test_inference_pipeline_drain_enqueues_flush_results_with_bound_frames() -> None:
+    frame_1 = VideoFrame(
+        image=np.zeros((8, 8, 3), dtype=np.uint8),
+        frame_id=1,
+        frame_timestamp=datetime.now(),
+        source_id=0,
+    )
+    frame_2 = VideoFrame(
+        image=np.zeros((8, 8, 3), dtype=np.uint8),
+        frame_id=2,
+        frame_timestamp=datetime.now(),
+        source_id=0,
+    )
+    handler = _FlushableInferenceHandler(
+        results=[
+            InferenceHandlerResult(predictions=["p1"], video_frames=[frame_1]),
+            InferenceHandlerResult(predictions=["p2"], video_frames=[frame_2]),
+        ]
+    )
+    watchdog = _PredictionReadyWatchdog()
+    pipeline = object.__new__(InferencePipeline)
+    pipeline._on_video_frame = handler
+    pipeline._watchdog = watchdog
+    pipeline._predictions_queue = Queue()
+    pipeline._status_update_handlers = []
+
+    pipeline._drain_inference_handler()
+
+    assert handler.flush_calls == 1
+    assert pipeline._predictions_queue.get_nowait() == (["p1"], [frame_1])
+    assert pipeline._predictions_queue.get_nowait() == (["p2"], [frame_2])
+    assert watchdog.ready_frames == [[frame_1], [frame_2]]
+
+
+def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None:
+    inner = Future()
+    inner.set_result("resolved")
+    outer = Future()
+    outer.set_result({"detections": [inner]})
+
+    assert _resolve_prediction_futures((outer, {"raw": inner})) == (
+        {"detections": ["resolved"]},
+        {"raw": "resolved"},
+    )
+
+
+def test_inference_pipeline_close_calls_handler_close_hook() -> None:
+    handler = _FlushableInferenceHandler(results=[])
+    pipeline = object.__new__(InferencePipeline)
+    pipeline._on_video_frame = handler
+
+    pipeline._close_inference_handler()
+
+    assert handler.close_calls == 1
 
 
 @pytest.mark.timeout(90)

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import supervision as sv
 
 from inference.core.active_learning.middlewares import ThreadingActiveLearningMiddleware
 from inference.core.cache import MemoryCache
@@ -35,7 +36,9 @@ from inference.core.interfaces.stream.entities import (
 )
 from inference.core.interfaces.stream.inference_pipeline import (
     InferencePipeline,
+    _apply_workflow_parent_coordinate_conversion,
     _resolve_prediction_futures,
+    _workflow_parent_coordinate_output_names,
 )
 from inference.core.interfaces.stream.model_handlers.roboflow_models import (
     default_process_frame,
@@ -212,6 +215,119 @@ def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None
     assert _resolve_prediction_futures((outer, {"raw": inner})) == (
         {"detections": ["resolved"]},
         {"raw": "resolved"},
+    )
+
+
+def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None:
+    inner = Future()
+    inner.set_result("resolved")
+    outer = Future()
+    outer.set_result({"detections": [inner]})
+
+    assert _resolve_prediction_futures((outer, {"raw": inner})) == (
+        {"detections": ["resolved"]},
+        {"raw": "resolved"},
+    )
+
+
+def test_workflow_parent_coordinate_output_names_defaults_to_parent_outputs() -> None:
+    workflow_specification = {
+        "outputs": [
+            {"name": "predictions", "selector": "$steps.model.predictions"},
+            {
+                "name": "crop_predictions",
+                "selector": "$steps.crop.predictions",
+                "coordinates_system": "own",
+            },
+            {"name": "visualization", "selector": "$steps.viz.image"},
+        ]
+    }
+
+    assert _workflow_parent_coordinate_output_names(
+        workflow_specification=workflow_specification
+    ) == frozenset({"predictions", "visualization"})
+
+
+def _detections_with_root_shift() -> sv.Detections:
+    return sv.Detections(
+        xyxy=np.array([[25.0, 50.0, 75.0, 150.0]]),
+        data={
+            "parent_coordinates": np.array([[10.0, 20.0]]),
+            "root_parent_coordinates": np.array([[50.0, 100.0]]),
+            "root_parent_dimensions": np.array([[512.0, 1024.0]]),
+            "root_parent_id": np.array(["root"]),
+        },
+    )
+
+
+def test_apply_workflow_parent_coordinate_conversion_shifts_parent_outputs() -> None:
+    detections = _detections_with_root_shift()
+    predictions = {
+        "predictions": detections,
+        "crop_predictions": sv.Detections(
+            xyxy=np.array([[5.0, 10.0, 15.0, 20.0]]),
+            data={
+                "parent_coordinates": np.array([[10.0, 20.0]]),
+                "root_parent_coordinates": np.array([[50.0, 100.0]]),
+                "root_parent_dimensions": np.array([[512.0, 1024.0]]),
+                "root_parent_id": np.array(["root"]),
+            },
+        ),
+    }
+
+    converted = _apply_workflow_parent_coordinate_conversion(
+        predictions=predictions,
+        parent_output_names=frozenset({"predictions"}),
+    )
+
+    assert np.allclose(
+        converted["predictions"].xyxy,
+        np.array([[75.0, 150.0, 125.0, 250.0]]),
+    )
+    assert np.allclose(
+        converted["crop_predictions"].xyxy,
+        np.array([[5.0, 10.0, 15.0, 20.0]]),
+    )
+
+
+def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    detections = _detections_with_root_shift()
+    prediction_future = Future()
+    prediction_future.set_result({"predictions": detections})
+    frame = VideoFrame(
+        image=np.zeros((8, 8, 3), dtype=np.uint8),
+        frame_id=1,
+        frame_timestamp=datetime.now(),
+        source_id=0,
+    )
+    dispatched = []
+
+    def on_prediction(prediction: dict, video_frame: VideoFrame) -> None:
+        dispatched.append((prediction, video_frame))
+
+    pipeline = object.__new__(InferencePipeline)
+    pipeline._predictions_queue = Queue()
+    pipeline._on_prediction = on_prediction
+    pipeline._workflow_parent_coordinate_outputs = frozenset({"predictions"})
+    pipeline._workflow_defer_output_coordinate_conversion = True
+    pipeline._handle_predictions_dispatching = InferencePipeline._handle_predictions_dispatching.__get__(
+        pipeline, InferencePipeline
+    )
+    monkeypatch.setattr(
+        "inference.core.interfaces.stream.inference_pipeline._rfdetr_stream_pipeline_enabled",
+        lambda: True,
+    )
+
+    pipeline._predictions_queue.put(([{"predictions": prediction_future}], [frame]))
+    pipeline._predictions_queue.put(None)
+    pipeline._dispatch_inference_results()
+
+    assert len(dispatched) == 1
+    assert np.allclose(
+        dispatched[0][0]["predictions"].xyxy,
+        np.array([[75.0, 150.0, 125.0, 250.0]]),
     )
 
 

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -36,6 +36,7 @@ from inference.core.interfaces.stream.entities import (
 )
 from inference.core.interfaces.stream.inference_pipeline import (
     InferencePipeline,
+    SinkMode,
     _apply_workflow_parent_coordinate_conversion,
     _resolve_prediction_futures,
     _workflow_parent_coordinate_output_names,
@@ -295,7 +296,7 @@ def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversio
 ) -> None:
     detections = _detections_with_root_shift()
     prediction_future = Future()
-    prediction_future.set_result({"predictions": detections})
+    prediction_future.set_result(detections)
     frame = VideoFrame(
         image=np.zeros((8, 8, 3), dtype=np.uint8),
         frame_id=1,
@@ -310,6 +311,8 @@ def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversio
     pipeline = object.__new__(InferencePipeline)
     pipeline._predictions_queue = Queue()
     pipeline._on_prediction = on_prediction
+    pipeline._sink_mode = SinkMode.SEQUENTIAL
+    pipeline._video_sources = []
     pipeline._workflow_parent_coordinate_outputs = frozenset({"predictions"})
     pipeline._workflow_defer_output_coordinate_conversion = True
     pipeline._handle_predictions_dispatching = InferencePipeline._handle_predictions_dispatching.__get__(

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.active_learning.middlewares import ThreadingActiveLearningMiddleware
 from inference.core.cache import MemoryCache
@@ -36,9 +35,7 @@ from inference.core.interfaces.stream.entities import (
 )
 from inference.core.interfaces.stream.inference_pipeline import (
     InferencePipeline,
-    _apply_workflow_parent_coordinate_conversion,
     _resolve_prediction_futures,
-    _workflow_parent_coordinate_output_names,
 )
 from inference.core.interfaces.stream.model_handlers.roboflow_models import (
     default_process_frame,
@@ -215,119 +212,6 @@ def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None
     assert _resolve_prediction_futures((outer, {"raw": inner})) == (
         {"detections": ["resolved"]},
         {"raw": "resolved"},
-    )
-
-
-def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None:
-    inner = Future()
-    inner.set_result("resolved")
-    outer = Future()
-    outer.set_result({"detections": [inner]})
-
-    assert _resolve_prediction_futures((outer, {"raw": inner})) == (
-        {"detections": ["resolved"]},
-        {"raw": "resolved"},
-    )
-
-
-def test_workflow_parent_coordinate_output_names_defaults_to_parent_outputs() -> None:
-    workflow_specification = {
-        "outputs": [
-            {"name": "predictions", "selector": "$steps.model.predictions"},
-            {
-                "name": "crop_predictions",
-                "selector": "$steps.crop.predictions",
-                "coordinates_system": "own",
-            },
-            {"name": "visualization", "selector": "$steps.viz.image"},
-        ]
-    }
-
-    assert _workflow_parent_coordinate_output_names(
-        workflow_specification=workflow_specification
-    ) == frozenset({"predictions", "visualization"})
-
-
-def _detections_with_root_shift() -> sv.Detections:
-    return sv.Detections(
-        xyxy=np.array([[25.0, 50.0, 75.0, 150.0]]),
-        data={
-            "parent_coordinates": np.array([[10.0, 20.0]]),
-            "root_parent_coordinates": np.array([[50.0, 100.0]]),
-            "root_parent_dimensions": np.array([[512.0, 1024.0]]),
-            "root_parent_id": np.array(["root"]),
-        },
-    )
-
-
-def test_apply_workflow_parent_coordinate_conversion_shifts_parent_outputs() -> None:
-    detections = _detections_with_root_shift()
-    predictions = {
-        "predictions": detections,
-        "crop_predictions": sv.Detections(
-            xyxy=np.array([[5.0, 10.0, 15.0, 20.0]]),
-            data={
-                "parent_coordinates": np.array([[10.0, 20.0]]),
-                "root_parent_coordinates": np.array([[50.0, 100.0]]),
-                "root_parent_dimensions": np.array([[512.0, 1024.0]]),
-                "root_parent_id": np.array(["root"]),
-            },
-        ),
-    }
-
-    converted = _apply_workflow_parent_coordinate_conversion(
-        predictions=predictions,
-        parent_output_names=frozenset({"predictions"}),
-    )
-
-    assert np.allclose(
-        converted["predictions"].xyxy,
-        np.array([[75.0, 150.0, 125.0, 250.0]]),
-    )
-    assert np.allclose(
-        converted["crop_predictions"].xyxy,
-        np.array([[5.0, 10.0, 15.0, 20.0]]),
-    )
-
-
-def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversion(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    detections = _detections_with_root_shift()
-    prediction_future = Future()
-    prediction_future.set_result({"predictions": detections})
-    frame = VideoFrame(
-        image=np.zeros((8, 8, 3), dtype=np.uint8),
-        frame_id=1,
-        frame_timestamp=datetime.now(),
-        source_id=0,
-    )
-    dispatched = []
-
-    def on_prediction(prediction: dict, video_frame: VideoFrame) -> None:
-        dispatched.append((prediction, video_frame))
-
-    pipeline = object.__new__(InferencePipeline)
-    pipeline._predictions_queue = Queue()
-    pipeline._on_prediction = on_prediction
-    pipeline._workflow_parent_coordinate_outputs = frozenset({"predictions"})
-    pipeline._workflow_defer_output_coordinate_conversion = True
-    pipeline._handle_predictions_dispatching = InferencePipeline._handle_predictions_dispatching.__get__(
-        pipeline, InferencePipeline
-    )
-    monkeypatch.setattr(
-        "inference.core.interfaces.stream.inference_pipeline._rfdetr_stream_pipeline_enabled",
-        lambda: True,
-    )
-
-    pipeline._predictions_queue.put(([{"predictions": prediction_future}], [frame]))
-    pipeline._predictions_queue.put(None)
-    pipeline._dispatch_inference_results()
-
-    assert len(dispatched) == 1
-    assert np.allclose(
-        dispatched[0][0]["predictions"].xyxy,
-        np.array([[75.0, 150.0, 125.0, 250.0]]),
     )
 
 

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -1,0 +1,537 @@
+from concurrent.futures import Future
+from datetime import datetime
+from types import SimpleNamespace
+
+import numpy as np
+
+from inference.core.interfaces.camera.entities import VideoFrame
+from inference.core.interfaces.stream.model_handlers.workflows import (
+    PipelinedWorkflowRunner,
+    WorkflowRunner,
+    wrap_workflow_runner_for_stream_pipeline,
+)
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v3 import (
+    RoboflowInstanceSegmentationModelBlockV3,
+)
+from inference_models.models.base.async_handoff import attach_async_response_future
+
+
+class _FakePipelinedStep:
+    def __init__(self, stream_buffer_depth: int) -> None:
+        self._stream_buffer_depth = stream_buffer_depth
+        self.flush_calls = 0
+        self.close_calls = 0
+
+    def is_stream_pipelined(self) -> bool:
+        return self._stream_buffer_depth > 0
+
+    def stream_pipeline_depth(self) -> int:
+        return self._stream_buffer_depth
+
+    def flush_stream_pipeline(self):
+        self.flush_calls += 1
+        return [[{"predictions": "frame-2"}]]
+
+    def close_stream_pipeline(self) -> None:
+        self.close_calls += 1
+
+
+class _FakeExecutionEngine:
+    def __init__(self, stream_buffer_depth: int) -> None:
+        self._stream_buffer_depth = stream_buffer_depth
+        self.step = _FakePipelinedStep(stream_buffer_depth=stream_buffer_depth)
+        self._engine = SimpleNamespace(
+            _compiled_workflow=SimpleNamespace(
+                steps={"segmentation": SimpleNamespace(step=self.step)}
+            )
+        )
+        self.calls = []
+
+    def run(
+        self,
+        runtime_parameters,
+        fps,
+        serialize_results,
+        _is_preview,
+        defer_stream_pipeline_flush=False,
+    ):
+        frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
+        self.calls.append(
+            {
+                "frame_number": frame_number,
+                "fps": fps,
+                "serialize_results": serialize_results,
+                "is_preview": _is_preview,
+                "defer_stream_pipeline_flush": defer_stream_pipeline_flush,
+            }
+        )
+        prediction_frame = frame_number - self._stream_buffer_depth
+        return [{"predictions": f"frame-{prediction_frame}"}]
+
+    def flush_stream_pipeline(
+        self,
+        runtime_parameters,
+        fps,
+        serialize_results,
+        _is_preview,
+    ):
+        return self.step.flush_stream_pipeline()[0]
+
+
+class _FakeLateActivatingStep:
+    def __init__(self, active_stream_buffer_depth: int) -> None:
+        self._active_stream_buffer_depth = active_stream_buffer_depth
+        self._stream_buffer_depth = 0
+        self.flush_calls = 0
+
+    def can_activate_stream_pipeline(self) -> bool:
+        return True
+
+    def is_stream_pipelined(self) -> bool:
+        return self._stream_buffer_depth > 0
+
+    def stream_pipeline_depth(self) -> int:
+        return self._stream_buffer_depth
+
+    def activate(self) -> None:
+        self._stream_buffer_depth = self._active_stream_buffer_depth
+
+    def flush_stream_pipeline(self):
+        self.flush_calls += 1
+        return [[{"predictions": "frame-2"}]]
+
+
+class _FakeLateActivatingExecutionEngine:
+    def __init__(self, active_stream_buffer_depth: int) -> None:
+        self.step = _FakeLateActivatingStep(
+            active_stream_buffer_depth=active_stream_buffer_depth
+        )
+        self._engine = SimpleNamespace(
+            _compiled_workflow=SimpleNamespace(
+                steps={"segmentation": SimpleNamespace(step=self.step)}
+            )
+        )
+
+    def run(
+        self,
+        runtime_parameters,
+        fps,
+        serialize_results,
+        _is_preview,
+        defer_stream_pipeline_flush=False,
+    ):
+        frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
+        # Real RF-DETR workflow steps only know whether stream pipelining is
+        # active after the first model request has loaded the concrete model.
+        self.step.activate()
+        prediction_frame = frame_number - self.step.stream_pipeline_depth()
+        return [{"predictions": f"frame-{prediction_frame}"}]
+
+    def flush_stream_pipeline(
+        self,
+        runtime_parameters,
+        fps,
+        serialize_results,
+        _is_preview,
+    ):
+        return self.step.flush_stream_pipeline()[0]
+
+
+class _FakeDownstreamPipelinedExecutionEngine:
+    def __init__(self) -> None:
+        self.step = _FakePipelinedStep(stream_buffer_depth=1)
+        self._engine = SimpleNamespace(
+            _compiled_workflow=SimpleNamespace(
+                steps={"segmentation": SimpleNamespace(step=self.step)}
+            )
+        )
+        self.calls = []
+        self.flush_calls = []
+
+    def run(
+        self,
+        runtime_parameters,
+        fps,
+        serialize_results,
+        _is_preview,
+        defer_stream_pipeline_flush=False,
+    ):
+        frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
+        self.calls.append(
+            {
+                "frame_number": frame_number,
+                "defer_stream_pipeline_flush": defer_stream_pipeline_flush,
+            }
+        )
+        if defer_stream_pipeline_flush:
+            prediction_frame = frame_number - self.step.stream_pipeline_depth()
+        else:
+            # This represents the reviewed regression: flushing before downstream
+            # consumers makes the workflow output belong to the current frame.
+            prediction_frame = frame_number
+        return [{"result": f"downstream-frame-{prediction_frame}"}]
+
+    def flush_stream_pipeline(
+        self,
+        runtime_parameters,
+        fps,
+        serialize_results,
+        _is_preview,
+    ):
+        frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
+        self.flush_calls.append(frame_number)
+        return [{"result": f"downstream-frame-{frame_number}"}]
+
+
+class _ImmediateExecutor:
+    def submit(self, fn, *args, **kwargs) -> Future:
+        future = Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except BaseException as error:  # pragma: no cover - defensive
+            future.set_exception(error)
+        return future
+
+
+class _FakeWorkflowImage:
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+
+    def to_inference_format(self, numpy_preferred: bool):
+        assert numpy_preferred is True
+        return {
+            "type": "numpy_object",
+            "value": np.zeros((8, 8, 3), dtype=np.uint8),
+        }
+
+
+class _FakeResponse:
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+
+    def model_dump(self, by_alias: bool, exclude_none: bool):
+        assert by_alias is True
+        assert exclude_none is True
+        return {"tag": self.tag}
+
+
+class _FakeStreamModel:
+    _pipeline_depth = 2
+
+    def __init__(self) -> None:
+        self.flush_calls = 0
+        self.shutdown_calls = 0
+
+    def flush(self):
+        self.flush_calls += 1
+        return [_FakeResponse("tail-final")]
+
+    def shutdown_pipeline(self) -> None:
+        self.shutdown_calls += 1
+
+
+class _FakeModelManager:
+    def __init__(self, inference_results) -> None:
+        self._inference_results = list(inference_results)
+        self.model = _FakeStreamModel()
+        self.add_model_calls = []
+        self.infer_calls = 0
+
+    def add_model(self, model_id: str, api_key: str) -> None:
+        self.add_model_calls.append((model_id, api_key))
+
+    def infer_from_request_sync(self, model_id: str, request):
+        self.infer_calls += 1
+        return self._inference_results.pop(0)
+
+    def __contains__(self, model_id: str) -> bool:
+        return model_id == "model"
+
+    def __getitem__(self, model_id: str):
+        assert model_id == "model"
+        return self.model
+
+
+def _make_async_placeholder(response_tag: str) -> _FakeResponse:
+    future = Future()
+    future.set_result([_FakeResponse(response_tag)])
+    response = _FakeResponse("placeholder")
+    attach_async_response_future(response=response, response_future=future)
+    return response
+
+
+def _make_frame(frame_id: int) -> VideoFrame:
+    return VideoFrame(
+        image=np.zeros((8, 8, 3), dtype=np.uint8),
+        frame_id=frame_id,
+        frame_timestamp=datetime.fromtimestamp(frame_id),
+        fps=30.0,
+        measured_fps=None,
+        source_id=0,
+        comes_from_video_file=True,
+    )
+
+
+def test_workflow_runner_without_stream_buffering_returns_current_frame() -> None:
+    engine = _FakeExecutionEngine(stream_buffer_depth=0)
+    runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+        serialize_results=True,
+        _is_preview=True,
+    )
+    frame = _make_frame(1)
+
+    result = runner([frame])
+
+    assert result == [{"predictions": "frame-1"}]
+    assert engine.calls == [
+        {
+            "frame_number": 1,
+            "fps": 30.0,
+            "serialize_results": True,
+            "is_preview": True,
+            "defer_stream_pipeline_flush": False,
+        }
+    ]
+
+
+def test_wrap_workflow_runner_leaves_non_pipelined_workflows_unchanged() -> None:
+    engine = _FakeExecutionEngine(stream_buffer_depth=0)
+    runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+    )
+
+    assert (
+        wrap_workflow_runner_for_stream_pipeline(
+            workflow_runner=runner,
+            execution_engine=engine,
+        )
+        is runner
+    )
+
+
+def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> None:
+    engine = _FakeExecutionEngine(stream_buffer_depth=1)
+    workflow_runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+    )
+    runner = wrap_workflow_runner_for_stream_pipeline(
+        workflow_runner=workflow_runner,
+        execution_engine=engine,
+    )
+    assert isinstance(runner, PipelinedWorkflowRunner)
+    frame_1 = _make_frame(1)
+    frame_2 = _make_frame(2)
+
+    first_result = runner([frame_1])
+    second_result = runner([frame_2])
+    flushed_results = runner.flush()
+
+    assert first_result is None
+    assert second_result is not None
+    assert second_result.predictions == [{"predictions": "frame-1"}]
+    assert second_result.video_frames == [frame_1]
+    assert flushed_results is not None
+    assert len(flushed_results) == 1
+    assert flushed_results[0].predictions == [{"predictions": "frame-2"}]
+    assert flushed_results[0].video_frames == [frame_2]
+    assert engine.step.flush_calls == 1
+    runner.close()
+    assert engine.step.close_calls == 1
+    assert engine.calls == [
+        {
+            "frame_number": 1,
+            "fps": 30.0,
+            "serialize_results": False,
+            "is_preview": False,
+            "defer_stream_pipeline_flush": True,
+        },
+        {
+            "frame_number": 2,
+            "fps": 30.0,
+            "serialize_results": False,
+            "is_preview": False,
+            "defer_stream_pipeline_flush": True,
+        },
+    ]
+
+
+def test_workflow_runner_buffers_when_stream_pipeline_activates_after_first_run() -> (
+    None
+):
+    engine = _FakeLateActivatingExecutionEngine(active_stream_buffer_depth=1)
+    workflow_runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+    )
+    runner = wrap_workflow_runner_for_stream_pipeline(
+        workflow_runner=workflow_runner,
+        execution_engine=engine,
+    )
+    assert isinstance(runner, PipelinedWorkflowRunner)
+    assert engine.step.stream_pipeline_depth() == 0
+    frame_1 = _make_frame(1)
+    frame_2 = _make_frame(2)
+
+    first_result = runner([frame_1])
+    second_result = runner([frame_2])
+    flushed_results = runner.flush()
+
+    assert first_result is None
+    assert second_result is not None
+    assert second_result.predictions == [{"predictions": "frame-1"}]
+    assert second_result.video_frames == [frame_1]
+    assert flushed_results is not None
+    assert len(flushed_results) == 1
+    assert flushed_results[0].predictions == [{"predictions": "frame-2"}]
+    assert flushed_results[0].video_frames == [frame_2]
+    assert engine.step.flush_calls == 1
+
+
+def test_pipelined_workflow_runner_preserves_frame_alignment_for_downstream_steps() -> (
+    None
+):
+    engine = _FakeDownstreamPipelinedExecutionEngine()
+    workflow_runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+    )
+    runner = wrap_workflow_runner_for_stream_pipeline(
+        workflow_runner=workflow_runner,
+        execution_engine=engine,
+    )
+    assert isinstance(runner, PipelinedWorkflowRunner)
+    frame_1 = _make_frame(1)
+    frame_2 = _make_frame(2)
+
+    first_result = runner([frame_1])
+    second_result = runner([frame_2])
+    flushed_results = runner.flush()
+
+    assert first_result is None
+    assert second_result is not None
+    assert second_result.predictions == [{"result": "downstream-frame-1"}]
+    assert second_result.video_frames == [frame_1]
+    assert flushed_results is not None
+    assert len(flushed_results) == 1
+    assert flushed_results[0].predictions == [{"result": "downstream-frame-2"}]
+    assert flushed_results[0].video_frames == [frame_2]
+    assert engine.calls == [
+        {"frame_number": 1, "defer_stream_pipeline_flush": True},
+        {"frame_number": 2, "defer_stream_pipeline_flush": True},
+    ]
+    assert engine.flush_calls == [2]
+
+
+def test_instance_segmentation_stream_pipeline_activation_requires_depth_above_one(
+    monkeypatch,
+) -> None:
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=_FakeModelManager(inference_results=[]),
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    monkeypatch.setattr(
+        "inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v3.get_rfdetr_pipeline_depth",
+        lambda: 1,
+    )
+    assert block.can_activate_stream_pipeline() is False
+
+    monkeypatch.setattr(
+        "inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v3.get_rfdetr_pipeline_depth",
+        lambda: 2,
+    )
+    assert block.can_activate_stream_pipeline() is True
+
+
+def test_instance_segmentation_stream_flush_drains_model_without_rerunning_workflow() -> (
+    None
+):
+    manager = _FakeModelManager(
+        inference_results=[
+            [_FakeResponse("priming")],
+            [_make_async_placeholder("first-final")],
+        ]
+    )
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    first_result = block.run_locally(
+        images=[_FakeWorkflowImage("frame-1")],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+    second_result = block.run_locally(
+        images=[_FakeWorkflowImage("frame-2")],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+    flushed_results = block.flush_stream_pipeline()
+
+    assert first_result == [
+        {
+            "predictions": "frame-1:priming",
+            "class_filter": ["car"],
+            "model_id": "model",
+        }
+    ]
+    assert second_result[0]["predictions"].result() == "frame-1:first-final"
+    assert flushed_results == [
+        [
+            {
+                "predictions": "frame-2:tail-final",
+                "class_filter": ["car"],
+                "model_id": "model",
+            }
+        ]
+    ]
+    assert manager.infer_calls == 2
+    assert manager.model.flush_calls == 1
+    block.close_stream_pipeline()
+    assert manager.model.shutdown_calls == 1

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Optional
 
+import networkx as nx
 import numpy as np
 import pytest
 
@@ -15,6 +16,16 @@ from inference.core.interfaces.stream.model_handlers.workflows import (
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v3 import (
     RoboflowInstanceSegmentationModelBlockV3,
+)
+from inference.core.workflows.execution_engine.constants import (
+    NODE_COMPILATION_OUTPUT_PROPERTY,
+)
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    DynamicStepInputDefinition,
+    NodeCategory,
+    NodeInputCategory,
+    ParameterSpecification,
+    StepNode,
 )
 from inference_models.models.base.async_handoff import attach_async_response_future
 
@@ -37,6 +48,16 @@ class _FakePipelinedStep:
 
     def close_stream_pipeline(self) -> None:
         self.close_calls += 1
+
+
+class _DisableAwarePipelinedStep(_FakePipelinedStep):
+    def __init__(self, stream_buffer_depth: int) -> None:
+        super().__init__(stream_buffer_depth=stream_buffer_depth)
+        self.disable_calls = 0
+
+    def disable_stream_pipeline_for_workflow(self) -> None:
+        self.disable_calls += 1
+        self._stream_buffer_depth = 0
 
 
 class _FakeExecutionEngine:
@@ -81,6 +102,17 @@ class _FakeExecutionEngine:
         _is_preview,
     ):
         return self.step.flush_stream_pipeline()[0]
+
+
+class _GraphAwareExecutionEngine:
+    def __init__(self, execution_graph, step) -> None:
+        self.step = step
+        self._engine = SimpleNamespace(
+            _compiled_workflow=SimpleNamespace(
+                steps={"segmentation": SimpleNamespace(step=self.step)},
+                execution_graph=execution_graph,
+            )
+        )
 
 
 class _FakeLateActivatingStep:
@@ -191,6 +223,47 @@ class _FakeDownstreamPipelinedExecutionEngine:
         return [{"result": f"downstream-frame-{frame_number}"}]
 
 
+def _step_node(
+    name: str,
+    input_data: Optional[dict] = None,
+) -> StepNode:
+    return StepNode(
+        node_category=NodeCategory.STEP_NODE,
+        name=name,
+        selector=f"$steps.{name}",
+        data_lineage=[],
+        step_manifest=SimpleNamespace(type=f"test/{name}@v1"),
+        input_data=input_data or {},
+    )
+
+
+def _dynamic_input(
+    parameter_name: str,
+    selector: str,
+    category: NodeInputCategory = NodeInputCategory.BATCH_STEP_OUTPUT,
+) -> DynamicStepInputDefinition:
+    return DynamicStepInputDefinition(
+        parameter_specification=ParameterSpecification(
+            parameter_name=parameter_name,
+        ),
+        category=category,
+        data_lineage=[],
+        selector=selector,
+    )
+
+
+def _graph_with_nodes(nodes, edges):
+    graph = nx.DiGraph()
+    for node in nodes:
+        graph.add_node(
+            node.selector,
+            **{NODE_COMPILATION_OUTPUT_PROPERTY: node},
+        )
+    for source, target in edges:
+        graph.add_edge(source, target)
+    return graph
+
+
 class _ImmediateExecutor:
     def submit(self, fn, *args, **kwargs) -> Future:
         future = Future()
@@ -259,6 +332,7 @@ class _FakeModelManager:
         self._inference_results = list(inference_results)
         self.model = _FakeStreamModel()
         self.add_model_calls = []
+        self.requests = []
         self.infer_calls = 0
 
     def add_model(self, model_id: str, api_key: str) -> None:
@@ -266,6 +340,7 @@ class _FakeModelManager:
 
     def infer_from_request_sync(self, model_id: str, request):
         self.infer_calls += 1
+        self.requests.append(request)
         return self._inference_results.pop(0)
 
     def __contains__(self, model_id: str) -> bool:
@@ -389,6 +464,88 @@ def test_wrap_workflow_runner_leaves_non_pipelined_workflows_unchanged() -> None
         )
         is runner
     )
+
+
+def test_wrap_workflow_runner_keeps_stream_pipeline_for_prediction_only_downstream() -> (
+    None
+):
+    step = _DisableAwarePipelinedStep(stream_buffer_depth=1)
+    segmentation = _step_node("segmentation")
+    confidence_filter = _step_node(
+        "confidence_filter",
+        input_data={
+            "predictions": _dynamic_input(
+                parameter_name="predictions",
+                selector="$steps.segmentation.predictions",
+            )
+        },
+    )
+    engine = _GraphAwareExecutionEngine(
+        execution_graph=_graph_with_nodes(
+            nodes=[segmentation, confidence_filter],
+            edges=[("$steps.segmentation", "$steps.confidence_filter")],
+        ),
+        step=step,
+    )
+    runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+    )
+
+    wrapped = wrap_workflow_runner_for_stream_pipeline(
+        workflow_runner=runner,
+        execution_engine=engine,
+    )
+
+    assert isinstance(wrapped, PipelinedWorkflowRunner)
+    assert step.disable_calls == 0
+
+
+def test_wrap_workflow_runner_disables_stream_pipeline_for_downstream_image_inputs() -> (
+    None
+):
+    step = _DisableAwarePipelinedStep(stream_buffer_depth=1)
+    segmentation = _step_node("segmentation")
+    center_crop = _step_node("center_crop")
+    polygon_visualization = _step_node(
+        "polygon_visualization",
+        input_data={
+            "predictions": _dynamic_input(
+                parameter_name="predictions",
+                selector="$steps.segmentation.predictions",
+            ),
+            "image": _dynamic_input(
+                parameter_name="image",
+                selector="$steps.center_crop.crops",
+            ),
+        },
+    )
+    engine = _GraphAwareExecutionEngine(
+        execution_graph=_graph_with_nodes(
+            nodes=[segmentation, center_crop, polygon_visualization],
+            edges=[
+                ("$steps.center_crop", "$steps.polygon_visualization"),
+                ("$steps.segmentation", "$steps.polygon_visualization"),
+            ],
+        ),
+        step=step,
+    )
+    runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+    )
+
+    wrapped = wrap_workflow_runner_for_stream_pipeline(
+        workflow_runner=runner,
+        execution_engine=engine,
+    )
+
+    assert wrapped is runner
+    assert step.disable_calls == 1
 
 
 def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> None:
@@ -541,6 +698,51 @@ def test_instance_segmentation_stream_pipeline_activation_requires_depth_above_o
         lambda: 2,
     )
     assert block.can_activate_stream_pipeline() is True
+
+
+def test_instance_segmentation_stream_pipeline_is_disabled_for_generated_batches() -> (
+    None
+):
+    manager = _FakeModelManager(
+        inference_results=[
+            [_FakeResponse("frame-1-a"), _FakeResponse("frame-1-b")],
+        ]
+    )
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{image.tag}:{prediction['tag']}",
+            "model_id": model_id,
+        }
+        for image, prediction in zip(images, predictions)
+    ]
+
+    result = block.run_locally(
+        images=[_FakeWorkflowImage("slice-1"), _FakeWorkflowImage("slice-2")],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=None,
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    assert manager.requests[0].disable_stream_pipeline is True
+    assert block.stream_pipeline_depth() == 0
+    assert result == [
+        {"predictions": "slice-1:frame-1-a", "model_id": "model"},
+        {"predictions": "slice-2:frame-1-b", "model_id": "model"},
+    ]
 
 
 def test_instance_segmentation_stream_flush_drains_model_without_rerunning_workflow() -> (

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -55,6 +55,7 @@ class _FakeExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         self.calls.append(
@@ -64,6 +65,7 @@ class _FakeExecutionEngine:
                 "serialize_results": serialize_results,
                 "is_preview": _is_preview,
                 "defer_stream_pipeline_flush": defer_stream_pipeline_flush,
+                "resolve_output_futures": resolve_output_futures,
             }
         )
         prediction_frame = frame_number - self._stream_buffer_depth
@@ -120,6 +122,7 @@ class _FakeLateActivatingExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         # Real RF-DETR workflow steps only know whether stream pipelining is
@@ -156,12 +159,14 @@ class _FakeDownstreamPipelinedExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         self.calls.append(
             {
                 "frame_number": frame_number,
                 "defer_stream_pipeline_flush": defer_stream_pipeline_flush,
+                "resolve_output_futures": resolve_output_futures,
             }
         )
         if defer_stream_pipeline_flush:
@@ -295,6 +300,7 @@ def test_workflow_runner_without_stream_buffering_returns_current_frame() -> Non
             "serialize_results": True,
             "is_preview": True,
             "defer_stream_pipeline_flush": False,
+            "resolve_output_futures": True,
         }
     ]
 
@@ -355,6 +361,7 @@ def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> No
             "serialize_results": False,
             "is_preview": False,
             "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
         },
         {
             "frame_number": 2,
@@ -362,6 +369,7 @@ def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> No
             "serialize_results": False,
             "is_preview": False,
             "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
         },
     ]
 
@@ -431,8 +439,16 @@ def test_pipelined_workflow_runner_preserves_frame_alignment_for_downstream_step
     assert flushed_results[0].predictions == [{"result": "downstream-frame-2"}]
     assert flushed_results[0].video_frames == [frame_2]
     assert engine.calls == [
-        {"frame_number": 1, "defer_stream_pipeline_flush": True},
-        {"frame_number": 2, "defer_stream_pipeline_flush": True},
+        {
+            "frame_number": 1,
+            "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
+        },
+        {
+            "frame_number": 2,
+            "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
+        },
     ]
     assert engine.flush_calls == [2]
 

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -1,8 +1,10 @@
 from concurrent.futures import Future
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Optional
 
 import numpy as np
+import pytest
 
 from inference.core.interfaces.camera.entities import VideoFrame
 from inference.core.interfaces.stream.model_handlers.workflows import (
@@ -200,25 +202,41 @@ class _ImmediateExecutor:
 
 
 class _FakeWorkflowImage:
-    def __init__(self, tag: str) -> None:
+    def __init__(self, tag: str, width: int = 8, height: int = 8) -> None:
         self.tag = tag
+        self._image = np.zeros((height, width, 3), dtype=np.uint8)
 
     def to_inference_format(self, numpy_preferred: bool):
         assert numpy_preferred is True
         return {
             "type": "numpy_object",
-            "value": np.zeros((8, 8, 3), dtype=np.uint8),
+            "value": self._image,
         }
+
+    @property
+    def numpy_image(self):
+        return self._image
 
 
 class _FakeResponse:
-    def __init__(self, tag: str) -> None:
+    def __init__(
+        self,
+        tag: str,
+        width: int = 8,
+        height: int = 8,
+    ) -> None:
         self.tag = tag
+        self.width = width
+        self.height = height
 
     def model_dump(self, by_alias: bool, exclude_none: bool):
         assert by_alias is True
         assert exclude_none is True
-        return {"tag": self.tag}
+        return {
+            "tag": self.tag,
+            "image": {"width": self.width, "height": self.height},
+            "predictions": [],
+        }
 
 
 class _FakeStreamModel:
@@ -258,11 +276,61 @@ class _FakeModelManager:
         return self.model
 
 
-def _make_async_placeholder(response_tag: str) -> _FakeResponse:
+class _ContextAwareModelManager(_FakeModelManager):
+    def __init__(self, mode: str) -> None:
+        super().__init__(inference_results=[])
+        self.mode = mode
+        self.source_infos = []
+
+    def infer_from_request_sync(self, model_id: str, request):
+        self.infer_calls += 1
+        self.source_infos.append(request.source_info)
+        if self.infer_calls == 1:
+            return [_FakeResponse("priming", width=8, height=8)]
+        if self.mode == "previous":
+            return [
+                _make_async_placeholder(
+                    "first-final",
+                    context_id=self.source_infos[0],
+                    response_width=8,
+                    response_height=8,
+                )
+            ]
+        if self.mode == "current-with-old-size":
+            return [
+                _make_async_placeholder(
+                    "first-final",
+                    context_id=request.source_info,
+                    response_width=8,
+                    response_height=8,
+                )
+            ]
+        return [
+            _make_async_placeholder(
+                "first-final",
+                context_id="missing-context",
+                response_width=8,
+                response_height=8,
+            )
+        ]
+
+
+def _make_async_placeholder(
+    response_tag: str,
+    context_id: Optional[str] = None,
+    response_width: int = 8,
+    response_height: int = 8,
+) -> _FakeResponse:
     future = Future()
-    future.set_result([_FakeResponse(response_tag)])
+    future.set_result(
+        [_FakeResponse(response_tag, width=response_width, height=response_height)]
+    )
     response = _FakeResponse("placeholder")
-    attach_async_response_future(response=response, response_future=future)
+    attach_async_response_future(
+        response=response,
+        response_future=future,
+        context_id=context_id,
+    )
     return response
 
 
@@ -551,3 +619,156 @@ def test_instance_segmentation_stream_flush_drains_model_without_rerunning_workf
     assert manager.model.flush_calls == 1
     block.close_stream_pipeline()
     assert manager.model.shutdown_calls == 1
+
+
+def test_instance_segmentation_stream_pipeline_uses_response_context_id() -> None:
+    manager = _ContextAwareModelManager(mode="previous")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+    second_result = block.run_locally(
+        images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    assert second_result[0]["predictions"].result() == "frame-1:first-final"
+
+
+def test_instance_segmentation_stream_pipeline_rejects_unknown_context_id() -> None:
+    manager = _ContextAwareModelManager(mode="missing")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    with pytest.raises(RuntimeError, match="context did not match"):
+        block.run_locally(
+            images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+            model_id="model",
+            class_agnostic_nms=None,
+            class_filter=["car"],
+            confidence=0.4,
+            iou_threshold=None,
+            max_detections=None,
+            max_candidates=None,
+            mask_decode_mode="accurate",
+            tradeoff_factor=None,
+            disable_active_learning=None,
+            active_learning_target_dataset=None,
+            enforce_dense_masks_in_inference_models=False,
+        )
+
+
+def test_instance_segmentation_stream_pipeline_rejects_image_metadata_mismatch() -> (
+    None
+):
+    manager = _ContextAwareModelManager(mode="current-with-old-size")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+    second_result = block.run_locally(
+        images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    with pytest.raises(RuntimeError, match="image metadata"):
+        second_result[0]["predictions"].result()

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -1,8 +1,10 @@
 from concurrent.futures import Future
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Optional
 
 import numpy as np
+import pytest
 
 from inference.core.interfaces.camera.entities import VideoFrame
 from inference.core.interfaces.stream.model_handlers.workflows import (
@@ -14,6 +16,7 @@ from inference.core.workflows.core_steps.common.entities import StepExecutionMod
 from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v3 import (
     RoboflowInstanceSegmentationModelBlockV3,
 )
+from inference.core.workflows.execution_engine.entities.base import Batch, VideoMetadata
 from inference_models.models.base.async_handoff import attach_async_response_future
 
 
@@ -200,25 +203,60 @@ class _ImmediateExecutor:
 
 
 class _FakeWorkflowImage:
-    def __init__(self, tag: str) -> None:
+    def __init__(
+        self,
+        tag: str,
+        width: int = 8,
+        height: int = 8,
+        frame_number: Optional[int] = None,
+    ) -> None:
         self.tag = tag
+        self._image = np.zeros((height, width, 3), dtype=np.uint8)
+        if frame_number is None and tag.rsplit("-", maxsplit=1)[-1].isdigit():
+            frame_number = int(tag.rsplit("-", maxsplit=1)[-1])
+        if frame_number is None:
+            frame_number = 1
+        self._video_metadata = VideoMetadata(
+            video_identifier=f"video-{tag}",
+            frame_number=frame_number,
+            frame_timestamp=datetime.now(),
+        )
+
+    @property
+    def video_metadata(self) -> VideoMetadata:
+        return self._video_metadata
+
+    @property
+    def numpy_image(self):
+        return self._image
 
     def to_inference_format(self, numpy_preferred: bool):
         assert numpy_preferred is True
         return {
             "type": "numpy_object",
-            "value": np.zeros((8, 8, 3), dtype=np.uint8),
+            "value": self._image,
         }
 
 
 class _FakeResponse:
-    def __init__(self, tag: str) -> None:
+    def __init__(
+        self,
+        tag: str,
+        width: int = 8,
+        height: int = 8,
+    ) -> None:
         self.tag = tag
+        self.width = width
+        self.height = height
 
     def model_dump(self, by_alias: bool, exclude_none: bool):
         assert by_alias is True
         assert exclude_none is True
-        return {"tag": self.tag}
+        return {
+            "tag": self.tag,
+            "image": {"width": self.width, "height": self.height},
+            "predictions": [],
+        }
 
 
 class _FakeStreamModel:
@@ -258,11 +296,62 @@ class _FakeModelManager:
         return self.model
 
 
-def _make_async_placeholder(response_tag: str) -> _FakeResponse:
+class _ContextAwareModelManager(_FakeModelManager):
+    def __init__(self, mode: str) -> None:
+        super().__init__(inference_results=[])
+        self.mode = mode
+        self.stream_pipeline_context_ids = []
+
+    def infer_from_request_sync(self, model_id: str, request):
+        self.infer_calls += 1
+        assert request.source_info is None
+        self.stream_pipeline_context_ids.append(request.stream_pipeline_context_id)
+        if self.infer_calls == 1:
+            return [_FakeResponse("priming", width=8, height=8)]
+        if self.mode == "previous":
+            return [
+                _make_async_placeholder(
+                    "first-final",
+                    context_id=self.stream_pipeline_context_ids[0],
+                    response_width=8,
+                    response_height=8,
+                )
+            ]
+        if self.mode == "current-with-old-size":
+            return [
+                _make_async_placeholder(
+                    "first-final",
+                    context_id=request.stream_pipeline_context_id,
+                    response_width=8,
+                    response_height=8,
+                )
+            ]
+        return [
+            _make_async_placeholder(
+                "first-final",
+                context_id="missing-context",
+                response_width=8,
+                response_height=8,
+            )
+        ]
+
+
+def _make_async_placeholder(
+    response_tag: str,
+    context_id: Optional[str] = None,
+    response_width: int = 8,
+    response_height: int = 8,
+) -> _FakeResponse:
     future = Future()
-    future.set_result([_FakeResponse(response_tag)])
+    future.set_result(
+        [_FakeResponse(response_tag, width=response_width, height=response_height)]
+    )
     response = _FakeResponse("placeholder")
-    attach_async_response_future(response=response, response_future=future)
+    attach_async_response_future(
+        response=response,
+        response_future=future,
+        context_id=context_id,
+    )
     return response
 
 
@@ -551,3 +640,177 @@ def test_instance_segmentation_stream_flush_drains_model_without_rerunning_workf
     assert manager.model.flush_calls == 1
     block.close_stream_pipeline()
     assert manager.model.shutdown_calls == 1
+
+
+def test_instance_segmentation_stream_pipeline_uses_response_context_id() -> None:
+    manager = _ContextAwareModelManager(mode="previous")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+    second_result = block.run_locally(
+        images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    assert second_result[0]["predictions"].result() == "frame-1:first-final"
+    assert len(manager.stream_pipeline_context_ids) == 2
+    assert (
+        manager.stream_pipeline_context_ids[0]
+        != manager.stream_pipeline_context_ids[1]
+    )
+
+
+def test_instance_segmentation_stream_pipeline_rejects_unknown_context_id() -> None:
+    manager = _ContextAwareModelManager(mode="missing")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    with pytest.raises(RuntimeError, match="context did not match"):
+        block.run_locally(
+            images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+            model_id="model",
+            class_agnostic_nms=None,
+            class_filter=["car"],
+            confidence=0.4,
+            iou_threshold=None,
+            max_detections=None,
+            max_candidates=None,
+            mask_decode_mode="accurate",
+            tradeoff_factor=None,
+            disable_active_learning=None,
+            active_learning_target_dataset=None,
+            enforce_dense_masks_in_inference_models=False,
+        )
+
+
+def test_instance_segmentation_stream_pipeline_rejects_image_metadata_mismatch() -> (
+    None
+):
+    manager = _ContextAwareModelManager(mode="current-with-old-size")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+    second_result = block.run_locally(
+        images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    with pytest.raises(RuntimeError, match="image metadata"):
+        second_result[0]["predictions"].result()
+
+
+def test_instance_segmentation_stream_context_id_includes_frame_metadata() -> None:
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=SimpleNamespace(__contains__=lambda *_args, **_kwargs: False),
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    image = _FakeWorkflowImage("frame-7", width=8, height=8, frame_number=7)
+
+    context_id = block._build_stream_context_id(
+        images=Batch.init(content=[image], indices=[(0,)]),
+    )
+
+    assert "video-frame-7" in context_id
+    assert ":7:" in context_id

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -98,6 +98,7 @@ def _make_pipeline_adapter(
     adapter._pending_futures = deque()
     adapter._response_futures = deque()
     adapter._response_executor = None
+    adapter._gpu_submit_generation = 0
     adapter._model = _FakePipelineModel(futures=futures, ops=ops)
     adapter.class_names = []
     adapter.map_inference_kwargs = lambda kwargs: dict(kwargs)

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -22,6 +22,7 @@ from inference_models import (
     InstanceDetections,
     MultiLabelClassificationPrediction,
 )
+from inference_models.models.base.async_handoff import attach_adapter_mapped_kwargs
 
 
 class _ImmediateExecutor:
@@ -414,3 +415,38 @@ def test_pipeline_depth_three_submits_oldest_pending_before_forward() -> None:
         "submit:f3",
         "result:f1",
     ]
+
+
+def test_pipeline_submit_response_build_stores_response_context_id() -> None:
+    ops: list[str] = []
+    future = _FakePipelineFuture(name="f1", ops=ops)
+    adapter = _make_pipeline_adapter(futures=[future], ops=ops, pipeline_depth=2)
+
+    attach_adapter_mapped_kwargs(
+        future,
+        {},
+        stream_pipeline_context_id="context-xyz",
+    )
+    adapter._submit_response_build(
+        future,
+        _make_meta("frame-1"),
+        {},
+    )
+
+    assert adapter._response_futures[-1][1] == "context-xyz"
+
+
+def test_map_inference_kwargs_strips_stream_pipeline_context_id() -> None:
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._model = SimpleNamespace(supported_mask_formats={"rle"})
+
+    mapped = adapter.map_inference_kwargs(
+        {
+            "stream_pipeline_context_id": "context-xyz",
+            "disable_preproc_contrast": False,
+            "disable_preproc_grayscale": False,
+            "disable_preproc_static_crop": False,
+        }
+    )
+
+    assert "stream_pipeline_context_id" not in mapped

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -86,6 +86,16 @@ def _make_meta(tag: str):
     ]
 
 
+def _make_batch_meta(*tags: str):
+    return [
+        SimpleNamespace(
+            tag=tag,
+            original_size=SimpleNamespace(width=10, height=20),
+        )
+        for tag in tags
+    ]
+
+
 def _make_pipeline_adapter(
     futures: list[_FakePipelineFuture],
     ops: list[str],
@@ -170,6 +180,25 @@ def test_pipeline_postprocess_uses_sync_path_for_non_future_predictions() -> Non
     assert responses == ["meta-1"]
     assert len(adapter._model.post_process_calls) == 1
     assert adapter._model.post_process_calls[0][0] == "sync-raw"
+
+
+def test_sync_postprocess_disables_triton_postprocess_for_batches() -> None:
+    ops: list[str] = []
+    adapter = _make_pipeline_adapter(
+        futures=[],
+        ops=ops,
+        pipeline_depth=2,
+    )
+
+    adapter.postprocess(
+        "sync-raw",
+        _make_batch_meta("meta-1", "meta-2"),
+        response_mask_format="dense",
+    )
+
+    assert len(adapter._model.post_process_calls) == 1
+    kwargs = adapter._model.post_process_calls[0][2]
+    assert kwargs["use_triton_postprocess"] is False
 
 
 def test_workflow_response_fast_dataclass_path_is_disabled_at_depth_one() -> None:

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -1,17 +1,220 @@
 """Unit tests for inference.core.models.inference_models_adapters."""
 
+from collections import deque
+from concurrent.futures import Future
+from types import SimpleNamespace
+
 import pytest
 import torch
 
+from inference.core.entities.responses.inference import (
+    InstanceSegmentationInferenceResponse,
+    InstanceSegmentationInferenceResponseDC,
+)
 from inference.core.exceptions import PostProcessingError
 from inference.core.models.inference_models_adapters import (
+    InferenceModelsInstanceSegmentationAdapter,
     prepare_classification_response,
     prepare_multi_label_classification_response,
 )
 from inference_models import (
     ClassificationPrediction,
+    InstanceDetections,
     MultiLabelClassificationPrediction,
 )
+
+
+class _ImmediateExecutor:
+    def submit(self, fn, *args, **kwargs) -> Future:
+        future = Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except BaseException as error:  # pragma: no cover - defensive
+            future.set_exception(error)
+        return future
+
+
+class _FakePipelineFuture:
+    def __init__(self, name: str, ops: list[str]):
+        self.name = name
+        self.ops = ops
+        self.submitted_meta = []
+        self._adapter_gpu_work_submitted = False
+
+    def submit_gpu_work(self, meta=None) -> None:
+        self.ops.append(f"submit:{self.name}")
+        self.submitted_meta.append(meta)
+
+    def result(self):
+        assert self.submitted_meta, f"result() called before submit for {self.name}"
+        self.ops.append(f"result:{self.name}")
+        return [SimpleNamespace(name=self.name)]
+
+    def done(self) -> bool:
+        return bool(self.submitted_meta)
+
+
+class _FakePipelineModel:
+    supported_mask_formats = {"rle"}
+
+    def __init__(self, futures: list[_FakePipelineFuture], ops: list[str]):
+        self._futures = deque(futures)
+        self._ops = ops
+        self.forward_calls = []
+        self.post_process_calls = []
+
+    def forward(self, img_in, **kwargs):
+        self.forward_calls.append((img_in, kwargs))
+        return "sync-raw"
+
+    def forward_async(self, _img_in, _meta, **_kwargs):
+        future = self._futures.popleft()
+        self._ops.append(f"forward:{future.name}")
+        return future
+
+    def post_process(self, predictions, meta, **kwargs):
+        self.post_process_calls.append((predictions, meta, kwargs))
+        return ["sync-detections"]
+
+
+def _make_meta(tag: str):
+    return [
+        SimpleNamespace(
+            tag=tag,
+            original_size=SimpleNamespace(width=10, height=20),
+        )
+    ]
+
+
+def _make_pipeline_adapter(
+    futures: list[_FakePipelineFuture],
+    ops: list[str],
+    pipeline_depth: int = 2,
+) -> InferenceModelsInstanceSegmentationAdapter:
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._pipeline_depth = pipeline_depth
+    adapter._response_delay = max(1, pipeline_depth - 1)
+    adapter._pending_gpu_submissions = deque()
+    adapter._pending_futures = deque()
+    adapter._response_futures = deque()
+    adapter._response_executor = None
+    adapter._model = _FakePipelineModel(futures=futures, ops=ops)
+    adapter.class_names = []
+    adapter.map_inference_kwargs = lambda kwargs: dict(kwargs)
+    adapter._get_response_executor = lambda: _ImmediateExecutor()
+    adapter._build_responses_from_detections = (
+        lambda _detections, preprocess_return_metadata, **_kwargs: [
+            preprocess_return_metadata[0].tag
+        ]
+    )
+
+    return adapter
+
+
+def test_pipeline_depth_falls_back_to_one_for_unsupported_models(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "inference.core.models.inference_models_adapters.get_rfdetr_pipeline_depth",
+        lambda: 2,
+    )
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._model = SimpleNamespace(supports_stream_pipeline=False)
+
+    assert adapter._resolve_pipeline_depth() == 1
+
+
+def test_pipeline_depth_honors_requested_depth_for_supported_models(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "inference.core.models.inference_models_adapters.get_rfdetr_pipeline_depth",
+        lambda: 3,
+    )
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._model = SimpleNamespace(supports_stream_pipeline=True)
+
+    assert adapter._resolve_pipeline_depth() == 3
+
+
+def test_pipeline_uses_sync_forward_for_batched_requests() -> None:
+    ops: list[str] = []
+    future = _FakePipelineFuture(name="f1", ops=ops)
+    adapter = _make_pipeline_adapter(
+        futures=[future],
+        ops=ops,
+        pipeline_depth=2,
+    )
+    img_in = SimpleNamespace(_pre_processing_meta=[object(), object()])
+
+    result = adapter.predict(img_in, response_mask_format="dense")
+
+    assert result == "sync-raw"
+    assert ops == []
+    assert len(adapter._model.forward_calls) == 1
+
+
+def test_pipeline_postprocess_uses_sync_path_for_non_future_predictions() -> None:
+    ops: list[str] = []
+    adapter = _make_pipeline_adapter(
+        futures=[],
+        ops=ops,
+        pipeline_depth=2,
+    )
+
+    responses = adapter.postprocess(
+        "sync-raw",
+        _make_meta("meta-1"),
+        response_mask_format="dense",
+    )
+
+    assert responses == ["meta-1"]
+    assert len(adapter._model.post_process_calls) == 1
+    assert adapter._model.post_process_calls[0][0] == "sync-raw"
+
+
+def test_workflow_response_fast_dataclass_path_is_disabled_at_depth_one() -> None:
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._pipeline_depth = 1
+    adapter.class_names = ["car"]
+    metadata = [SimpleNamespace(original_size=SimpleNamespace(width=4, height=4))]
+    detections = [
+        InstanceDetections(
+            xyxy=torch.tensor([[1, 1, 3, 3]], dtype=torch.int32),
+            confidence=torch.tensor([0.9], dtype=torch.float32),
+            class_id=torch.tensor([0], dtype=torch.int32),
+            mask=torch.zeros((1, 4, 4), dtype=torch.uint8),
+        )
+    ]
+
+    responses = adapter._build_responses_from_detections(
+        detections,
+        metadata,
+        source="workflow-execution",
+    )
+
+    assert isinstance(responses[0], InstanceSegmentationInferenceResponse)
+
+
+def test_workflow_response_fast_dataclass_path_is_enabled_above_depth_one() -> None:
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._pipeline_depth = 2
+    adapter.class_names = ["car"]
+    metadata = [SimpleNamespace(original_size=SimpleNamespace(width=4, height=4))]
+    detections = [
+        InstanceDetections(
+            xyxy=torch.tensor([[1, 1, 3, 3]], dtype=torch.int32),
+            confidence=torch.tensor([0.9], dtype=torch.float32),
+            class_id=torch.tensor([0], dtype=torch.int32),
+            mask=torch.zeros((1, 4, 4), dtype=torch.uint8),
+        )
+    ]
+
+    responses = adapter._build_responses_from_detections(
+        detections,
+        metadata,
+        source="workflow-execution",
+    )
+
+    assert isinstance(responses[0], InstanceSegmentationInferenceResponseDC)
 
 
 def test_prepare_multi_label_response_uses_class_ids_for_predicted_classes() -> None:
@@ -86,3 +289,128 @@ def test_prepare_classification_response_fails_on_class_count_mismatch() -> None
             class_names=["cat", "dog"],
             confidence_threshold=0.0,
         )
+
+
+def test_pipeline_submits_previous_future_before_next_forward() -> None:
+    ops: list[str] = []
+    future_1 = _FakePipelineFuture(name="f1", ops=ops)
+    future_2 = _FakePipelineFuture(name="f2", ops=ops)
+    adapter = _make_pipeline_adapter(
+        futures=[future_1, future_2],
+        ops=ops,
+        pipeline_depth=2,
+    )
+
+    meta_1 = _make_meta("meta-1")
+    prediction_1 = adapter.predict("frame-1", response_mask_format="dense")
+    priming = adapter.postprocess(
+        prediction_1,
+        meta_1,
+        response_mask_format="dense",
+    )
+
+    assert len(priming) == 1
+    assert future_1.submitted_meta == []
+
+    adapter.predict("frame-2", response_mask_format="dense")
+
+    assert future_1.submitted_meta == [meta_1]
+    assert ops == ["forward:f1", "submit:f1", "forward:f2"]
+
+
+def test_pipeline_returns_previous_frame_response_using_previous_metadata() -> None:
+    ops: list[str] = []
+    future_1 = _FakePipelineFuture(name="f1", ops=ops)
+    future_2 = _FakePipelineFuture(name="f2", ops=ops)
+    adapter = _make_pipeline_adapter(
+        futures=[future_1, future_2],
+        ops=ops,
+        pipeline_depth=2,
+    )
+
+    meta_1 = _make_meta("meta-1")
+    meta_2 = _make_meta("meta-2")
+    prediction_1 = adapter.predict("frame-1", response_mask_format="dense")
+    adapter.postprocess(prediction_1, meta_1, response_mask_format="dense")
+
+    prediction_2 = adapter.predict("frame-2", response_mask_format="dense")
+    responses = adapter.postprocess(
+        prediction_2,
+        meta_2,
+        response_mask_format="dense",
+    )
+
+    assert responses == ["meta-1"]
+    assert future_1.submitted_meta == [meta_1]
+    assert future_2.submitted_meta == [meta_2]
+    assert ops == [
+        "forward:f1",
+        "submit:f1",
+        "forward:f2",
+        "submit:f2",
+        "result:f1",
+    ]
+
+
+def test_pipeline_flush_submits_remaining_gpu_work_before_finalizing() -> None:
+    ops: list[str] = []
+    future_1 = _FakePipelineFuture(name="f1", ops=ops)
+    adapter = _make_pipeline_adapter(
+        futures=[future_1],
+        ops=ops,
+        pipeline_depth=2,
+    )
+
+    meta_1 = _make_meta("meta-1")
+    prediction_1 = adapter.predict("frame-1", response_mask_format="dense")
+    adapter.postprocess(prediction_1, meta_1, response_mask_format="dense")
+
+    responses = adapter.flush()
+
+    assert responses == ["meta-1"]
+    assert future_1.submitted_meta == [meta_1]
+    assert ops == ["forward:f1", "submit:f1", "result:f1"]
+
+
+def test_pipeline_depth_three_submits_oldest_pending_before_forward() -> None:
+    ops: list[str] = []
+    future_1 = _FakePipelineFuture(name="f1", ops=ops)
+    future_2 = _FakePipelineFuture(name="f2", ops=ops)
+    future_3 = _FakePipelineFuture(name="f3", ops=ops)
+    adapter = _make_pipeline_adapter(
+        futures=[future_1, future_2, future_3],
+        ops=ops,
+        pipeline_depth=3,
+    )
+
+    meta_1 = _make_meta("meta-1")
+    meta_2 = _make_meta("meta-2")
+    meta_3 = _make_meta("meta-3")
+
+    prediction_1 = adapter.predict("frame-1", response_mask_format="dense")
+    adapter.postprocess(prediction_1, meta_1, response_mask_format="dense")
+
+    prediction_2 = adapter.predict("frame-2", response_mask_format="dense")
+    priming = adapter.postprocess(prediction_2, meta_2, response_mask_format="dense")
+
+    prediction_3 = adapter.predict("frame-3", response_mask_format="dense")
+    responses = adapter.postprocess(
+        prediction_3,
+        meta_3,
+        response_mask_format="dense",
+    )
+
+    assert len(priming) == 1
+    assert responses == ["meta-1"]
+    assert future_1.submitted_meta == [meta_1]
+    assert future_2.submitted_meta == [meta_2]
+    assert future_3.submitted_meta == [meta_3]
+    assert ops == [
+        "forward:f1",
+        "submit:f1",
+        "forward:f2",
+        "submit:f2",
+        "forward:f3",
+        "submit:f3",
+        "result:f1",
+    ]

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -417,36 +417,15 @@ def test_pipeline_depth_three_submits_oldest_pending_before_forward() -> None:
     ]
 
 
-def test_pipeline_submit_response_build_stores_response_context_id() -> None:
+def test_pipeline_flush_raises_on_response_future_timeout(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "inference.core.models.inference_models_adapters.WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT",
+        0.001,
+    )
     ops: list[str] = []
-    future = _FakePipelineFuture(name="f1", ops=ops)
-    adapter = _make_pipeline_adapter(futures=[future], ops=ops, pipeline_depth=2)
+    adapter = _make_pipeline_adapter(futures=[], ops=ops, pipeline_depth=2)
+    hung_future = Future()
+    adapter._response_futures.append((hung_future, None))
 
-    attach_adapter_mapped_kwargs(
-        future,
-        {},
-        stream_pipeline_context_id="context-xyz",
-    )
-    adapter._submit_response_build(
-        future,
-        _make_meta("frame-1"),
-        {},
-    )
-
-    assert adapter._response_futures[-1][1] == "context-xyz"
-
-
-def test_map_inference_kwargs_strips_stream_pipeline_context_id() -> None:
-    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
-    adapter._model = SimpleNamespace(supported_mask_formats={"rle"})
-
-    mapped = adapter.map_inference_kwargs(
-        {
-            "stream_pipeline_context_id": "context-xyz",
-            "disable_preproc_contrast": False,
-            "disable_preproc_grayscale": False,
-            "disable_preproc_static_crop": False,
-        }
-    )
-
-    assert "stream_pipeline_context_id" not in mapped
+    with pytest.raises(RuntimeError, match="Timed out while waiting for"):
+        adapter.flush()

--- a/tests/inference/unit_tests/core/utils/test_rle_to_polygon.py
+++ b/tests/inference/unit_tests/core/utils/test_rle_to_polygon.py
@@ -1,0 +1,230 @@
+import warnings
+from typing import Iterable, List, Tuple
+
+import numpy as np
+import pytest
+from pycocotools import mask as mask_utils
+
+from inference.core.utils.postprocess import mask2poly
+from inference.core.utils.rle_to_polygon import rle_masks_to_polygons
+from inference_models.models.base.types import InstancesRLEMasks
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:__array__ implementation doesn't accept a copy keyword.*:DeprecationWarning"
+)
+
+
+def _legacy_rle_masks2poly(masks: InstancesRLEMasks) -> List[np.ndarray]:
+    segments = []
+    h, w = masks.image_size
+    for counts in masks.masks:
+        rle_dict = {"size": [h, w], "counts": counts}
+        decoded_rle = np.ascontiguousarray(mask_utils.decode(rle_dict))
+        if not np.any(decoded_rle):
+            segments.append(np.zeros((0, 2), dtype=np.float32))
+            continue
+        segments.append(mask2poly(decoded_rle))
+    return segments
+
+
+def _to_instances(masks: Iterable[np.ndarray]) -> InstancesRLEMasks:
+    masks = list(masks)
+    assert masks
+    image_size = tuple(masks[0].shape)
+    rles = [_encode_mask(mask) for mask in masks]
+    return InstancesRLEMasks(image_size=image_size, masks=rles)
+
+
+def _encode_mask(mask: np.ndarray) -> bytes:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="__array__ implementation doesn't accept a copy keyword.*",
+            category=DeprecationWarning,
+        )
+        return mask_utils.encode(np.asfortranarray(mask.astype(np.uint8)))["counts"]
+
+
+def _assert_polygons_exactly_equal(
+    actual: List[np.ndarray],
+    expected: List[np.ndarray],
+) -> None:
+    assert len(actual) == len(expected)
+    for actual_poly, expected_poly in zip(actual, expected):
+        assert actual_poly.dtype == expected_poly.dtype
+        assert actual_poly.shape == expected_poly.shape
+        assert np.array_equal(actual_poly, expected_poly)
+
+
+def _uncompressed_counts(mask: np.ndarray) -> List[int]:
+    flat = mask.astype(np.uint8).ravel(order="F")
+    if flat.size == 0:
+        return []
+    counts = []
+    current = 0
+    run_length = 0
+    for value in flat:
+        value = int(value)
+        if value == current:
+            run_length += 1
+        else:
+            counts.append(run_length)
+            current = value
+            run_length = 1
+    counts.append(run_length)
+    return counts
+
+
+class _FakeLazyRLEMasks:
+    def __init__(self, image_size: Tuple[int, int], masks: List[np.ndarray]) -> None:
+        self.image_size = image_size
+        counts = [_uncompressed_counts(mask) for mask in masks]
+        max_len = max(len(c) for c in counts)
+        self._rle_counts_cpu = np.zeros((len(counts), max_len), dtype=np.int32)
+        self._rle_lengths_cpu = np.asarray([len(c) for c in counts], dtype=np.int32)
+        for i, count in enumerate(counts):
+            self._rle_counts_cpu[i, : len(count)] = count
+
+    def _ensure_rle_cpu(self) -> None:
+        pass
+
+
+def _deterministic_masks() -> List[np.ndarray]:
+    masks = []
+
+    masks.append(np.zeros((12, 14), dtype=np.uint8))
+
+    single_pixels = np.zeros((12, 14), dtype=np.uint8)
+    single_pixels[0, 0] = 1
+    single_pixels[5, 7] = 1
+    single_pixels[11, 13] = 1
+    masks.append(single_pixels)
+
+    full = np.ones((12, 14), dtype=np.uint8)
+    masks.append(full)
+
+    touching_border = np.zeros((12, 14), dtype=np.uint8)
+    touching_border[0:8, 0:5] = 1
+    touching_border[4:12, 9:14] = 1
+    masks.append(touching_border)
+
+    ring = np.zeros((18, 20), dtype=np.uint8)
+    ring[2:16, 2:18] = 1
+    ring[5:13, 6:14] = 0
+    masks.append(ring)
+
+    side_by_side_holes = np.zeros((18, 22), dtype=np.uint8)
+    side_by_side_holes[2:16, 2:20] = 1
+    side_by_side_holes[5:13, 5:8] = 0
+    side_by_side_holes[5:13, 13:16] = 0
+    masks.append(side_by_side_holes)
+
+    diagonal = np.zeros((16, 16), dtype=np.uint8)
+    for i in range(2, 14):
+        diagonal[i, i] = 1
+        diagonal[i, i - 1] = 1
+    masks.append(diagonal)
+
+    equal_length_components = np.zeros((16, 20), dtype=np.uint8)
+    equal_length_components[2:6, 2:6] = 1
+    equal_length_components[10:14, 14:18] = 1
+    masks.append(equal_length_components)
+
+    jagged = np.zeros((24, 26), dtype=np.uint8)
+    jagged[3:20, 4:22] = 1
+    jagged[7:11, 8:20] = 0
+    jagged[14:18, 9:17] = 0
+    jagged[5:9, 21:24] = 1
+    jagged[18:23, 2:9] = 1
+    masks.append(jagged)
+
+    return masks
+
+
+def test_rle_masks_to_polygons_matches_legacy_dense_path_on_adversarial_masks() -> None:
+    for mask in _deterministic_masks():
+        instances = _to_instances([mask])
+
+        actual = rle_masks_to_polygons(masks=instances)
+        expected = _legacy_rle_masks2poly(masks=instances)
+
+        _assert_polygons_exactly_equal(actual=actual, expected=expected)
+
+
+def test_rle_masks_to_polygons_matches_legacy_dense_path_on_random_masks() -> None:
+    rng = np.random.default_rng(20260530)
+    for height, width in [(1, 1), (2, 3), (5, 7), (16, 17), (31, 29), (64, 64)]:
+        masks = []
+        for density in [0.0, 0.01, 0.05, 0.15, 0.35, 0.65, 1.0]:
+            for _ in range(8):
+                masks.append((rng.random((height, width)) < density).astype(np.uint8))
+        instances = _to_instances(masks)
+
+        actual = rle_masks_to_polygons(masks=instances)
+        expected = _legacy_rle_masks2poly(masks=instances)
+
+        _assert_polygons_exactly_equal(actual=actual, expected=expected)
+
+
+def test_rle_masks_to_polygons_matches_legacy_dense_path_for_lazy_uncompressed_counts() -> (
+    None
+):
+    for mask in _deterministic_masks():
+        legacy_instances = _to_instances([mask])
+        lazy_instances = _FakeLazyRLEMasks(
+            image_size=legacy_instances.image_size,
+            masks=[mask],
+        )
+
+        actual = rle_masks_to_polygons(masks=lazy_instances)
+        expected = _legacy_rle_masks2poly(masks=legacy_instances)
+
+        _assert_polygons_exactly_equal(actual=actual, expected=expected)
+
+
+def test_adapter_rle_masks2poly_matches_legacy_dense_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inference.core.models import inference_models_adapters
+
+    monkeypatch.setattr(
+        inference_models_adapters,
+        "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED",
+        False,
+    )
+
+    for mask in _deterministic_masks():
+        instances = _to_instances([mask])
+
+        actual = inference_models_adapters.rle_masks2poly(masks=instances)
+        expected = _legacy_rle_masks2poly(masks=instances)
+
+        _assert_polygons_exactly_equal(actual=actual, expected=expected)
+
+
+def test_adapter_rle_masks2poly_uses_sparse_path_only_with_triton_postproc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inference.core.models import inference_models_adapters
+
+    instances = _to_instances([np.zeros((8, 8), dtype=np.uint8)])
+    sentinel = [np.array([[1.0, 2.0]], dtype=np.float32)]
+    calls = []
+
+    def fake_sparse_converter(masks):
+        calls.append(masks)
+        return sentinel
+
+    monkeypatch.setattr(
+        inference_models_adapters,
+        "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        inference_models_adapters,
+        "rle_masks_to_polygons",
+        fake_sparse_converter,
+    )
+
+    assert inference_models_adapters.rle_masks2poly(masks=instances) is sentinel
+    assert calls == [instances]

--- a/tests/workflows/integration_tests/execution/control_flow_with_side_effects/test_rfdetr_sliced_workflow_main_parity.py
+++ b/tests/workflows/integration_tests/execution/control_flow_with_side_effects/test_rfdetr_sliced_workflow_main_parity.py
@@ -1,0 +1,1120 @@
+import argparse
+import copy
+import json
+import math
+import os
+import pickle
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import cv2
+import numpy as np
+import pytest
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[5]
+SELF = Path(__file__).resolve()
+PY = sys.executable
+
+MODEL_TYPE = "rfdetr-seg-nano"
+MODEL_ALIAS = "__workflow_parity_rfdetr_seg_nano__"
+LOCAL_WORKFLOW_MODEL_ID = f"{MODEL_ALIAS}/1"
+CONFIDENCE = 0.4
+IMAGE_COUNT = 4
+IMAGE_SIZE = 2560
+VIDEO_REFERENCE = "vehicles_1080p.mp4"
+DEFAULT_BASE_OUT = "/tmp/rfdetr_sliced_workflow_main_base.pkl"
+DEFAULT_CANDIDATE_OUT = "/tmp/rfdetr_sliced_workflow_main_candidate.pkl"
+TRT_PACKAGE_REQUIRED_FILES = (
+    "model_config.json",
+    "class_names.txt",
+    "inference_config.json",
+    "engine.plan",
+)
+ALL_BACKENDS = {
+    "torch",
+    "torch-script",
+    "onnx",
+    "trt",
+    "hugging-face",
+    "ultralytics",
+    "custom",
+}
+BASE_FLAGS_OFF = {
+    "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED": "false",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED": "false",
+    "RFDETR_PIPELINE_DEPTH": "1",
+    "ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND": "false",
+}
+CANDIDATE_FLAGS_ON = {
+    "INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED": "true",
+    "INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED": "true",
+    "RFDETR_PIPELINE_DEPTH": "2",
+    "ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND": "true",
+}
+_VOLATILE_OUTPUT_KEYS = {"detection_id", "inference_id"}
+
+
+@dataclass(frozen=True)
+class WorkflowParityCase:
+    workflow_definition: dict[str, Any]
+    image_count: int
+    image_size: int
+    pass_image_list: bool
+    description: str
+
+
+def _segmentation_step(
+    images_selector: str,
+    *,
+    custom_confidence: float = CONFIDENCE,
+    enforce_dense_masks_in_inference_models: bool = False,
+    class_filter: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    step = {
+        "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+        "name": "segmentation",
+        "images": images_selector,
+        "model_id": LOCAL_WORKFLOW_MODEL_ID,
+        "confidence_mode": "custom",
+        "custom_confidence": custom_confidence,
+        "iou_threshold": 0.3,
+        "max_detections": 300,
+        "max_candidates": 3000,
+        "class_agnostic_nms": False,
+        "mask_decode_mode": "accurate",
+        "tradeoff_factor": 0.0,
+        "disable_active_learning": True,
+        "enforce_dense_masks_in_inference_models": (
+            enforce_dense_masks_in_inference_models
+        ),
+    }
+    if class_filter is not None:
+        step["class_filter"] = class_filter
+    return step
+
+
+def _workflow_definition(steps: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": steps,
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.segmentation.predictions",
+            }
+        ],
+    }
+
+
+SLICED_WORKFLOW_DEFINITION = _workflow_definition(
+    steps=[
+        {
+            "type": "roboflow_core/image_slicer@v2",
+            "name": "image_slicer",
+            "image": "$inputs.image",
+            "slice_width": 640,
+            "slice_height": 640,
+            "overlap_ratio_width": 0.0,
+            "overlap_ratio_height": 0.0,
+        },
+        _segmentation_step(
+            images_selector="$steps.image_slicer.slices",
+            enforce_dense_masks_in_inference_models=False,
+        ),
+    ]
+)
+DIRECT_RLE_WORKFLOW_DEFINITION = _workflow_definition(
+    steps=[
+        _segmentation_step(
+            images_selector="$inputs.image",
+            enforce_dense_masks_in_inference_models=False,
+        )
+    ]
+)
+DIRECT_DENSE_WORKFLOW_DEFINITION = _workflow_definition(
+    steps=[
+        _segmentation_step(
+            images_selector="$inputs.image",
+            enforce_dense_masks_in_inference_models=True,
+        )
+    ]
+)
+DIRECT_CLASS_FILTER_WORKFLOW_DEFINITION = _workflow_definition(
+    steps=[
+        _segmentation_step(
+            images_selector="$inputs.image",
+            enforce_dense_masks_in_inference_models=False,
+            class_filter=["car", "truck", "bus"],
+        )
+    ]
+)
+WORKFLOW_PARITY_CASES = {
+    "sliced_rle_batch": WorkflowParityCase(
+        workflow_definition=SLICED_WORKFLOW_DEFINITION,
+        image_count=IMAGE_COUNT,
+        image_size=IMAGE_SIZE,
+        pass_image_list=True,
+        description="Sliced 4-image workflow; each image fans out to 640px slices.",
+    ),
+    "direct_rle_single": WorkflowParityCase(
+        workflow_definition=DIRECT_RLE_WORKFLOW_DEFINITION,
+        image_count=1,
+        image_size=IMAGE_SIZE,
+        pass_image_list=False,
+        description="Single-image instance segmentation with RLE masks.",
+    ),
+    "direct_dense_single": WorkflowParityCase(
+        workflow_definition=DIRECT_DENSE_WORKFLOW_DEFINITION,
+        image_count=1,
+        image_size=640,
+        pass_image_list=False,
+        description="Single-image instance segmentation with dense masks.",
+    ),
+    "direct_class_filter_single": WorkflowParityCase(
+        workflow_definition=DIRECT_CLASS_FILTER_WORKFLOW_DEFINITION,
+        image_count=1,
+        image_size=IMAGE_SIZE,
+        pass_image_list=False,
+        description="Single-image RLE instance segmentation with class filtering.",
+    ),
+}
+
+
+def bool_env(val: Any) -> bool:
+    if isinstance(val, bool):
+        return val
+    return str(val).lower() in {"true", "1", "t", "y", "yes"}
+
+
+def _repo_import_roots(repo_root: Path) -> list[Path]:
+    return [repo_root, repo_root / "inference_models"]
+
+
+def _child_pythonpath(repo_root: Path, existing_pythonpath: Optional[str]) -> str:
+    entries = [str(path) for path in _repo_import_roots(repo_root) if path.exists()]
+    if existing_pythonpath:
+        entries.append(existing_pythonpath)
+    return os.pathsep.join(entries)
+
+
+def _prioritize_local_packages(repo_root: Path) -> None:
+    for search_root in reversed(_repo_import_roots(repo_root)):
+        search_root_str = str(search_root)
+        if search_root_str in sys.path:
+            sys.path.remove(search_root_str)
+        if search_root.exists():
+            sys.path.insert(0, search_root_str)
+    for module_name in list(sys.modules):
+        if module_name == "inference" or module_name.startswith("inference."):
+            sys.modules.pop(module_name, None)
+        if module_name == "inference_models" or module_name.startswith(
+            "inference_models."
+        ):
+            sys.modules.pop(module_name, None)
+
+
+def _bootstrap_repo_root(repo_root: str) -> Path:
+    repo_path = Path(repo_root).resolve()
+    os.chdir(repo_path)
+    _prioritize_local_packages(repo_path)
+    return repo_path
+
+
+def _git_output(repo_root: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=str(repo_root),
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+def _safe_git_output(repo_root: Path, *args: str, default: str = "<unknown>") -> str:
+    try:
+        return _git_output(repo_root, *args)
+    except subprocess.CalledProcessError:
+        return default
+
+
+def _remove_worktree(worktree_root: Path) -> None:
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(worktree_root)],
+        cwd=str(SCRIPT_REPO_ROOT),
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    shutil.rmtree(worktree_root, ignore_errors=True)
+
+
+def _materialize_target(ref: str) -> dict:
+    if ref.lower() in {"working-tree", "worktree", "current"}:
+        return {
+            "label": (
+                f"{_safe_git_output(SCRIPT_REPO_ROOT, 'rev-parse', '--abbrev-ref', 'HEAD')} "
+                "(working-tree)"
+            ),
+            "repo_root": SCRIPT_REPO_ROOT,
+            "cleanup": None,
+        }
+    worktree_root = Path(tempfile.mkdtemp(prefix="rfdetr-sliced-workflow-parity-"))
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree_root), ref],
+        cwd=str(SCRIPT_REPO_ROOT),
+        check=True,
+    )
+    return {
+        "label": ref,
+        "repo_root": worktree_root,
+        "cleanup": lambda: _remove_worktree(worktree_root),
+    }
+
+
+def _is_trt_package(package_dir: Path) -> bool:
+    return package_dir.is_dir() and all(
+        (package_dir / filename).exists() for filename in TRT_PACKAGE_REQUIRED_FILES
+    )
+
+
+def _resolve_model_package() -> Optional[Path]:
+    explicit_model_path = os.environ.get("PARITY_MODEL_PATH")
+    if explicit_model_path and _is_trt_package(Path(explicit_model_path)):
+        return Path(explicit_model_path).resolve()
+    for root in (
+        SCRIPT_REPO_ROOT,
+        SCRIPT_REPO_ROOT / "temp",
+        Path.cwd(),
+        Path(tempfile.gettempdir()),
+    ):
+        for name in (
+            "rfdetr-seg-nano-t4-trt-package",
+            "rfdetr-seg-nano-orin-trt-package",
+            "rfdetr-seg-nano-trt-package",
+        ):
+            package = root / name
+            if _is_trt_package(package):
+                return package.resolve()
+    return None
+
+
+def _safe_unlink(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def _prepare_local_workflow_model_bundle(repo_root: Path) -> tuple[str, callable]:
+    package = _resolve_model_package()
+    if package is None:
+        return MODEL_TYPE, lambda: None
+    os.environ.setdefault(
+        "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES", "true"
+    )
+    model_root = repo_root / MODEL_ALIAS
+    model_dir = model_root / "1"
+    if model_dir.exists() or model_dir.is_symlink():
+        raise RuntimeError(
+            f"Refusing to reuse existing parity model alias path: {model_dir}"
+        )
+    model_root.mkdir(parents=True, exist_ok=True)
+    model_dir.symlink_to(package, target_is_directory=True)
+
+    model_cache_root = (
+        Path(os.environ.get("MODEL_CACHE_DIR", "/tmp/cache")) / MODEL_ALIAS
+    )
+    model_cache_dir = model_cache_root / "1"
+    model_cache_dir.mkdir(parents=True, exist_ok=True)
+    model_type_path = model_cache_dir / "model_type.json"
+    model_metadata = {
+        "project_task_type": "instance-segmentation",
+        "model_type": MODEL_TYPE,
+    }
+    model_type_path.write_text(json.dumps(model_metadata, indent=4))
+
+    def cleanup() -> None:
+        if model_dir.is_symlink():
+            _safe_unlink(model_dir)
+        elif model_dir.exists():
+            shutil.rmtree(model_dir, ignore_errors=True)
+        try:
+            model_root.rmdir()
+        except OSError:
+            pass
+        _safe_unlink(model_type_path)
+        try:
+            model_cache_dir.rmdir()
+        except OSError:
+            pass
+        try:
+            model_cache_root.rmdir()
+        except OSError:
+            pass
+
+    return LOCAL_WORKFLOW_MODEL_ID, cleanup
+
+
+def _letterbox_to_square(image: np.ndarray, size: int) -> np.ndarray:
+    height, width = image.shape[:2]
+    scale = size / max(height, width)
+    target_width = max(1, int(round(width * scale)))
+    target_height = max(1, int(round(height * scale)))
+    resized = cv2.resize(
+        image,
+        (target_width, target_height),
+        interpolation=cv2.INTER_LINEAR,
+    )
+    canvas = np.zeros((size, size, 3), dtype=np.uint8)
+    offset_x = (size - target_width) // 2
+    offset_y = (size - target_height) // 2
+    canvas[offset_y : offset_y + target_height, offset_x : offset_x + target_width] = (
+        resized
+    )
+    return canvas
+
+
+def _load_video_frames_as_square_images(
+    video_reference: str,
+    image_count: int,
+    image_size: int,
+) -> list[np.ndarray]:
+    video_path = Path(video_reference)
+    if not video_path.is_absolute():
+        candidate = SCRIPT_REPO_ROOT / video_path
+        if candidate.exists():
+            video_path = candidate.resolve()
+    capture = cv2.VideoCapture(str(video_path))
+    if not capture.isOpened():
+        raise RuntimeError(f"Could not open video reference: {video_path}")
+    frame_count = max(int(capture.get(cv2.CAP_PROP_FRAME_COUNT)), 1)
+    indices = np.linspace(0, frame_count - 1, num=image_count, dtype=int).tolist()
+    images = []
+    try:
+        for frame_index in indices:
+            capture.set(cv2.CAP_PROP_POS_FRAMES, int(frame_index))
+            success, frame = capture.read()
+            if not success or frame is None:
+                raise RuntimeError(
+                    f"Could not read frame {frame_index} from {video_path}"
+                )
+            images.append(_letterbox_to_square(frame, size=image_size))
+    finally:
+        capture.release()
+    return images
+
+
+def _build_workflow(model_id: str, workflow_case: str) -> dict:
+    case = WORKFLOW_PARITY_CASES[workflow_case]
+    workflow_definition = copy.deepcopy(case.workflow_definition)
+    for step in workflow_definition["steps"]:
+        if step.get("name") == "segmentation":
+            step["model_id"] = model_id
+            break
+    else:
+        raise ValueError(f"Workflow case {workflow_case!r} has no segmentation step")
+    return workflow_definition
+
+
+def _normalize_output(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _normalize_output(val)
+            for key, val in sorted(value.items())
+            if str(key) not in _VOLATILE_OUTPUT_KEYS
+        }
+    if isinstance(value, list):
+        return [_normalize_output(element) for element in value]
+    if isinstance(value, tuple):
+        return [_normalize_output(element) for element in value]
+    if isinstance(value, np.ndarray):
+        return _normalize_output(value.tolist())
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _normalized_rle(rle: dict) -> dict:
+    counts = rle["counts"]
+    if isinstance(counts, bytes):
+        counts = counts.decode("ascii")
+    return {"size": list(rle["size"]), "counts": counts}
+
+
+def _rle_for_coco_iou(rle: dict) -> dict:
+    counts = rle["counts"]
+    if isinstance(counts, str):
+        counts = counts.encode("ascii")
+    return {"size": list(rle["size"]), "counts": counts}
+
+
+def _rle_iou(left: dict, right: dict) -> float:
+    from pycocotools import mask as mask_utils
+
+    return float(
+        mask_utils.iou([_rle_for_coco_iou(left)], [_rle_for_coco_iou(right)], [False])[
+            0, 0
+        ]
+    )
+
+
+def _extract_detection_list(value: Any) -> Optional[list]:
+    if not isinstance(value, dict):
+        return None
+    predictions = value.get("predictions")
+    if isinstance(predictions, list):
+        return predictions
+    return None
+
+
+def _xyxy_from_detection(
+    detection: dict,
+) -> Optional[tuple[float, float, float, float]]:
+    try:
+        width = float(detection["width"])
+        height = float(detection["height"])
+        center_x = float(detection["x"])
+        center_y = float(detection["y"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    half_width = width / 2.0
+    half_height = height / 2.0
+    return (
+        center_x - half_width,
+        center_y - half_height,
+        center_x + half_width,
+        center_y + half_height,
+    )
+
+
+def _box_iou(
+    left: tuple[float, float, float, float],
+    right: tuple[float, float, float, float],
+) -> float:
+    x0 = max(left[0], right[0])
+    y0 = max(left[1], right[1])
+    x1 = min(left[2], right[2])
+    y1 = min(left[3], right[3])
+    iw = max(0.0, x1 - x0)
+    ih = max(0.0, y1 - y0)
+    inter = iw * ih
+    left_area = max(0.0, left[2] - left[0]) * max(0.0, left[3] - left[1])
+    right_area = max(0.0, right[2] - right[0]) * max(0.0, right[3] - right[1])
+    union = left_area + right_area - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _compare_detection_lists(
+    base_detections: list,
+    candidate_detections: list,
+    path: str,
+    min_box_iou: float,
+    max_score_delta: float,
+    min_mask_iou: float,
+    stats: dict,
+    errors: list[str],
+) -> None:
+    stats["base_detections"] += len(base_detections)
+    stats["candidate_detections"] += len(candidate_detections)
+    if len(base_detections) != len(candidate_detections):
+        stats["count_mismatch_containers"] += 1
+        errors.append(
+            f"{path}: detection count mismatch "
+            f"{len(base_detections)} != {len(candidate_detections)}"
+        )
+        return
+
+    used_base_indices = set()
+    for candidate_index, candidate_detection in enumerate(candidate_detections):
+        candidate_class = candidate_detection.get("class_id")
+        candidate_box = _xyxy_from_detection(candidate_detection)
+        if candidate_box is None:
+            errors.append(f"{path}[{candidate_index}]: candidate detection has no box")
+            continue
+        best_base_index = -1
+        best_iou = min_box_iou
+        for base_index, base_detection in enumerate(base_detections):
+            if base_index in used_base_indices:
+                continue
+            if base_detection.get("class_id") != candidate_class:
+                continue
+            base_box = _xyxy_from_detection(base_detection)
+            if base_box is None:
+                continue
+            box_iou = _box_iou(base_box, candidate_box)
+            if box_iou > best_iou:
+                best_iou = box_iou
+                best_base_index = base_index
+        if best_base_index < 0:
+            stats["unmatched_candidate_detections"] += 1
+            errors.append(
+                f"{path}[{candidate_index}]: no base match for class_id={candidate_class!r}"
+            )
+            continue
+
+        used_base_indices.add(best_base_index)
+        stats["matched_detections"] += 1
+        stats["box_ious"].append(best_iou)
+        base_detection = base_detections[best_base_index]
+        base_score = float(base_detection.get("confidence", 0.0))
+        candidate_score = float(candidate_detection.get("confidence", 0.0))
+        score_delta = abs(base_score - candidate_score)
+        stats["score_deltas"].append(score_delta)
+        if score_delta > max_score_delta:
+            errors.append(
+                f"{path}[{candidate_index}]: score delta {score_delta:.6f} exceeds "
+                f"{max_score_delta:.6f}"
+            )
+
+        base_rle = base_detection.get("rle")
+        candidate_rle = candidate_detection.get("rle")
+        if base_rle is None and candidate_rle is None:
+            continue
+        if base_rle is None or candidate_rle is None:
+            errors.append(
+                f"{path}[{candidate_index}]: RLE presence mismatch "
+                f"{base_rle is not None} != {candidate_rle is not None}"
+            )
+            continue
+        base_rle = _normalized_rle(base_rle)
+        candidate_rle = _normalized_rle(candidate_rle)
+        mask_iou = _rle_iou(base_rle, candidate_rle)
+        stats["mask_ious"].append(mask_iou)
+        if base_rle == candidate_rle:
+            stats["pixel_identical_masks"] += 1
+        if mask_iou < min_mask_iou:
+            errors.append(
+                f"{path}[{candidate_index}]: mask IoU {mask_iou:.6f} is below "
+                f"{min_mask_iou:.6f}"
+            )
+
+    unmatched_base = len(base_detections) - len(used_base_indices)
+    stats["unmatched_base_detections"] += unmatched_base
+    if unmatched_base:
+        errors.append(f"{path}: {unmatched_base} base detections left unmatched")
+
+
+def _compare_values(
+    base: Any,
+    candidate: Any,
+    path: str,
+    atol: float,
+    min_box_iou: float,
+    max_score_delta: float,
+    min_mask_iou: float,
+    stats: dict,
+    errors: list[str],
+) -> None:
+    base_detections = _extract_detection_list(base)
+    candidate_detections = _extract_detection_list(candidate)
+    if (
+        base_detections is not None
+        and candidate_detections is not None
+        and isinstance(base, dict)
+        and isinstance(candidate, dict)
+        and isinstance(base.get("image"), dict)
+        and isinstance(candidate.get("image"), dict)
+    ):
+        stats["prediction_containers"] += 1
+        _compare_values(
+            base["image"],
+            candidate["image"],
+            f"{path}.image",
+            atol,
+            min_box_iou,
+            max_score_delta,
+            min_mask_iou,
+            stats,
+            errors,
+        )
+        _compare_detection_lists(
+            base_detections=base_detections,
+            candidate_detections=candidate_detections,
+            path=f"{path}.predictions",
+            min_box_iou=min_box_iou,
+            max_score_delta=max_score_delta,
+            min_mask_iou=min_mask_iou,
+            stats=stats,
+            errors=errors,
+        )
+        return
+    if isinstance(base, dict) and isinstance(candidate, dict):
+        if set(base) != set(candidate):
+            errors.append(f"{path}: key mismatch {sorted(base)} != {sorted(candidate)}")
+            return
+        for key in sorted(base):
+            _compare_values(
+                base[key],
+                candidate[key],
+                f"{path}.{key}",
+                atol,
+                min_box_iou,
+                max_score_delta,
+                min_mask_iou,
+                stats,
+                errors,
+            )
+        return
+    if isinstance(base, list) and isinstance(candidate, list):
+        if len(base) != len(candidate):
+            errors.append(f"{path}: length mismatch {len(base)} != {len(candidate)}")
+            return
+        for index, (base_item, candidate_item) in enumerate(zip(base, candidate)):
+            _compare_values(
+                base_item,
+                candidate_item,
+                f"{path}[{index}]",
+                atol,
+                min_box_iou,
+                max_score_delta,
+                min_mask_iou,
+                stats,
+                errors,
+            )
+        return
+    if isinstance(base, (int, float)) and isinstance(candidate, (int, float)):
+        if not math.isclose(float(base), float(candidate), abs_tol=atol, rel_tol=0.0):
+            errors.append(f"{path}: numeric mismatch {base} != {candidate}")
+        return
+    if base != candidate:
+        errors.append(f"{path}: value mismatch {base!r} != {candidate!r}")
+
+
+def do_run(
+    out_path: str,
+    repo_root: str,
+    label: str,
+    workflow_case: str,
+    video_reference: str,
+    image_count: int,
+    image_size: int,
+) -> None:
+    repo_path = _bootstrap_repo_root(repo_root)
+    os.environ.setdefault(
+        "ONNXRUNTIME_EXECUTION_PROVIDERS",
+        "[TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider]",
+    )
+    os.environ["DISABLED_INFERENCE_MODELS_BACKENDS"] = ",".join(
+        sorted(ALL_BACKENDS - {"trt"})
+    )
+    model_id, cleanup_model_bundle = _prepare_local_workflow_model_bundle(repo_path)
+    try:
+        case = WORKFLOW_PARITY_CASES[workflow_case]
+        from inference.core.managers.base import ModelManager
+        from inference.core.registries.roboflow import RoboflowModelRegistry
+        from inference.core.workflows.core_steps.common.entities import (
+            StepExecutionMode,
+        )
+        from inference.core.workflows.execution_engine.core import ExecutionEngine
+        from inference.models.utils import ROBOFLOW_MODEL_TYPES
+
+        workflow_definition = _build_workflow(
+            model_id=model_id,
+            workflow_case=workflow_case,
+        )
+        model_manager = ModelManager(
+            model_registry=RoboflowModelRegistry(ROBOFLOW_MODEL_TYPES)
+        )
+        execution_engine = ExecutionEngine.init(
+            workflow_definition=workflow_definition,
+            init_parameters={
+                "workflows_core.model_manager": model_manager,
+                "workflows_core.api_key": None,
+                "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+            },
+            max_concurrent_steps=4,
+        )
+        images = _load_video_frames_as_square_images(
+            video_reference=video_reference,
+            image_count=image_count,
+            image_size=image_size,
+        )
+        workflow_image_input = images if case.pass_image_list else images[0]
+        result = execution_engine.run(
+            runtime_parameters={"image": workflow_image_input},
+            serialize_results=True,
+        )
+        payload = {
+            "label": label,
+            "workflow_case": workflow_case,
+            "workflow_description": case.description,
+            "repo_root": str(repo_path),
+            "git_head": _safe_git_output(repo_path, "rev-parse", "--short", "HEAD"),
+            "git_describe": _safe_git_output(
+                repo_path,
+                "describe",
+                "--always",
+                "--dirty",
+                "--broken",
+            ),
+            "video_reference": video_reference,
+            "image_count": image_count,
+            "image_size": image_size,
+            "flags": {
+                key: os.environ.get(key)
+                for key in sorted({*BASE_FLAGS_OFF.keys(), *CANDIDATE_FLAGS_ON.keys()})
+            },
+            "result": _normalize_output(result),
+        }
+        with open(out_path, "wb") as f:
+            pickle.dump(payload, f)
+        print(
+            "[run] "
+            f"label={label} repo_root={repo_path} head={payload['git_head']} "
+            f"workflow_case={workflow_case} images={image_count} "
+            f"image_size={image_size} out={out_path}",
+            flush=True,
+        )
+    finally:
+        cleanup_model_bundle()
+
+
+def _load_payload(path: str) -> dict:
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def do_compare(
+    base_path: str,
+    candidate_path: str,
+    atol: float,
+    min_box_iou: float,
+    max_score_delta: float,
+    min_mask_iou: float,
+) -> None:
+    base_payload = _load_payload(base_path)
+    candidate_payload = _load_payload(candidate_path)
+    errors: list[str] = []
+    stats = {
+        "prediction_containers": 0,
+        "base_detections": 0,
+        "candidate_detections": 0,
+        "matched_detections": 0,
+        "count_mismatch_containers": 0,
+        "unmatched_base_detections": 0,
+        "unmatched_candidate_detections": 0,
+        "box_ious": [],
+        "score_deltas": [],
+        "mask_ious": [],
+        "pixel_identical_masks": 0,
+    }
+    _compare_values(
+        base=base_payload["result"],
+        candidate=candidate_payload["result"],
+        path="result",
+        atol=atol,
+        min_box_iou=min_box_iou,
+        max_score_delta=max_score_delta,
+        min_mask_iou=min_mask_iou,
+        stats=stats,
+        errors=errors,
+    )
+
+    print()
+    print(
+        f"==== RF-DETR workflow parity: {base_payload['label']} vs "
+        f"{candidate_payload['label']} ===="
+    )
+    print(f"  workflow case                : {base_payload.get('workflow_case')}")
+    print(f"  base repo                    : {base_payload['git_describe']}")
+    print(f"  candidate repo               : {candidate_payload['git_describe']}")
+    print(f"  prediction containers        : {stats['prediction_containers']}")
+    print(
+        f"  detections base / candidate  : "
+        f"{stats['base_detections']} / {stats['candidate_detections']}"
+    )
+    print(f"  matched detections           : {stats['matched_detections']}")
+    print(f"  count-mismatch containers    : " f"{stats['count_mismatch_containers']}")
+    print(
+        f"  unmatched base / candidate   : "
+        f"{stats['unmatched_base_detections']} / "
+        f"{stats['unmatched_candidate_detections']}"
+    )
+    if stats["box_ious"]:
+        print(
+            f"  mean / min box IoU           : "
+            f"{np.mean(stats['box_ious']):.6f} / {np.min(stats['box_ious']):.6f}"
+        )
+    if stats["score_deltas"]:
+        print(
+            f"  mean / max |delta score|     : "
+            f"{np.mean(stats['score_deltas']):.3e} / "
+            f"{np.max(stats['score_deltas']):.3e}"
+        )
+    if stats["mask_ious"]:
+        print(
+            f"  mean / min mask IoU          : "
+            f"{np.mean(stats['mask_ious']):.6f} / {np.min(stats['mask_ious']):.6f}"
+        )
+        print(
+            f"  pixel-identical masks        : "
+            f"{stats['pixel_identical_masks']}/{len(stats['mask_ious'])}"
+        )
+    if errors:
+        print("  first mismatches:")
+        for error in errors[:20]:
+            print(f"    - {error}")
+        raise AssertionError(f"{len(errors)} parity mismatches found")
+    print("  result                       : outputs matched parity thresholds")
+
+
+def _run_child(
+    repo_root: Path,
+    label: str,
+    out_path: str,
+    workflow_case: str,
+    video_reference: str,
+    image_count: int,
+    image_size: int,
+    flags: dict[str, str],
+) -> None:
+    env = os.environ.copy()
+    env.update(flags)
+    model_package = _resolve_model_package()
+    if model_package is not None:
+        env["PARITY_MODEL_PATH"] = str(model_package)
+    env["PYTHONPATH"] = _child_pythonpath(repo_root, env.get("PYTHONPATH"))
+    args = [
+        PY,
+        str(SELF),
+        "--mode",
+        "run",
+        "--repo-root",
+        str(repo_root),
+        "--label",
+        label,
+        "--out",
+        out_path,
+        "--workflow-case",
+        workflow_case,
+        "--video-reference",
+        video_reference,
+        "--image-count",
+        str(image_count),
+        "--image-size",
+        str(image_size),
+    ]
+    print(
+        "\n---- child ----\n"
+        f"  label={label}\n"
+        f"  workflow_case={workflow_case}\n"
+        f"  repo_root={repo_root}\n"
+        f"  out={out_path}\n"
+        f"  flags={flags}",
+        flush=True,
+    )
+    subprocess.run(args, cwd=str(SCRIPT_REPO_ROOT), env=env, check=True)
+
+
+def _run_driver(
+    base_ref: str,
+    candidate_ref: str,
+    base_out: str,
+    candidate_out: str,
+    workflow_case: str,
+    video_reference: str,
+    image_count: int,
+    image_size: int,
+    float_atol: float,
+    min_box_iou: float,
+    max_score_delta: float,
+    min_mask_iou: float,
+    keep_worktrees: bool,
+) -> None:
+    base_target = _materialize_target(base_ref)
+    candidate_target = _materialize_target(candidate_ref)
+    cleanup_callbacks = [
+        target["cleanup"]
+        for target in (base_target, candidate_target)
+        if callable(target["cleanup"])
+    ]
+    try:
+        _run_child(
+            repo_root=Path(base_target["repo_root"]),
+            label=f"{base_target['label']} flags-off",
+            out_path=base_out,
+            workflow_case=workflow_case,
+            video_reference=video_reference,
+            image_count=image_count,
+            image_size=image_size,
+            flags=BASE_FLAGS_OFF,
+        )
+        _run_child(
+            repo_root=Path(candidate_target["repo_root"]),
+            label=f"{candidate_target['label']} flags-on",
+            out_path=candidate_out,
+            workflow_case=workflow_case,
+            video_reference=video_reference,
+            image_count=image_count,
+            image_size=image_size,
+            flags=CANDIDATE_FLAGS_ON,
+        )
+    finally:
+        if not keep_worktrees:
+            for cleanup in reversed(cleanup_callbacks):
+                cleanup()
+    do_compare(
+        base_path=base_out,
+        candidate_path=candidate_out,
+        atol=float_atol,
+        min_box_iou=min_box_iou,
+        max_score_delta=max_score_delta,
+        min_mask_iou=min_mask_iou,
+    )
+
+
+def _selected_workflow_cases() -> set[str]:
+    selected_cases = os.getenv("RFDETR_WORKFLOW_PARITY_CASES")
+    if not selected_cases:
+        return set(WORKFLOW_PARITY_CASES)
+    result = {case.strip() for case in selected_cases.split(",") if case.strip()}
+    unknown = result - set(WORKFLOW_PARITY_CASES)
+    if unknown:
+        raise ValueError(f"Unknown workflow parity cases: {sorted(unknown)}")
+    return result
+
+
+@pytest.mark.slow
+@pytest.mark.workflows
+@pytest.mark.parametrize("workflow_case", list(WORKFLOW_PARITY_CASES))
+@pytest.mark.skipif(
+    bool_env(os.getenv("SKIP_RFDETR_SLICED_WORKFLOW_MAIN_PARITY_TEST", True)),
+    reason="Skipping RF-DETR workflow parity test",
+)
+def test_rfdetr_workflow_optimized_flow_matches_main_branch(
+    workflow_case: str,
+) -> None:
+    if workflow_case not in _selected_workflow_cases():
+        pytest.skip(f"Workflow case {workflow_case!r} not selected")
+    case = WORKFLOW_PARITY_CASES[workflow_case]
+    image_count = int(
+        os.getenv("RFDETR_WORKFLOW_PARITY_IMAGE_COUNT", str(case.image_count))
+    )
+    if not case.pass_image_list:
+        image_count = 1
+    image_size = int(
+        os.getenv("RFDETR_WORKFLOW_PARITY_IMAGE_SIZE", str(case.image_size))
+    )
+    base_out = Path(
+        tempfile.mkstemp(prefix=f"rfdetr-{workflow_case}-base-", suffix=".pkl")[1]
+    )
+    candidate_out = Path(
+        tempfile.mkstemp(prefix=f"rfdetr-{workflow_case}-candidate-", suffix=".pkl")[1]
+    )
+    try:
+        _run_driver(
+            base_ref=os.getenv("RFDETR_WORKFLOW_PARITY_BASE_REF", "main"),
+            candidate_ref=os.getenv(
+                "RFDETR_WORKFLOW_PARITY_CANDIDATE_REF", "working-tree"
+            ),
+            base_out=str(base_out),
+            candidate_out=str(candidate_out),
+            workflow_case=workflow_case,
+            video_reference=os.getenv(
+                "RFDETR_WORKFLOW_PARITY_VIDEO_REFERENCE",
+                VIDEO_REFERENCE,
+            ),
+            image_count=image_count,
+            image_size=image_size,
+            float_atol=float(os.getenv("RFDETR_WORKFLOW_PARITY_FLOAT_ATOL", "1e-4")),
+            min_box_iou=float(os.getenv("RFDETR_WORKFLOW_PARITY_MIN_BOX_IOU", "0.5")),
+            max_score_delta=float(
+                os.getenv("RFDETR_WORKFLOW_PARITY_MAX_SCORE_DELTA", "0.25")
+            ),
+            min_mask_iou=float(
+                os.getenv("RFDETR_WORKFLOW_PARITY_MIN_MASK_IOU", "0.95")
+            ),
+            keep_worktrees=bool_env(
+                os.getenv("RFDETR_WORKFLOW_PARITY_KEEP_WORKTREES", False)
+            ),
+        )
+    finally:
+        base_out.unlink(missing_ok=True)
+        candidate_out.unlink(missing_ok=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("driver", "run", "compare"),
+        default="driver",
+    )
+    parser.add_argument("--repo-root")
+    parser.add_argument("--label")
+    parser.add_argument("--out")
+    parser.add_argument("--base", default=DEFAULT_BASE_OUT)
+    parser.add_argument("--candidate", default=DEFAULT_CANDIDATE_OUT)
+    parser.add_argument("--base-ref", default="main")
+    parser.add_argument("--candidate-ref", default="working-tree")
+    parser.add_argument(
+        "--workflow-case",
+        choices=tuple(WORKFLOW_PARITY_CASES),
+        default="sliced_rle_batch",
+    )
+    parser.add_argument("--video-reference", default=VIDEO_REFERENCE)
+    parser.add_argument("--image-count", type=int)
+    parser.add_argument("--image-size", type=int)
+    parser.add_argument("--float-atol", type=float, default=1e-4)
+    parser.add_argument("--min-box-iou", type=float, default=0.5)
+    parser.add_argument("--max-score-delta", type=float, default=0.25)
+    parser.add_argument("--min-mask-iou", type=float, default=0.95)
+    parser.add_argument("--keep-worktrees", action="store_true")
+    args = parser.parse_args()
+    case = WORKFLOW_PARITY_CASES[args.workflow_case]
+    if args.image_count is None:
+        args.image_count = case.image_count
+    if not case.pass_image_list:
+        args.image_count = 1
+    if args.image_size is None:
+        args.image_size = case.image_size
+
+    if args.mode == "run":
+        if not args.out:
+            raise ValueError("--out is required in run mode")
+        do_run(
+            out_path=args.out,
+            repo_root=args.repo_root or str(SCRIPT_REPO_ROOT),
+            label=args.label or "run",
+            workflow_case=args.workflow_case,
+            video_reference=args.video_reference,
+            image_count=args.image_count,
+            image_size=args.image_size,
+        )
+        return
+    if args.mode == "compare":
+        do_compare(
+            base_path=args.base,
+            candidate_path=args.candidate,
+            atol=args.float_atol,
+            min_box_iou=args.min_box_iou,
+            max_score_delta=args.max_score_delta,
+            min_mask_iou=args.min_mask_iou,
+        )
+        return
+
+    _run_driver(
+        base_ref=args.base_ref,
+        candidate_ref=args.candidate_ref,
+        base_out=args.base,
+        candidate_out=args.candidate,
+        workflow_case=args.workflow_case,
+        video_reference=args.video_reference,
+        image_count=args.image_count,
+        image_size=args.image_size,
+        float_atol=args.float_atol,
+        min_box_iou=args.min_box_iou,
+        max_score_delta=args.max_score_delta,
+        min_mask_iou=args.min_mask_iou,
+        keep_worktrees=args.keep_worktrees,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/workflows/integration_tests/execution/test_workflow_with_flow_control.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_flow_control.py
@@ -1232,3 +1232,102 @@ def test_workflow_with_stacked_flow_control(
     assert result[0]["output"] == "a, c"
     assert result[1]["output"] == None
     assert result[2]["output"] == "a, c"
+
+
+WORKFLOW_WITH_NON_SIMD_CONTINUE_IF_AND_MULTIPLE_NEXT_STEPS = {
+    "version": "1.0",
+    "inputs": [{"type": "WorkflowParameter", "name": "some"}],
+    "steps": [
+        {
+            "type": "ContinueIf",
+            "name": "gate",
+            "condition_statement": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "DynamicOperand",
+                            "operand_name": "left",
+                        },
+                        "comparator": {"type": "(Number) =="},
+                        "right_operand": {"type": "StaticOperand", "value": 1},
+                    }
+                ],
+            },
+            "evaluation_parameters": {"left": "$inputs.some"},
+            "next_steps": ["$steps.first_expression", "$steps.second_expression"],
+        },
+        {
+            "type": "Expression",
+            "name": "first_expression",
+            "data": {"value": "$inputs.some"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED FIRST!"},
+            },
+        },
+        {
+            "type": "Expression",
+            "name": "second_expression",
+            "data": {"value": "$inputs.some"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED SECOND!"},
+            },
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "first_expression",
+            "selector": "$steps.first_expression.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "second_expression",
+            "selector": "$steps.second_expression.output",
+        },
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    "some, expected_first, expected_second",
+    [
+        (1, "EXECUTED FIRST!", "EXECUTED SECOND!"),
+        (0, None, None),
+    ],
+    ids=["condition_met_executes_both_next_steps", "condition_not_met_terminates_both"],
+)
+def test_non_simd_continue_if_with_multiple_next_steps(
+    some: int,
+    expected_first,
+    expected_second,
+) -> None:
+    """
+    Regression test: a non-SIMD flow-control step with more than one selector in
+    `next_steps` used to crash with "Attempted to re-register maks for execution
+    branch" - all selectors of a list property share a single execution branch and
+    the mask was registered once per selector instead of once per branch.
+    """
+    # given
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_NON_SIMD_CONTINUE_IF_AND_MULTIPLE_NEXT_STEPS,
+        init_parameters={
+            "workflows_core.model_manager": None,
+            "workflows_core.api_key": None,
+            "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+        },
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(runtime_parameters={"some": some})
+
+    # then
+    assert result == [
+        {"first_expression": expected_first, "second_expression": expected_second}
+    ]

--- a/tests/workflows/integration_tests/execution/test_workflow_with_switch_case.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_switch_case.py
@@ -1,0 +1,153 @@
+import pytest
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.errors import WorkflowSyntaxError
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+SWITCH_CASE_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowParameter", "name": "routing_value"},
+    ],
+    "steps": [
+        {
+            "type": "roboflow_core/switch_case@v1",
+            "name": "switch",
+            "value": "$inputs.routing_value",
+            "cases": {
+                "a": "$steps.on_a",
+                "b": "$steps.on_b",
+            },
+            "default_next_steps": ["$steps.on_default"],
+        },
+        {
+            "type": "Expression",
+            "name": "on_a",
+            "data": {"value": "$inputs.routing_value"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED A!"},
+            },
+        },
+        {
+            "type": "Expression",
+            "name": "on_b",
+            "data": {"value": "$inputs.routing_value"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED B!"},
+            },
+        },
+        {
+            "type": "Expression",
+            "name": "on_default",
+            "data": {"value": "$inputs.routing_value"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED DEFAULT!"},
+            },
+        },
+    ],
+    "outputs": [
+        {"type": "JsonField", "name": "on_a", "selector": "$steps.on_a.output"},
+        {"type": "JsonField", "name": "on_b", "selector": "$steps.on_b.output"},
+        {
+            "type": "JsonField",
+            "name": "on_default",
+            "selector": "$steps.on_default.output",
+        },
+    ],
+}
+
+
+def _init_engine(workflow_definition: dict) -> ExecutionEngine:
+    return ExecutionEngine.init(
+        workflow_definition=workflow_definition,
+        init_parameters={
+            "workflows_core.model_manager": None,
+            "workflows_core.api_key": None,
+            "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+        },
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+
+@pytest.mark.parametrize(
+    "routing_value, expected",
+    [
+        ("a", {"on_a": "EXECUTED A!", "on_b": None, "on_default": None}),
+        ("b", {"on_a": None, "on_b": "EXECUTED B!", "on_default": None}),
+        ("c", {"on_a": None, "on_b": None, "on_default": "EXECUTED DEFAULT!"}),
+    ],
+    ids=["case_a_matches", "case_b_matches", "no_match_routes_to_default"],
+)
+def test_switch_case_routes_to_expected_branch(
+    routing_value: str, expected: dict
+) -> None:
+    # given
+    execution_engine = _init_engine(SWITCH_CASE_WORKFLOW)
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={"routing_value": routing_value},
+    )
+
+    # then
+    assert isinstance(result, list), "Expected result to be list"
+    assert len(result) == 1, "Single (non-batch) result expected"
+    assert (
+        result[0] == expected
+    ), f"Expected only the branch matching '{routing_value}' to execute"
+
+
+def test_switch_case_terminates_branch_when_no_match_and_no_default() -> None:
+    # given - on_default step removed entirely: without a flow-control edge it would
+    # execute unconditionally as an independent step
+    workflow_definition = {
+        **SWITCH_CASE_WORKFLOW,
+        "steps": [
+            ({**step, "default_next_steps": []} if step["name"] == "switch" else step)
+            for step in SWITCH_CASE_WORKFLOW["steps"]
+            if step["name"] != "on_default"
+        ],
+        "outputs": [
+            output
+            for output in SWITCH_CASE_WORKFLOW["outputs"]
+            if output["name"] != "on_default"
+        ],
+    }
+    execution_engine = _init_engine(workflow_definition)
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={"routing_value": "unmatched"},
+    )
+
+    # then
+    assert result == [
+        {"on_a": None, "on_b": None}
+    ], "Expected all case branches terminated when nothing matches and no default is set"
+
+
+def test_switch_case_compilation_fails_on_duplicated_targets() -> None:
+    # given
+    workflow_definition = {
+        **SWITCH_CASE_WORKFLOW,
+        "steps": [
+            (
+                {**step, "cases": {"a": "$steps.on_a", "alias_of_a": "$steps.on_a"}}
+                if step["name"] == "switch"
+                else step
+            )
+            for step in SWITCH_CASE_WORKFLOW["steps"]
+        ],
+    }
+
+    # when / then
+    with pytest.raises(WorkflowSyntaxError) as error:
+        _init_engine(workflow_definition)
+    assert "targeted at most once" in str(error.value.inner_error)

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -23,6 +23,9 @@ from inference.core.workflows.execution_engine.entities.base import (
     OriginCoordinatesSystem,
     WorkflowImageData,
 )
+from inference.core.workflows.execution_engine.constants import (
+    POLYGON_KEY_IN_SV_DETECTIONS,
+)
 
 
 def test_attach_prediction_type_info_for_non_empty_predictions() -> None:
@@ -466,6 +469,12 @@ def test_sv_detections_to_root_coordinates_when_shift_is_needed() -> None:
             "keypoints_xy": np.array(
                 [np.array([[10, 20], [20, 30]]), np.array([])], dtype="object"
             ),
+            POLYGON_KEY_IN_SV_DETECTIONS: np.array(
+                [
+                    [[25, 50], [75, 50], [75, 150], [25, 150]],
+                    [[50, 125], [100, 125], [100, 225], [50, 225]],
+                ]
+            ),
         },
     )
 
@@ -543,6 +552,25 @@ def test_sv_detections_to_root_coordinates_when_shift_is_needed() -> None:
     assert (
         result["keypoints_xy"][1] == np.array([])
     ).all(), "Expected empty keypoints xy to be left as is"
+    assert np.allclose(
+        result[POLYGON_KEY_IN_SV_DETECTIONS],
+        np.array(
+            [
+                [
+                    [50 + 25, 100 + 50],
+                    [50 + 75, 100 + 50],
+                    [50 + 75, 100 + 150],
+                    [50 + 25, 100 + 150],
+                ],
+                [
+                    [50 + 50, 100 + 125],
+                    [50 + 100, 100 + 125],
+                    [50 + 100, 100 + 225],
+                    [50 + 50, 100 + 225],
+                ],
+            ]
+        ),
+    ), "Expected polygon metadata to be shifted into root coordinates"
 
 
 def test_sv_detections_to_root_coordinates_when_scale_and_shift_is_needed() -> None:
@@ -584,6 +612,12 @@ def test_sv_detections_to_root_coordinates_when_scale_and_shift_is_needed() -> N
                 [np.array([[10, 20], [20, 30]]), np.array([])], dtype="object"
             ),
             "image_dimensions": np.array([[200, 100], [200, 100]]),
+            POLYGON_KEY_IN_SV_DETECTIONS: np.array(
+                [
+                    [[25, 50], [75, 50], [75, 150], [25, 150]],
+                    [[50, 125], [100, 125], [100, 225], [50, 225]],
+                ]
+            ),
         },
     )
 
@@ -667,6 +701,25 @@ def test_sv_detections_to_root_coordinates_when_scale_and_shift_is_needed() -> N
     assert (
         result["keypoints_xy"][1] == np.array([])
     ).all(), "Expected empty keypoints xy to be left as is"
+    assert np.allclose(
+        result[POLYGON_KEY_IN_SV_DETECTIONS],
+        np.array(
+            [
+                [
+                    [50 + 2 * 25, 100 + 2 * 50],
+                    [50 + 2 * 75, 100 + 2 * 50],
+                    [50 + 2 * 75, 100 + 2 * 150],
+                    [50 + 2 * 25, 100 + 2 * 150],
+                ],
+                [
+                    [50 + 2 * 50, 100 + 2 * 125],
+                    [50 + 2 * 100, 100 + 2 * 125],
+                    [50 + 2 * 100, 100 + 2 * 225],
+                    [50 + 2 * 50, 100 + 2 * 225],
+                ],
+            ]
+        ),
+    ), "Expected polygon metadata to be scaled and shifted into root coordinates"
     assert np.allclose(
         result["image_dimensions"], np.array([[1024, 512], [1024, 512]])
     ), "Expected image dimensions to be root dimensions"

--- a/tests/workflows/unit_tests/core_steps/control_flow/test_switch_case.py
+++ b/tests/workflows/unit_tests/core_steps/control_flow/test_switch_case.py
@@ -1,0 +1,250 @@
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.flow_control.switch_case.v1 import (
+    BlockManifest,
+    SwitchCaseBlockV1,
+)
+from inference.core.workflows.execution_engine.v1.entities import FlowControl
+
+
+@pytest.mark.parametrize(
+    "value", ["$inputs.mode", "$steps.classifier.top", "red", 5, 1.5, True]
+)
+def test_switch_case_manifest_parsing_when_input_is_valid(value) -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": value,
+        "cases": {"red": "$steps.on_red", "blue": "$steps.on_blue"},
+        "default_next_steps": ["$steps.fallback"],
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result == BlockManifest(
+        type="roboflow_core/switch_case@v1",
+        name="switch",
+        value=value,
+        cases={"red": "$steps.on_red", "blue": "$steps.on_blue"},
+        default_next_steps=["$steps.fallback"],
+    )
+
+
+def test_switch_case_manifest_parsing_when_cases_and_default_are_omitted() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result.cases == {}
+    assert result.default_next_steps == []
+
+
+def test_switch_case_manifest_parsing_when_target_duplicated_across_cases() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"red": "$steps.on_red", "crimson": "$steps.on_red"},
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(raw_manifest)
+
+
+def test_switch_case_manifest_parsing_when_target_duplicated_between_cases_and_default() -> (
+    None
+):
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"red": "$steps.on_red"},
+        "default_next_steps": ["$steps.on_red"],
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(raw_manifest)
+
+
+def test_switch_case_manifest_parsing_when_keys_collide_case_insensitively() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"Red": "$steps.on_red", "red": "$steps.on_other"},
+        "case_insensitive": True,
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(raw_manifest)
+
+
+def test_switch_case_manifest_parsing_when_colliding_keys_allowed_case_sensitively() -> (
+    None
+):
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"Red": "$steps.on_red", "red": "$steps.on_other"},
+        "case_insensitive": False,
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result.cases == {"Red": "$steps.on_red", "red": "$steps.on_other"}
+
+
+def test_switch_case_manifest_parsing_when_case_target_is_not_step_selector() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"red": "$inputs.on_red"},
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(raw_manifest)
+
+
+def test_switch_case_run_when_case_matches() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="red",
+        cases={"red": "$steps.on_red", "blue": "$steps.on_blue"},
+        case_insensitive=False,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.on_red"])
+
+
+def test_switch_case_run_when_no_case_matches_and_default_defined() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="green",
+        cases={"red": "$steps.on_red", "blue": "$steps.on_blue"},
+        case_insensitive=False,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.fallback"])
+
+
+def test_switch_case_run_when_no_case_matches_and_default_empty() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="green",
+        cases={"red": "$steps.on_red"},
+        case_insensitive=False,
+        default_next_steps=[],
+    )
+
+    # then
+    assert result == FlowControl(mode="terminate_branch")
+
+
+def test_switch_case_run_when_case_insensitive_match() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="RED",
+        cases={"red": "$steps.on_red"},
+        case_insensitive=True,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.on_red"])
+
+
+def test_switch_case_run_when_case_sensitive_mismatch() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="RED",
+        cases={"red": "$steps.on_red"},
+        case_insensitive=False,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.fallback"])
+
+
+@pytest.mark.parametrize(
+    "value,matching_key",
+    [
+        (None, "None"),
+        (5, "5"),
+        (True, "True"),
+        (1.0, "1.0"),
+    ],
+)
+def test_switch_case_run_coerces_value_to_string(value, matching_key) -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value=value,
+        cases={matching_key: "$steps.on_match"},
+        case_insensitive=False,
+        default_next_steps=[],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.on_match"])
+
+
+def test_switch_case_run_when_no_cases_defined() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="anything",
+        cases={},
+        case_insensitive=False,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.fallback"])

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import supervision as sv
 from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.workflows.core_steps.fusion.detections_stitch.v1 import (
     BlockManifest,
@@ -197,6 +198,42 @@ def test_detections_stitch_with_masks() -> None:
     assert merged.mask is not None
     assert len(merged) == 1
     assert merged.mask.shape[1:] == (400, 500)
+
+
+def test_detections_stitch_moves_compact_masks_without_materializing_dense_masks() -> (
+    None
+):
+    # given
+    block = DetectionsStitchBlockV1()
+    reference_image = make_test_image(width=100, height=100)
+    dense_mask = np.zeros((1, 10, 10), dtype=np.bool_)
+    dense_mask[0, 2:5, 3:7] = True
+    boxes = np.array([[3, 2, 6, 4]], dtype=np.float32)
+    detections = make_test_detections(
+        boxes=boxes.copy(),
+        parent_offset=(20, 30),
+        parent_dims=(100, 100),
+    )
+    detections.mask = CompactMask.from_dense(
+        masks=dense_mask,
+        xyxy=boxes,
+        image_shape=(10, 10),
+    )
+
+    # when
+    result = block.run(
+        reference_image=reference_image,
+        predictions=[detections],
+        overlap_filtering_strategy="none",
+        iou_threshold=0.5,
+    )
+
+    # then
+    stitched = result["predictions"]
+    assert isinstance(stitched.mask, CompactMask)
+    np.testing.assert_array_equal(stitched.xyxy, np.array([[23, 32, 26, 34]]))
+    assert stitched.mask.offsets.tolist() == [[23, 32]]
+    assert stitched.mask.shape == (1, 100, 100)
 
 
 def test_detections_stitch_verify_mask_dimensions_match_reference() -> None:

--- a/tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_output_future_resolution.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_output_future_resolution.py
@@ -1,0 +1,176 @@
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from inference.core.workflows.execution_engine.entities.base import Batch
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    DynamicStepInputDefinition,
+    NodeInputCategory,
+    ParameterSpecification,
+)
+from inference.core.workflows.execution_engine.v1.executor.execution_data_manager.step_input_assembler import (
+    GuardForIndicesWrapping,
+    construct_non_simd_step_non_compound_input,
+    get_non_compound_parameter_value,
+)
+
+
+def _completed_future(value):
+    future = Future()
+    future.set_result(value)
+    return future
+
+
+def _failed_future(error):
+    future = Future()
+    future.set_exception(error)
+    return future
+
+
+def test_construct_non_simd_step_non_compound_input_resolves_nested_step_output_futures() -> (
+    None
+):
+    execution_cache = MagicMock()
+    execution_cache.get_non_batch_output.return_value = _completed_future(
+        {"predictions": _completed_future(["resolved"])}
+    )
+    parameter_spec = DynamicStepInputDefinition(
+        parameter_specification=ParameterSpecification(parameter_name="predictions"),
+        category=NodeInputCategory.NON_BATCH_STEP_OUTPUT,
+        data_lineage=[],
+        selector="$steps.segmentation.predictions",
+    )
+
+    value, is_empty = construct_non_simd_step_non_compound_input(
+        step_node=SimpleNamespace(name="consumer"),
+        parameter_spec=parameter_spec,
+        runtime_parameters={},
+        execution_cache=execution_cache,
+    )
+
+    assert value == {"predictions": ["resolved"]}
+    assert is_empty is False
+
+
+def test_construct_non_simd_step_non_compound_input_preserves_resolved_step_output() -> (
+    None
+):
+    resolved_output = {"predictions": ["resolved"]}
+    execution_cache = MagicMock()
+    execution_cache.get_non_batch_output.return_value = resolved_output
+    parameter_spec = DynamicStepInputDefinition(
+        parameter_specification=ParameterSpecification(parameter_name="predictions"),
+        category=NodeInputCategory.NON_BATCH_STEP_OUTPUT,
+        data_lineage=[],
+        selector="$steps.segmentation.predictions",
+    )
+
+    value, is_empty = construct_non_simd_step_non_compound_input(
+        step_node=SimpleNamespace(name="consumer"),
+        parameter_spec=parameter_spec,
+        runtime_parameters={},
+        execution_cache=execution_cache,
+    )
+
+    assert value is resolved_output
+    assert is_empty is False
+
+
+def test_construct_non_simd_step_non_compound_input_propagates_future_resolution_error() -> (
+    None
+):
+    resolution_error = RuntimeError("future resolution failed")
+    execution_cache = MagicMock()
+    execution_cache.get_non_batch_output.return_value = _completed_future(
+        {"predictions": _failed_future(resolution_error)}
+    )
+    parameter_spec = DynamicStepInputDefinition(
+        parameter_specification=ParameterSpecification(parameter_name="predictions"),
+        category=NodeInputCategory.NON_BATCH_STEP_OUTPUT,
+        data_lineage=[],
+        selector="$steps.segmentation.predictions",
+    )
+
+    with pytest.raises(RuntimeError) as error_info:
+        construct_non_simd_step_non_compound_input(
+            step_node=SimpleNamespace(name="consumer"),
+            parameter_spec=parameter_spec,
+            runtime_parameters={},
+            execution_cache=execution_cache,
+        )
+
+    assert error_info.value is resolution_error
+
+
+def test_get_non_compound_parameter_value_resolves_batched_step_output_futures() -> (
+    None
+):
+    execution_cache = MagicMock()
+    execution_cache.get_batch_output.return_value = [
+        _completed_future({"frame": 0}),
+        _completed_future({"frame": 1}),
+    ]
+    dynamic_batches_manager = MagicMock()
+    dynamic_batches_manager.get_indices_for_data_lineage.return_value = [(0,), (1,)]
+    parameter = DynamicStepInputDefinition(
+        parameter_specification=ParameterSpecification(parameter_name="predictions"),
+        category=NodeInputCategory.BATCH_STEP_OUTPUT,
+        data_lineage=["<workflow_input>"],
+        selector="$steps.segmentation.predictions",
+    )
+
+    value, indices, contains_empty = get_non_compound_parameter_value(
+        parameter=parameter,
+        step_execution_dimensionality=1,
+        masks={1: None},
+        scalars_discarded=False,
+        dynamic_batches_manager=dynamic_batches_manager,
+        runtime_parameters={},
+        execution_cache=execution_cache,
+        guard_of_indices_wrapping=GuardForIndicesWrapping(),
+        auto_batch_casting_lineage_supports={},
+        step_requests_batch_input=True,
+    )
+
+    assert isinstance(value, Batch)
+    assert list(value) == [{"frame": 0}, {"frame": 1}]
+    assert value.indices == [(0,), (1,)]
+    assert indices == [(0,), (1,)]
+    assert contains_empty is False
+
+
+def test_get_non_compound_parameter_value_propagates_batched_future_resolution_error() -> (
+    None
+):
+    resolution_error = RuntimeError("batched future resolution failed")
+    execution_cache = MagicMock()
+    execution_cache.get_batch_output.return_value = [
+        _completed_future({"frame": 0}),
+        _failed_future(resolution_error),
+    ]
+    dynamic_batches_manager = MagicMock()
+    dynamic_batches_manager.get_indices_for_data_lineage.return_value = [(0,), (1,)]
+    parameter = DynamicStepInputDefinition(
+        parameter_specification=ParameterSpecification(parameter_name="predictions"),
+        category=NodeInputCategory.BATCH_STEP_OUTPUT,
+        data_lineage=["<workflow_input>"],
+        selector="$steps.segmentation.predictions",
+    )
+
+    with pytest.raises(RuntimeError) as error_info:
+        get_non_compound_parameter_value(
+            parameter=parameter,
+            step_execution_dimensionality=1,
+            masks={1: None},
+            scalars_discarded=False,
+            dynamic_batches_manager=dynamic_batches_manager,
+            runtime_parameters={},
+            execution_cache=execution_cache,
+            guard_of_indices_wrapping=GuardForIndicesWrapping(),
+            auto_batch_casting_lineage_supports={},
+            step_requests_batch_input=True,
+        )
+
+    assert error_info.value is resolution_error

--- a/tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py
@@ -2,10 +2,12 @@ from concurrent.futures import Future
 
 import pytest
 
+from inference.core.workflows.errors import ExecutionEngineRuntimeError
 from inference.core.workflows.execution_engine.entities.base import Batch
 from inference.core.workflows.execution_engine.v1.executor.utils import (
     contains_future,
     maybe_resolve_futures,
+    resolve_future_result,
     resolve_futures,
 )
 
@@ -79,3 +81,22 @@ def test_resolve_futures_propagates_future_exception() -> None:
         resolve_futures(batch)
 
     assert error_info.value is resolution_error
+
+
+def test_resolve_future_result_raises_on_timeout() -> None:
+    future = Future()
+
+    with pytest.raises(ExecutionEngineRuntimeError, match="Timed out"):
+        resolve_future_result(
+            future,
+            context="test | future_resolution",
+            timeout=0.001,
+        )
+
+
+def test_resolve_futures_raises_on_timeout() -> None:
+    future = Future()
+    batch = Batch.init(content=[future], indices=[(0,)])
+
+    with pytest.raises(ExecutionEngineRuntimeError, match="Timed out"):
+        resolve_futures(batch, timeout=0.001)

--- a/tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py
@@ -1,0 +1,81 @@
+from concurrent.futures import Future
+
+import pytest
+
+from inference.core.workflows.execution_engine.entities.base import Batch
+from inference.core.workflows.execution_engine.v1.executor.utils import (
+    contains_future,
+    maybe_resolve_futures,
+    resolve_futures,
+)
+
+
+def _completed_future(value):
+    future = Future()
+    future.set_result(value)
+    return future
+
+
+def _failed_future(error):
+    future = Future()
+    future.set_exception(error)
+    return future
+
+
+def test_contains_future_detects_future_inside_batch() -> None:
+    batch = Batch.init(content=[_completed_future("resolved")], indices=[(0,)])
+
+    assert contains_future(batch) is True
+
+
+def test_contains_future_returns_false_for_resolved_batch() -> None:
+    batch = Batch.init(content=["resolved"], indices=[(0,)])
+
+    assert contains_future(batch) is False
+
+
+def test_resolve_futures_resolves_future_inside_batch() -> None:
+    batch = Batch.init(
+        content=[_completed_future("first"), _completed_future("second")],
+        indices=[(0,), (1,)],
+    )
+
+    resolved = resolve_futures(batch)
+
+    assert isinstance(resolved, Batch)
+    assert list(resolved) == ["first", "second"]
+    assert resolved.indices == [(0,), (1,)]
+
+
+def test_resolve_futures_resolves_batch_nested_in_dict() -> None:
+    value = {
+        "predictions": Batch.init(
+            content=[_completed_future({"frame": 0})],
+            indices=[(0,)],
+        )
+    }
+
+    resolved = resolve_futures(value)
+
+    resolved_batch = resolved["predictions"]
+    assert isinstance(resolved_batch, Batch)
+    assert list(resolved_batch) == [{"frame": 0}]
+    assert resolved_batch.indices == [(0,)]
+
+
+def test_maybe_resolve_futures_is_noop_without_futures() -> None:
+    value = Batch.init(content=[{"frame": 0}], indices=[(0,)])
+
+    resolved = maybe_resolve_futures(value)
+
+    assert resolved is value
+
+
+def test_resolve_futures_propagates_future_exception() -> None:
+    resolution_error = RuntimeError("future resolution failed")
+    batch = Batch.init(content=[_failed_future(resolution_error)], indices=[(0,)])
+
+    with pytest.raises(RuntimeError) as error_info:
+        resolve_futures(batch)
+
+    assert error_info.value is resolution_error

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -13,7 +13,7 @@ from inference.core.workflows.execution_engine.constants import (
     TOP_LEVEL_LINEAGES_KEY,
     WORKFLOW_INPUT_BATCH_LINEAGE_ID,
 )
-from inference.core.workflows.execution_engine.entities.base import JsonField
+from inference.core.workflows.execution_engine.entities.base import Batch, JsonField
 from inference.core.workflows.execution_engine.entities.types import (
     IMAGE_KIND,
     INTEGER_KIND,
@@ -31,6 +31,7 @@ from inference.core.workflows.execution_engine.v1.executor.output_constructor im
     place_data_in_array,
     serialize_data_piece,
 )
+from inference.core.workflows.execution_engine.v1.executor.utils import contains_future
 
 
 def _completed_future(value: Any) -> Future:
@@ -475,6 +476,45 @@ def test_construct_workflow_output_resolves_futures_by_default() -> None:
     assert result == [{"a": {"predictions": ["resolved"]}}]
 
 
+def test_construct_workflow_output_resolves_batch_wrapped_futures() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = Batch.init(
+        content=[_completed_future("resolved")],
+        indices=[(0,)],
+    )
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+    )
+
+    # then
+    resolved_batch = result[0]["a"]
+    assert isinstance(resolved_batch, Batch)
+    assert list(resolved_batch) == ["resolved"]
+    assert resolved_batch.indices == [(0,)]
+
+
 def test_construct_workflow_output_can_defer_future_resolution() -> None:
     # given
     execution_data_manager = MagicMock()
@@ -508,6 +548,45 @@ def test_construct_workflow_output_can_defer_future_resolution() -> None:
 
     # then
     assert result == [{"a": {"predictions": predictions}}]
+
+
+def test_construct_workflow_output_defers_batch_wrapped_futures() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    deferred_batch = Batch.init(
+        content=[_completed_future("resolved")],
+        indices=[(0,)],
+    )
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = deferred_batch
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    assert result == [{"a": deferred_batch}]
+    assert contains_future(result[0]["a"]) is True
 
 
 def test_construct_workflow_output_when_batch_outputs_present() -> None:

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from typing import Any, List, Optional
 from unittest.mock import MagicMock
 
@@ -30,6 +31,12 @@ from inference.core.workflows.execution_engine.v1.executor.output_constructor im
     place_data_in_array,
     serialize_data_piece,
 )
+
+
+def _completed_future(value: Any) -> Future:
+    future = Future()
+    future.set_result(value)
+    return future
 
 
 def test_data_contains_sv_detections_when_no_sv_detections_provided() -> None:
@@ -431,6 +438,76 @@ def test_construct_workflow_output_when_no_batch_outputs_present() -> None:
 
     # then
     assert result == [{"a": "a_value", "b": "b_value"}]
+
+
+def test_construct_workflow_output_resolves_futures_by_default() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = {
+        "predictions": _completed_future(["resolved"])
+    }
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+    )
+
+    # then
+    assert result == [{"a": {"predictions": ["resolved"]}}]
+
+
+def test_construct_workflow_output_can_defer_future_resolution() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    predictions = _completed_future(["resolved"])
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = {"predictions": predictions}
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    assert result == [{"a": {"predictions": predictions}}]
 
 
 def test_construct_workflow_output_when_batch_outputs_present() -> None:

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -13,7 +13,7 @@ from inference.core.workflows.execution_engine.constants import (
     TOP_LEVEL_LINEAGES_KEY,
     WORKFLOW_INPUT_BATCH_LINEAGE_ID,
 )
-from inference.core.workflows.execution_engine.entities.base import JsonField
+from inference.core.workflows.execution_engine.entities.base import Batch, JsonField
 from inference.core.workflows.execution_engine.entities.types import (
     IMAGE_KIND,
     INTEGER_KIND,
@@ -475,6 +475,45 @@ def test_construct_workflow_output_resolves_futures_by_default() -> None:
     assert result == [{"a": {"predictions": ["resolved"]}}]
 
 
+def test_construct_workflow_output_resolves_batch_wrapped_futures() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = Batch.init(
+        content=[_completed_future("resolved")],
+        indices=[(0,)],
+    )
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+    )
+
+    # then
+    resolved_batch = result[0]["a"]
+    assert isinstance(resolved_batch, Batch)
+    assert list(resolved_batch) == ["resolved"]
+    assert resolved_batch.indices == [(0,)]
+
+
 def test_construct_workflow_output_can_defer_future_resolution() -> None:
     # given
     execution_data_manager = MagicMock()
@@ -494,7 +533,9 @@ def test_construct_workflow_output_can_defer_future_resolution() -> None:
     )
     predictions = _completed_future(["resolved"])
     execution_data_manager.get_selector_indices.return_value = None
-    execution_data_manager.get_non_batch_data.return_value = {"predictions": predictions}
+    execution_data_manager.get_non_batch_data.return_value = {
+        "predictions": predictions
+    }
 
     # when
     result = construct_workflow_output(

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -551,6 +551,51 @@ def test_construct_workflow_output_can_defer_future_resolution() -> None:
     assert result == [{"a": {"predictions": predictions}}]
 
 
+def test_construct_workflow_output_defers_coordinate_conversion_with_future_output() -> (
+    None
+):
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=["<workflow_input>"],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_graph.graph[TOP_LEVEL_LINEAGES_KEY] = WORKFLOW_INPUT_BATCH_LINEAGE_ID
+    execution_data_manager.get_selector_indices.return_value = [(0,)]
+    execution_data_manager.get_batch_data.return_value = [
+        {"predictions": _completed_future(assembly_sv_detections())}
+    ]
+    execution_data_manager.get_lineage_indices.return_value = [(0,)]
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    deferred_output = result[0]["a"]
+    assert isinstance(deferred_output, Future)
+    resolved_output = deferred_output.result()
+    assert_transformed_detections_matches_expectation(
+        result=resolved_output["predictions"]
+    )
+
+
 def test_construct_workflow_output_when_batch_outputs_present() -> None:
     # given
     execution_data_manager = MagicMock()

--- a/tests/workflows/unit_tests/execution_engine/executor/test_sparse_rle_workflow_coordinates.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_sparse_rle_workflow_coordinates.py
@@ -1,0 +1,183 @@
+import numpy as np
+import supervision as sv
+
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.constants import (
+    POLYGON_KEY_IN_SV_DETECTIONS,
+)
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+WORKFLOW_WITH_CROP_SEGMENTATION_AND_FILTER = {
+    "version": "1.0",
+    "inputs": [{"type": "WorkflowImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "RelativeStaticCrop",
+            "name": "crop",
+            "image": "$inputs.image",
+            "x_center": 0.4,
+            "y_center": 0.375,
+            "width": 0.4,
+            "height": 0.5,
+        },
+        {
+            "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+            "name": "segmentation",
+            "images": "$steps.crop.crops",
+            "model_id": "rfdetr-seg-nano/1",
+            "confidence_mode": "custom",
+            "custom_confidence": 0.4,
+        },
+        {
+            "type": "roboflow_core/detections_filter@v1",
+            "name": "only_cars",
+            "predictions": "$steps.segmentation.predictions",
+            "operations": [
+                {
+                    "type": "DetectionsFilter",
+                    "filter_operation": {
+                        "type": "StatementGroup",
+                        "operator": "and",
+                        "statements": [
+                            {
+                                "type": "BinaryStatement",
+                                "left_operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "_",
+                                    "operations": [
+                                        {
+                                            "type": "ExtractDetectionProperty",
+                                            "property_name": "class_name",
+                                        }
+                                    ],
+                                },
+                                "comparator": {"type": "in (Sequence)"},
+                                "right_operand": {
+                                    "type": "StaticOperand",
+                                    "value": ["car"],
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+            "operations_parameters": {},
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "model_predictions",
+            "selector": "$steps.segmentation.predictions",
+        },
+        {
+            "type": "JsonField",
+            "name": "filtered_predictions",
+            "selector": "$steps.only_cars.predictions",
+        },
+    ],
+}
+
+
+class _FakeSparseRLEWorkflowResponse:
+    _rfdetr_sparse_rle_postprocess = True
+
+    def model_dump(self, by_alias: bool, exclude_none: bool) -> dict:
+        assert by_alias is True
+        assert exclude_none is True
+        return {
+            "image": {"width": 40, "height": 40},
+            "predictions": [
+                {
+                    "x": 10,
+                    "y": 10,
+                    "width": 10,
+                    "height": 10,
+                    "confidence": 0.9,
+                    "class": "car",
+                    "class_id": 0,
+                    # Forces the workflow converter through sv.Detections.from_inference,
+                    # which is where stale polygon metadata can enter this path.
+                    "rle": {"size": [40, 40], "counts": "unused-by-test"},
+                }
+            ],
+        }
+
+
+class _FakeModelManager:
+    def __init__(self) -> None:
+        self.add_model_calls = []
+        self.infer_calls = []
+
+    def add_model(self, model_id: str, api_key: str) -> None:
+        self.add_model_calls.append((model_id, api_key))
+
+    def infer_from_request_sync(self, model_id: str, request):
+        self.infer_calls.append((model_id, request))
+        return [_FakeSparseRLEWorkflowResponse()]
+
+    def __contains__(self, model_id: str) -> bool:
+        return False
+
+
+def test_sparse_rle_segmentation_after_relative_crop_serializes_direct_output_in_root_coordinates(
+    monkeypatch,
+) -> None:
+    # given
+    model_manager = _FakeModelManager()
+    image = np.zeros((80, 100, 3), dtype=np.uint8)
+
+    def fake_from_inference(payload: dict) -> sv.Detections:
+        assert payload["image"] == {"width": 40, "height": 40}
+        mask = np.zeros((1, 40, 40), dtype=np.bool_)
+        mask[0, 5:16, 5:16] = True
+        return sv.Detections(
+            xyxy=np.array([[5, 5, 15, 15]]),
+            mask=mask,
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+            data={
+                "class_name": np.array(["car"]),
+                # Crop-local polygon metadata must not win over the shifted mask
+                # when the sparse RLE workflow output is serialized.
+                POLYGON_KEY_IN_SV_DETECTIONS: np.array(
+                    [[[5, 5], [5, 15], [15, 15], [15, 5]]]
+                ),
+            },
+        )
+
+    monkeypatch.setattr(sv.Detections, "from_inference", fake_from_inference)
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_CROP_SEGMENTATION_AND_FILTER,
+        init_parameters={
+            "workflows_core.model_manager": model_manager,
+            "workflows_core.api_key": None,
+            "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+        },
+        max_concurrent_steps=1,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={"image": image},
+        serialize_results=True,
+    )
+
+    # then
+    assert len(result) == 1
+    model_prediction = result[0]["model_predictions"]["predictions"][0]
+    filtered_prediction = result[0]["filtered_predictions"]["predictions"][0]
+    assert model_prediction["x"] == 30
+    assert model_prediction["y"] == 20
+    assert model_prediction["width"] == 10
+    assert model_prediction["height"] == 10
+    assert _points_bounds(model_prediction["points"]) == (25, 15, 35, 25)
+    assert "polygon" not in model_prediction
+    assert _points_bounds(filtered_prediction["points"]) == (25, 15, 35, 25)
+    assert "polygon" not in filtered_prediction
+
+
+def _points_bounds(points: list[dict]) -> tuple[float, float, float, float]:
+    x_values = [point["x"] for point in points]
+    y_values = [point["y"] for point in points]
+    return min(x_values), min(y_values), max(x_values), max(y_values)

--- a/tests/workflows/unit_tests/execution_engine/executor/test_stream_pipeline_flush.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_stream_pipeline_flush.py
@@ -1,0 +1,221 @@
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type
+
+import networkx as nx
+
+from inference.core.workflows.execution_engine.constants import (
+    NODE_COMPILATION_OUTPUT_PROPERTY,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    JsonField,
+    OutputDefinition,
+)
+from inference.core.workflows.execution_engine.entities.types import WILDCARD_KIND
+from inference.core.workflows.execution_engine.profiling.core import (
+    NullWorkflowsProfiler,
+)
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    BlockSpecification,
+    CompiledWorkflow,
+    DynamicStepInputDefinition,
+    InitialisedStep,
+    NodeCategory,
+    NodeInputCategory,
+    OutputNode,
+    ParameterSpecification,
+    ParsedWorkflowDefinition,
+    StepNode,
+)
+from inference.core.workflows.execution_engine.v1.executor.core import (
+    flush_stream_pipeline_workflow,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+
+class DeferredProducerManifest(WorkflowBlockManifest):
+    type: Literal["test/deferred_producer@v1"]
+    name: str
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [OutputDefinition(name="predictions")]
+
+
+class DeferredProducerBlock(WorkflowBlock):
+    def __init__(self) -> None:
+        self.flush_calls = 0
+        self.closed = False
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return DeferredProducerManifest
+
+    def run(self) -> BlockResult:
+        return {"predictions": "warmup-placeholder"}
+
+    def flush_stream_pipeline_outputs(
+        self,
+    ) -> List[Tuple[List[Tuple[int, ...]], BlockResult]]:
+        self.flush_calls += 1
+        if self.flush_calls > 1:
+            return []
+        return [([], [{"predictions": "flushed-tail"}])]
+
+    def close_stream_pipeline(self) -> None:
+        self.closed = True
+
+
+class ConsumerManifest(WorkflowBlockManifest):
+    type: Literal["test/consumer@v1"]
+    name: str
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [OutputDefinition(name="consumed")]
+
+
+class ConsumerBlock(WorkflowBlock):
+    def __init__(self) -> None:
+        self.seen_predictions: List[Any] = []
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return ConsumerManifest
+
+    def run(self, predictions: Any) -> BlockResult:
+        self.seen_predictions.append(predictions)
+        return {"consumed": predictions}
+
+
+def test_stream_pipeline_flush_runs_tail_output_through_downstream_steps() -> None:
+    producer = DeferredProducerBlock()
+    consumer = ConsumerBlock()
+    workflow = _compiled_workflow(
+        producer=producer,
+        consumer=consumer,
+        producer_manifest=DeferredProducerManifest(
+            type="test/deferred_producer@v1",
+            name="segmentation",
+        ),
+        consumer_manifest=ConsumerManifest(
+            type="test/consumer@v1",
+            name="consumer",
+        ),
+    )
+
+    result = flush_stream_pipeline_workflow(
+        workflow=workflow,
+        runtime_parameters={},
+        max_concurrent_steps=1,
+        kinds_serializers={},
+        serialize_results=False,
+        profiler=NullWorkflowsProfiler.init(),
+    )
+
+    assert consumer.seen_predictions == ["flushed-tail"]
+    assert result == [{"result": "flushed-tail"}]
+    assert producer.flush_calls == 1
+    assert producer.closed is False
+
+
+def _compiled_workflow(
+    producer: DeferredProducerBlock,
+    consumer: ConsumerBlock,
+    producer_manifest: DeferredProducerManifest,
+    consumer_manifest: ConsumerManifest,
+) -> CompiledWorkflow:
+    workflow_output = JsonField(
+        type="JsonField",
+        name="result",
+        selector="$steps.consumer.consumed",
+    )
+    graph = nx.DiGraph()
+    graph.add_node(
+        "$steps.segmentation",
+        **{
+            NODE_COMPILATION_OUTPUT_PROPERTY: StepNode(
+                node_category=NodeCategory.STEP_NODE,
+                name="segmentation",
+                selector="$steps.segmentation",
+                data_lineage=[],
+                step_manifest=producer_manifest,
+            )
+        },
+    )
+    graph.add_node(
+        "$steps.consumer",
+        **{
+            NODE_COMPILATION_OUTPUT_PROPERTY: StepNode(
+                node_category=NodeCategory.STEP_NODE,
+                name="consumer",
+                selector="$steps.consumer",
+                data_lineage=[],
+                step_manifest=consumer_manifest,
+                input_data={
+                    "predictions": DynamicStepInputDefinition(
+                        parameter_specification=ParameterSpecification(
+                            parameter_name="predictions"
+                        ),
+                        category=NodeInputCategory.NON_BATCH_STEP_OUTPUT,
+                        data_lineage=[],
+                        selector="$steps.segmentation.predictions",
+                    )
+                },
+            )
+        },
+    )
+    graph.add_node(
+        "$outputs.result",
+        **{
+            NODE_COMPILATION_OUTPUT_PROPERTY: OutputNode(
+                node_category=NodeCategory.OUTPUT_NODE,
+                name="result",
+                selector="$outputs.result",
+                data_lineage=[],
+                output_manifest=workflow_output,
+                kind=[WILDCARD_KIND],
+            )
+        },
+    )
+    graph.add_edge("$steps.segmentation", "$steps.consumer")
+    graph.add_edge("$steps.consumer", "$outputs.result")
+
+    return CompiledWorkflow(
+        workflow_definition=ParsedWorkflowDefinition(
+            version="1.0",
+            inputs=[],
+            steps=[producer_manifest, consumer_manifest],
+            outputs=[workflow_output],
+        ),
+        execution_graph=graph,
+        steps={
+            "segmentation": InitialisedStep(
+                block_specification=BlockSpecification(
+                    block_source="test",
+                    identifier="test/deferred_producer@v1",
+                    block_class=DeferredProducerBlock,
+                    manifest_class=DeferredProducerManifest,
+                ),
+                manifest=producer_manifest,
+                step=producer,
+            ),
+            "consumer": InitialisedStep(
+                block_specification=BlockSpecification(
+                    block_source="test",
+                    identifier="test/consumer@v1",
+                    block_class=ConsumerBlock,
+                    manifest_class=ConsumerManifest,
+                ),
+                manifest=consumer_manifest,
+                step=consumer,
+            ),
+        },
+        input_substitutions=[],
+        workflow_json={},
+        init_parameters={},
+        kinds_serializers={},
+        kinds_deserializers={},
+    )


### PR DESCRIPTION
## Summary
- preserve RF-DETR stream-frame alignment by disabling stream pipelining only for workflow graphs with unsafe downstream image/state dependencies
- keep optimized stream pipelining for prediction-only downstream chains and single-step workflows
- make generated batch requests synchronous and avoid the slower sparse Triton postprocess path for batch-shaped workflow inputs
- fix compact-mask stitching without dense materialization
- strip stale sparse-RLE polygon metadata only for optimized RF-DETR sparse-RLE outputs so root-coordinate serialization uses shifted masks

## Tests
- `source .venv/bin/activate && PYTHONPATH=/home/ubuntu/inference:/home/ubuntu/inference/inference_models pytest tests/inference/unit_tests/core/interfaces/stream/test_workflows.py tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py tests/inference/unit_tests/core/models/test_inference_models_adapters.py tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_output_future_resolution.py tests/workflows/unit_tests/execution_engine/executor/test_stream_pipeline_flush.py tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py tests/workflows/unit_tests/execution_engine/executor/test_sparse_rle_workflow_coordinates.py -q`
  - `101 passed`

## Benchmark Notes
All comparisons were against `origin/main` with `rfdetr-seg-small`, 150 frames, main flags off vs optimized flags on.

312px workflows, all correctness OK:
- `single_seg`: 49.10 -> 151.06 FPS, 3.08x
- `crop_filter`: 46.30 -> 121.27 FPS, 2.62x
- `crop_polygon`: 45.70 -> 66.93 FPS, 1.46x
- `crop_filter_polygon`: 44.33 -> 66.51 FPS, 1.50x
- `tracker_box`: 37.99 -> 60.72 FPS, 1.60x
- `slicer_seg`: 13.68 -> 14.62 FPS, 1.07x
- `slicer_stitch_mask`: 11.49 -> 13.61 FPS, 1.19x

Additional 312px multistep workflows, all correctness OK:
- `seg_filter_combine_box`: 46.44 -> 73.03 FPS, 1.57x
- `absolute_crop_mask_label`: rerun 44.35 -> 67.42 FPS, 1.52x
- `tracker_lock_stabilize`: 34.69 -> 49.15 FPS, 1.42x
- `slicer_filter_stitch_polygon`: 11.87 -> 13.90 FPS, 1.17x
- `slicer_stitch_box_label`: 11.79 -> 13.66 FPS, 1.16x

1080p workflows, all correctness OK:
- `single_seg`: 11.75 -> 110.02 FPS, 9.36x
- `crop_filter`: 14.03 -> 50.60 FPS, 3.61x
- `crop_polygon`: 15.05 -> 34.17 FPS, 2.27x
- `tracker_box`: 9.44 -> 39.19 FPS, 4.15x

Additional 1080p multistep workflows, all correctness OK:
- `seg_filter_combine_box`: 9.35 -> 43.94 FPS, 4.70x
- `absolute_crop_mask_label`: 63.87 -> 93.61 FPS, 1.47x
- `tracker_lock_stabilize`: 8.59 -> 34.87 FPS, 4.06x
